### PR TITLE
Rename fee variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ yarn start
 
 - `/tx/artifacts/NUMBER` fetch artifacts used for creating transactions at block height `NUMBER`.
 
-- `/tx/fee-estimate` submit an extrinsic in order to get back a fee estimation. Expects a string
-  with a hex-encoded extrinsic in a JSON POST body:
+- `/tx/fee-estimate` submit a transaction in order to get back a fee estimation. Expects a string
+  with a hex-encoded transaction in a JSON POST body:
   ```
-  curl localhost:8080/tx/fee-estimate -X POST --data '{"extrinsic": "0x..."}' -H 'Content-Type: application/json'
+  curl localhost:8080/tx/fee-estimate -X POST --data '{"tx": "0x..."}' -H 'Content-Type: application/json'
   ```
   Expected result is a JSON with fee information:
   ```
@@ -62,12 +62,13 @@ yarn start
     "partialFee": "165600000"
   }
   ```
+
 - `/tx/` submit a signed transaction, expects a string with hex-encoded transaction in a JSON POST
   body:
   ```
   curl localhost:8080/tx/ -X POST --data '{"tx": "0x..."}' -H 'Content-Type: application/json'
   ```
-  Expected result is a json with transaction hash:
+  Expected result is a JSON with transaction hash:
   ```
   {
       "hash": "..."

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -301,13 +301,20 @@ export default class ApiHandler {
 
 	async fetchFeeInformation(hash: BlockHash, extrinsic: string) {
 		const api = await this.ensureMeta(hash);
+		let tx;
 
 		try {
-			const feeInfo = api.createType(
-				'RuntimeDispatchInfo',
-				await api.rpc.payment.queryInfo(extrinsic, hash)
-			);
-			return feeInfo;
+			tx = api.tx(extrinsic);
+		} catch (err) {
+			throw {
+				error: 'Failed to parse a tx',
+				data: extrinsic,
+				cause: err.toString(),
+			};
+		}
+
+		try {
+			return await api.rpc.payment.queryInfo(tx.toHex(), hash);
 		} catch (err) {
 			throw {
 				error: 'Unable to fetch fee info',

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -301,9 +301,13 @@ export default class ApiHandler {
 
 	async fetchFeeInformation(hash: BlockHash, extrinsic: string) {
 		const api = await this.ensureMeta(hash)
+		let feeInfo = {};
 
 		try {
-			return await api.rpc.payment.queryInfo(extrinsic, hash);
+			feeInfo = api.createType(
+				'RuntimeDispatchInfo',
+				await api.rpc.payment.queryInfo(extrinsic, hash)
+			);
 		} catch (err) {
 			throw {
 				error: 'Unable to fetch fee info',

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -301,20 +301,9 @@ export default class ApiHandler {
 
 	async fetchFeeInformation(hash: BlockHash, extrinsic: string) {
 		const api = await this.ensureMeta(hash);
-		let tx;
 
 		try {
-			tx = api.tx(extrinsic);
-		} catch (err) {
-			throw {
-				error: 'Failed to parse a tx',
-				data: extrinsic,
-				cause: err.toString(),
-			};
-		}
-
-		try {
-			return await api.rpc.payment.queryInfo(tx.toHex(), hash);
+			return await api.rpc.payment.queryInfo(extrinsic, hash);
 		} catch (err) {
 			throw {
 				error: 'Unable to fetch fee info',

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -300,14 +300,14 @@ export default class ApiHandler {
 	}
 
 	async fetchFeeInformation(hash: BlockHash, extrinsic: string) {
-		const api = await this.ensureMeta(hash)
-		let feeInfo = {};
+		const api = await this.ensureMeta(hash);
 
 		try {
-			feeInfo = api.createType(
+			const feeInfo = api.createType(
 				'RuntimeDispatchInfo',
 				await api.rpc.payment.queryInfo(extrinsic, hash)
 			);
+			return feeInfo;
 		} catch (err) {
 			throw {
 				error: 'Unable to fetch fee info',

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,7 +157,7 @@ async function main() {
 		return await handler.fetchMetadata(hash);
 	});
 
-	get('/claims/:ethAddress/', async (params) => {
+	get('/claims/:ethAddress', async (params) => {
 		const { ethAddress } = params;
 		const hash = await api.rpc.chain.getFinalizedHead();
 
@@ -185,16 +185,16 @@ async function main() {
 		return await handler.fetchTxArtifacts(hash);
 	});
 
-	post('/tx/fee-estimate', async (_, body) => {
-		if(body && typeof body.extrinsic !== 'string'){
+	post('/tx/fee-estimate/', async (_, body) => {
+		if(body && typeof body.tx !== 'string'){
 			return {
-				error: "Missing field `extrinsic` on request body.",
+				error: "Missing field `tx` on request body.",
 			};
 		}
 
 		const hash = await api.rpc.chain.getFinalizedHead();
 
-		return await handler.fetchFeeInformation(hash, body.extrinsic);
+		return await handler.fetchFeeInformation(hash, body.tx);
 	});
 
 	post('/tx/', async (_, body) => {


### PR DESCRIPTION
Change `extrinsic` to `tx`. Although you could submit an extrinsic here, it wouldn't make much sense as only signed transactions actually pay fees. Also one would expect the same post body, `'{"tx": "0x..."}'`, as submitting the transaction.