### PR TITLE
query info from parent

### DIFF
--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -59,7 +59,7 @@ export default class ApiHandler {
 		const queryInfo = await Promise.all(block.extrinsics.map(async (extrinsic) => {
 			if (extrinsic.isSigned && extrinsic.method.sectionName !== 'sudo') {
 				try {
-					return await api.rpc.payment.queryInfo(extrinsic.toHex(), hash);
+					return await api.rpc.payment.queryInfo(extrinsic.toHex(), parentHash);
 				} catch (err) {
 					console.error(err);
 


### PR DESCRIPTION
See: https://github.com/paritytech/substrate/issues/5943#issuecomment-628184778

I tested this and it works:
```
Actual Balance:   997999664157491
Expected Balance: 997999664157491
              -------------------
Difference:                     0
```