### PR TITLE
Logging and LOG_MODE "errors" ||  "all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Following ENV variables can be set:
 - `BIND_PORT`: port on which the server will be listening, defaults to `8080`.
 - `NODE_WS_URL`: WebSocket URL to which the RPC proxy will attempt to connect to, defaults to
   `ws://127.0.0.1:9944`.
+- `NODE_WS_URL`:
 
 ### Chain compatibility
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Following ENV variables can be set:
 - `BIND_PORT`: port on which the server will be listening, defaults to `8080`.
 - `NODE_WS_URL`: WebSocket URL to which the RPC proxy will attempt to connect to, defaults to
   `ws://127.0.0.1:9944`.
-- `NODE_WS_URL`:
+- `LOG_MODE`: enable console logging of "all" HTTP requests, only "errors", or nothing by setting it to anything else. LOG_MODE defaults to only "errors".
 
 ### Chain compatibility
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "@polkadot/types": "^1.19.0-beta.3",
     "@types/body-parser": "^1.19.0",
     "@types/express": "^4.17.2",
+    "@types/morgan": "^1.9.1",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "morgan": "^1.10.0",
     "typescript": "^3.9.5"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { parseBlockNumber, sanitizeNumbers } from './utils';
 const HOST = process.env.BIND_HOST || '127.0.0.1';
 const PORT = Number(process.env.BIND_PORT) || 8080;
 const WS_URL = process.env.NODE_WS_URL || 'ws://127.0.0.1:9944';
-const NODE_ENV = process.env.NODE_ENV || 'development';
+const NODE_ENV = process.env.NODE_ENV || 'production';
 
 type Params = { [key: string]: string };
 
@@ -50,9 +50,11 @@ async function main() {
 				}) as express.Handler
 			);
 			break;
-		default:
+		case 'development':
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			app.use(morgan('dev'));
+			break;
+		default:
 			break;
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ async function main() {
 					skip: function (_: express.Request, res: express.Response) {
 						return res.statusCode < 400; // Only log errors
 					},
-				}) as express.Handler
+				})
 			);
 			break;
 		case 'all':

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { parseBlockNumber, sanitizeNumbers } from './utils';
 const HOST = process.env.BIND_HOST || '127.0.0.1';
 const PORT = Number(process.env.BIND_PORT) || 8080;
 const WS_URL = process.env.NODE_WS_URL || 'ws://127.0.0.1:9944';
-const NODE_ENV = process.env.NODE_ENV || 'production';
+const LOG_MODE = process.env.LOG_MODE || 'errors';
 
 type Params = { [key: string]: string };
 
@@ -39,8 +39,8 @@ async function main() {
 
 	app.use(bodyParser.json());
 
-	switch (NODE_ENV) {
-		case 'production':
+	switch (LOG_MODE) {
+		case 'errors':
 			app.use(
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 				morgan('combined', {
@@ -50,7 +50,7 @@ async function main() {
 				}) as express.Handler
 			);
 			break;
-		case 'development':
+		case 'all':
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			app.use(morgan('dev'));
 			break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import type { BlockHash } from '@polkadot/types/interfaces';
 import { isHex } from '@polkadot/util';
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
+import * as morgan from 'morgan';
 
 import ApiHandler from './ApiHandler';
 import { parseBlockNumber, sanitizeNumbers } from './utils';
@@ -27,6 +28,7 @@ import { parseBlockNumber, sanitizeNumbers } from './utils';
 const HOST = process.env.BIND_HOST || '127.0.0.1';
 const PORT = Number(process.env.BIND_PORT) || 8080;
 const WS_URL = process.env.NODE_WS_URL || 'ws://127.0.0.1:9944';
+const NODE_ENV = process.env.NODE_ENV || 'development';
 
 type Params = { [key: string]: string };
 
@@ -36,6 +38,23 @@ async function main() {
 	const app = express();
 
 	app.use(bodyParser.json());
+
+	switch (NODE_ENV) {
+		case 'production':
+			app.use(
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				morgan('combined', {
+					skip: function (_: express.Request, res: express.Response) {
+						return res.statusCode < 400; // Only log errors
+					},
+				}) as express.Handler
+			);
+			break;
+		default:
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			app.use(morgan('dev'));
+			break;
+	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	function get(path: string, cb: (params: Params) => Promise<any>) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -274,6 +274,13 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.2.tgz#857a118d8634c84bba7ae14088e4508490cd5da5"
   integrity sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==
 
+"@types/morgan@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@types/morgan/-/morgan-1.9.1.tgz#6457872df95647c1dbc6b3741e8146b71ece74bf"
+  integrity sha512-2j5IKrgJpEP6xw/uiVb2Xfga0W0sSVD9JP9t7EZLvpBENdB0OKgcnoKS8IsjNeNnZ/86robdZ61Orl0QCFGOXg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "14.0.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
@@ -443,6 +450,13 @@ base-x@^3.0.2, base-x@^3.0.8:
   integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
   dependencies:
     safe-buffer "^5.0.1"
+
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 bip39@^3.0.2:
   version "3.0.2"
@@ -701,6 +715,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -1548,6 +1567,17 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1661,6 +1691,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
 ### Overview
Closes #84 

Use `morgan` to log HTTP request/response and create the env var `LOG_MODE` which has the options "all" and "error". When set to "all", every request/response will get logged. When set to "error" only request/response that result in a status code of 400 or greater will be logged.

When not explicitly set, `LOG_MODE` defaults to "error". In order to have no logs, simply set `LOG_MODE` to anything other than "error" or "all". 

#### Follow up PRs
- Write logs to file in production mode
- Customization of logging messages specific to sidecar use
- Set up`dotenv` to declare ENV vars