### PR TITLE
Extrinsic queryInfo, account nonce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-rpc-proxy",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
+ Added `info` to extrinsics in block endpoint, which contains a calculation of all tx fees.
+ Added `nonce` to accounts in balance endpoint.