### PR TITLE
Use `unwrap()`-ed `StakingLedger` values converted to string

### DIFF
--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -400,7 +400,13 @@ export default class ApiHandler {
 
 		return {
 			at,
-			staking,
+			staking: {
+				stash: ledger.stash.toString(),
+				total: ledger.total.toString(),
+				active: ledger.active.toString(),
+				unlocking: ledger.unlocking.toString(),
+				claimedRewards: ledger.claimedRewards.toString(),
+			},
 			numSlashingSpans,
 		};
 	}


### PR DESCRIPTION
Closes #91 

Use `unwrap()`-ed  `StakingLedger` values converted to string to ensure proper decimal serialization.