### PR TITLE
Add wasm-pack install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ with meaningful responses.
 
 ### Installation
 
+Make sure your machine has an [up-to-date version of `rustup`](https://www.rust-lang.org/tools/install) installed so rust dependencies can be managed.
+
+Install `wasm-pack` if your machine does not already have it:
+
+```
+cargo install wasm-pack
+```
+
+Use yarn to do the remaining setup:
+
 ```
 yarn
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ with meaningful responses.
 
 ### Installation
 
-Make sure your machine has an [up-to-date version of `rustup`](https://www.rust-lang.org/tools/install) installed so rust dependencies can be managed.
+Make sure your machine has an
+[up-to-date version of `rustup`](https://www.rust-lang.org/tools/install) installed to manage Rust
+dependencies.
 
 Install `wasm-pack` if your machine does not already have it:
 


### PR DESCRIPTION
closes #65

companion #50

The new instructions worked on my machine (macOS Mojave 10.14.6) so hopefully safe to assume they should work for target audience.