### PR TITLE
Add author ID to `/block` response

### DIFF
--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -247,6 +247,9 @@ export default class ApiHandler {
 			}
 		}
 
+		const header = await api.derive.chain.getHeader(hash);
+		const authorId = header?.author;
+
 		return {
 			number,
 			hash,
@@ -257,6 +260,7 @@ export default class ApiHandler {
 			onInitialize,
 			extrinsics,
 			onFinalize,
+			authorId,
 		};
 	}
 

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -66,6 +66,9 @@ export default class ApiHandler {
 
 		const { parentHash, number, stateRoot, extrinsicsRoot } = block.header;
 
+		const header = await api.derive.chain.getHeader(hash);
+		const authorId = header?.author;
+
 		const logs = block.header.digest.logs.map((log) => {
 			const { type, index, value } = log;
 
@@ -247,20 +250,17 @@ export default class ApiHandler {
 			}
 		}
 
-		const header = await api.derive.chain.getHeader(hash);
-		const authorId = header?.author;
-
 		return {
 			number,
 			hash,
 			parentHash,
 			stateRoot,
 			extrinsicsRoot,
+			authorId,
 			logs,
 			onInitialize,
 			extrinsics,
 			onFinalize,
-			authorId,
 		};
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ async function main() {
 	// - `parentHash`: The hash of the parent block.
 	// - `stateRoot`: The state root after executing this block.
 	// - `extrinsicsRoot`: The Merkle root of the extrinsics.
-	// - `authorId`: The account ID of the block author (may be undefined for development chains).
+	// - `authorId`: The account ID of the block author (may be undefined for some chains).
 	// - `logs`: Array of `DigestItem`s associated with the block.
 	// - `onInitialize`: Object with an array of `SanitizedEvent`s that occurred during block
 	//   initialization with the `method` and `data` for each.

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,7 @@ async function main() {
 	// - `parentHash`: The hash of the parent block.
 	// - `stateRoot`: The state root after executing this block.
 	// - `extrinsicsRoot`: The Merkle root of the extrinsics.
+	// - `authorId`: The account ID of the block author (may be undefined for development chains).
 	// - `logs`: Array of `DigestItem`s associated with the block.
 	// - `onInitialize`: Object with an array of `SanitizedEvent`s that occurred during block
 	//   initialization with the `method` and `data` for each.


### PR DESCRIPTION
Response from Kusama looks like this (note that when I ran against local dev node the author ID was not defined)
![image](https://user-images.githubusercontent.com/2193247/84434387-c8eba100-abe4-11ea-888a-0a48022187c9.png)

Closes #74