### PR TITLE
Reconfigure `/staking/ADDRESS` to accept stash and give `controller`, `rewardDestination`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,9 @@ a 32-byte hex string (`0x` followed by 64 hexadecimal digits) that denotes the b
 
 - `/balance/ADDRESS/NUMBER` fetch balances for `ADDRESS` at the block identified by 'NUMBER`.
 
-- `/payout/ADDRESS` fetch payout info for `ADDRESS` at latest finalized block.
+- `/staking/ADDRESS` fetch the staking info for `ADDRESS` at latest finalized block.
 
-- `/payout/ADDRESS/NUMBER` fetch payout info for `ADDRESS` at the block identified by 'NUMBER`.
-
-- `/staking/ADDRESS` fetch the staking ledger info for `ADDRESS` at latest finalized block.
-
-- `/staking/ADDRESS/NUMBER` fetch the staking ledger info for `ADDRESS` at the block identified by 'NUMBER`.
+- `/staking/ADDRESS/NUMBER` fetch the staking info for `ADDRESS` at the block identified by 'NUMBER`.
 
 - `/vesting/ADDRESS` fetch the vesting info for `ADDRESS` at latest finalized block.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-rpc-proxy",
-  "version": "0.8.0-rc1",
+  "version": "0.8.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -364,7 +364,7 @@ export default class ApiHandler {
 	/**
 	 *
 	 * @param hash BlockHash to make call at.
-	 * @param stash: _Stash_ address.
+	 * @param stash _Stash_ address.
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	async fetchStakingInfo(hash: BlockHash, stash: string) {
@@ -380,14 +380,11 @@ export default class ApiHandler {
 			height: header.number.toNumber().toString(10),
 		};
 
-		if (
-			controllerOption.isNone === true ||
-			controllerOption.isSome !== true
-		) {
+		if (controllerOption.isNone) {
 			// if controllerOption.isNone, `stash` address param is not a stash.
 			throw {
 				error: `The address ${stash} is not a stash address.`,
-				statusCode: 422,
+				statusCode: 400,
 			};
 		}
 
@@ -403,20 +400,19 @@ export default class ApiHandler {
 			await api.query.staking.slashingSpans.at(hash, stash),
 		]);
 
-		// should always work because we know that we have a bonded pair
 		const stakingLedger = stakingLedgerOption.unwrapOr(null);
 
 		if (stakingLedger === null) {
+			// should never throw because by time we get here we know we have a bonded pair
 			throw {
 				error: `Staking ledger could not be found for address "${controller.toString()}"`,
 				statusCode: 404,
 			};
 		}
 
-		const numSlashingSpans =
-			slashingSpansOption.isSome === true
-				? slashingSpansOption.unwrap().prior.length + 1
-				: 0;
+		const numSlashingSpans = slashingSpansOption.isSome
+			? slashingSpansOption.unwrap().prior.length + 1
+			: 0;
 
 		return {
 			at,

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -380,23 +380,25 @@ export default class ApiHandler {
 			height: header.number.toNumber().toString(10),
 		};
 
-		const noneResponse = {
-			at,
-			controller: null,
-			rewardDestination: null,
-			numSlashingSpans: null,
-			staking: {},
-		};
-
 		if (bonded.isNone) {
 			// If bonded.isNone, address is not a stash.
-			return noneResponse;
+			return {
+				at,
+				controller: null,
+				rewardDestination: null,
+				numSlashingSpans: null,
+				staking: {},
+			};
 		}
 
-		// We can safely infer (optionBonded.isSome === true) and safely unwrap
+		// We can infer (optionBonded.isSome === true) and safely unwrap
 		const controller = bonded.unwrap();
 
-		const [stakingLedger, rewardDestination, slashingSpans] = await Promise.all([
+		const [
+			stakingLedger,
+			rewardDestination,
+			slashingSpans,
+		] = await Promise.all([
 			await api.query.staking.ledger.at(hash, controller),
 			await api.query.staking.payee.at(hash, address),
 			await api.query.staking.slashingSpans.at(hash, address),

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -380,7 +380,7 @@ export default class ApiHandler {
 			height: header.number.toNumber().toString(10),
 		};
 
-		if (optionController.isNone) {
+		if (optionController.isNone === true) {
 			// if bonded.isNone, `stash` address param is not a stash.
 			return {
 				at,

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -363,19 +363,18 @@ export default class ApiHandler {
 
 	/**
 	 *
-	 * @param hash: BlockHash
-	 * @param address: string - _Stash_ address
+	 * @param hash BlockHash to make call at.
+	 * @param address: _Stash_ address.
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	async fetchStakingLedger(hash: BlockHash, address: string) {
 		const api = await this.ensureMeta(hash);
 
-		// optionBonded: Option<AccountId>
 		const [header, rewardDestination, optionBonded] = await Promise.all([
 			api.rpc.chain.getHeader(hash),
 			api.query.staking.payee.at(hash, address),
 
-			// Use stash address to get info on payee and controller
+			// This returns an Option<AccountId> representing the controller
 			api.query.staking.bonded.at(hash, address),
 		]);
 

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -404,8 +404,8 @@ export default class ApiHandler {
 			await api.query.staking.slashingSpans.at(hash, stash),
 		]);
 
-		// should always work because we know that we have a bonded pair
-		// but just in case we return a default value of null
+		// should always work because we know that we have a bonded pair but just
+		// in case we return a default value of null so we know to handle later
 		const stakingLedger = optionStakingLedger.unwrapOr(null);
 
 		const numSlashingSpans = optionSlashingSpans.isSome

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -378,13 +378,21 @@ export default class ApiHandler {
 			api.query.staking.bonded.at(hash, address),
 		]);
 
+		const at = {
+			hash,
+			height: header.number.toNumber().toString(10),
+		};
+
+		const noneResponse = {
+			at,
+			controller: null,
+			rewardDestination: null,
+			numSlashingSpans: null,
+			staking: {},
+		};
+
 		if (optionBonded.isNone === true) {
-			return {
-				controller: null,
-				rewardDestination: null,
-				numSlashingSpans: null,
-				staking: {},
-			};
+			return noneResponse;
 		}
 
 		// We can safely infer (optionBonded.isSome === true) and safely unwrap
@@ -395,18 +403,8 @@ export default class ApiHandler {
 			bonded
 		);
 
-		const at = {
-			hash,
-			height: header.number.toNumber().toString(10),
-		};
-
 		if (staking.isNone) {
-			// Address is not a Controller, no need to look up slashing spans.
-			return {
-				at,
-				staking: {},
-				numSlashingSpans: null,
-			};
+			return noneResponse;
 		}
 
 		const ledger = staking.unwrap(); // should always work if staking.isSome
@@ -425,11 +423,13 @@ export default class ApiHandler {
 
 		return {
 			at,
-			// staking,
-			staking: ledger.toJSON(),
-			numSlashingSpans,
+			controller: bonded,
 			rewardDestination,
-			bonded,
+			numSlashingSpans,
+			staking,
+			// I will take this line out if we don't use it, but it does work
+			// and I think it addresses #92 - zeke
+			// staking: ledger.toJSON(),
 		};
 	}
 

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -16,11 +16,11 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { CalcFee } from '@polkadot/calc-fee';
-import { Option, Struct } from '@polkadot/types';
+import { Struct } from '@polkadot/types';
 import { getSpecTypes } from '@polkadot/types-known';
 import { GenericCall } from '@polkadot/types/generic';
 import { EventData } from '@polkadot/types/generic/Event';
-import { DispatchInfo, StakingLedger } from '@polkadot/types/interfaces';
+import { DispatchInfo } from '@polkadot/types/interfaces';
 import { BlockHash } from '@polkadot/types/interfaces/chain';
 import { EventRecord } from '@polkadot/types/interfaces/system';
 import { u32 } from '@polkadot/types/primitive';

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -404,7 +404,7 @@ export default class ApiHandler {
 		if (stakingLedger === null) {
 			// should never throw because by time we get here we know we have a bonded pair
 			throw {
-				error: `Staking ledger could not be found for address "${controller.toString()}"`,
+				error: `Staking ledger could not be found for controller address "${controller.toString()}"`,
 				statusCode: 404,
 			};
 		}

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -381,7 +381,6 @@ export default class ApiHandler {
 		};
 
 		if (controllerOption.isNone) {
-			// if controllerOption.isNone, `stash` address param is not a stash.
 			throw {
 				error: `The address ${stash} is not a stash address.`,
 				statusCode: 400,

--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -381,7 +381,7 @@ export default class ApiHandler {
 		};
 
 		if (optionController.isNone) {
-			// if bonded.isNone, `stash` param is not a stash.
+			// if bonded.isNone, `stash` address param is not a stash.
 			return {
 				at,
 				controller: null,
@@ -405,7 +405,8 @@ export default class ApiHandler {
 		]);
 
 		// should always work because we know that we have a bonded pair
-		const stakingLedger = optionStakingLedger.unwrap();
+		// but just in case we return a default value of null
+		const stakingLedger = optionStakingLedger.unwrapOr(null);
 
 		const numSlashingSpans = optionSlashingSpans.isSome
 			? optionSlashingSpans.unwrap().prior.length + 1
@@ -416,7 +417,7 @@ export default class ApiHandler {
 			controller,
 			rewardDestination,
 			numSlashingSpans,
-			staking: stakingLedger.toJSON(),
+			staking: stakingLedger ? stakingLedger.toJSON() : {},
 		};
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -218,7 +218,7 @@ async function main() {
 	// GET staking information for an address.
 	//
 	// Paths:
-	// - `address`: The _Controller_ address for staking.
+	// - `address`: The _Stash_ address for staking.
 	// - (Optional) `number`: Block hash or height at which to query. If not provided, queries
 	//   finalized head.
 	//

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,7 +183,7 @@ async function main() {
 		return await handler.fetchBalance(hash, address);
 	});
 
-	// GET payout information for an address.
+	// GET staking information for an address.
 	//
 	// Paths:
 	// - `address`: The _Stash_ address for staking.
@@ -195,35 +195,7 @@ async function main() {
 	// - `rewardDestination`: The account to which rewards will be paid. Can be 'Staked' (Stash
 	//   account, adding to the amount at stake), 'Stash' (Stash address, not adding to the amount at
 	//   stake), or 'Controller' (Controller address).
-	// - `bonded`: Controller address for the given Stash.
-	//
-	// Substrate Reference:
-	// - Staking Pallet: https://crates.parity.io/pallet_staking/index.html
-	// - `RewardDestination`: https://crates.parity.io/pallet_staking/enum.RewardDestination.html
-	// - `Bonded`: https://crates.parity.io/pallet_staking/struct.Bonded.html
-	get('/payout/:address', async (params) => {
-		const { address } = params;
-		const hash = await api.rpc.chain.getFinalizedHead();
-
-		return await handler.fetchPayoutInfo(hash, address);
-	});
-
-	get('/payout/:address/:number', async (params) => {
-		const { address } = params;
-		const hash: BlockHash = await getHashForBlock(api, params.number);
-
-		return await handler.fetchPayoutInfo(hash, address);
-	});
-
-	// GET staking information for an address.
-	//
-	// Paths:
-	// - `address`: The _Stash_ address for staking.
-	// - (Optional) `number`: Block hash or height at which to query. If not provided, queries
-	//   finalized head.
-	//
-	// Returns:
-	// - `at`: Block number and hash at which the call was made.
+	// - `controller`: Controller address for the given Stash.
 	// - `staking`: The staking ledger. Empty object if provided address is not a Controller.
 	//   - `stash`: The stash account whose balance is actually locked and at stake.
 	//   - `total`: The total amount of the stash's balance that we are currently accounting for.
@@ -245,19 +217,21 @@ async function main() {
 	//
 	// Substrate Reference:
 	// - Staking Pallet: https://crates.parity.io/pallet_staking/index.html
+	// - `RewardDestination`: https://crates.parity.io/pallet_staking/enum.RewardDestination.html
+	// - `Bonded`: https://crates.parity.io/pallet_staking/struct.Bonded.html
 	// - `StakingLedger`: https://crates.parity.io/pallet_staking/struct.StakingLedger.html
 	get('/staking/:address', async (params) => {
 		const { address } = params;
 		const hash = await api.rpc.chain.getFinalizedHead();
 
-		return await handler.fetchStakingLedger(hash, address);
+		return await handler.fetchStakingInfo(hash, address);
 	});
 
 	get('/staking/:address/:number', async (params) => {
 		const { address } = params;
 		const hash: BlockHash = await getHashForBlock(api, params.number);
 
-		return await handler.fetchStakingLedger(hash, address);
+		return await handler.fetchStakingInfo(hash, address);
 	});
 
 	// GET vesting information for an address.

--- a/src/main.ts
+++ b/src/main.ts
@@ -224,14 +224,14 @@ async function main() {
 	// - `RewardDestination`: https://crates.parity.io/pallet_staking/enum.RewardDestination.html
 	// - `Bonded`: https://crates.parity.io/pallet_staking/struct.Bonded.html
 	// - `StakingLedger`: https://crates.parity.io/pallet_staking/struct.StakingLedger.html
-	get('/accounts/:address/staking', async (params) => {
+	get('/staking/:address', async (params) => {
 		const { address } = params;
 		const hash = await api.rpc.chain.getFinalizedHead();
 
 		return await handler.fetchStakingInfo(hash, address);
 	});
 
-	get('/accounts/:address/staking/:number', async (params) => {
+	get('/staking/:address/:number', async (params) => {
 		const { address } = params;
 		const hash: BlockHash = await getHashForBlock(api, params.number);
 


### PR DESCRIPTION
#### Overview

- Delete `payout/:address` and move that info to '/staking' in order to create a single endpoint for an accounts staking info.
- Start migration to a _more_ RESTful resource model by changing endpoint paths.
- Rudimentary error handling improvement in `get`

#### Endpoint change from `staking/:address/:number` to `accounts/:address/staking/:number` discussion

tl;dr - we should think about changing the path to `accounts/:address/staking/:number` because it more accurately models our resource taxonomy.

As we approach V1 and dialing in the api, the importance of communicating meaning through our endpoint increases and thus it behooves us to carefully consider how they model resources.

After offline discussion with @danforbes, consensus has begun to coalesce around modeling the resource `accounts`, representing the (collection of) `AccountId`s of the chain. Under `accounts` we would then have single resource, an `account`, identified by its `AccountId`, (commonly referred to in sidecar and its reference material as ADDRESS or `address`).

Following this we can identify the following resources and relationships to an `account`:

- `balance` belongs to an `account`; an `account` has one `balance`.
- `staking{information}` belongs to an `account`; an `account` has one `staking{information}`.
- `vesting{information}` belongs to an `account`; an `account` has one `vesting{information}`.

Using this model we can then define paths that semantically correspond:

- `accounts/:address/balance`
- `accounts/:address/staking`
- `accounts/:address/vesting`

If critical consensus can be reached on the aforementioned paths, it still leaves the question of where an optional `number` (block hash or height) parameter would semantically fit with our model. Some say REST principles lean towards using a query param because `number` is not necessarily a resource ID, but instead a search term. However, to another subset of people, simply putting `number` at the end of the path still communicates model while staying terse. These two options for `number` would look like:

1) `accounts/:address/staking?number=2643`
2) `accounts/:address/staking/:number`

To move the discussion forward, I have gone ahead and changed the staking paths to `accounts/:address/staking/` and `accounts/:address/staking/:number`


_What about the other two routes?_ 
In order to keep the diff for this PR minimal I decided to only change this route for now. However, if this change is implemented the other routes should be changed prior to the v1 release.

#### Follow up PRs:

- Creating a swagger to document API
- Modify other endpoints to stay in line with model