### PR TITLE
Fix fee calculation at runtime upgrade

### DIFF
--- a/calc-fee/build.sh
+++ b/calc-fee/build.sh
@@ -6,5 +6,5 @@ if [ -z ${FEE_DEBUG} ]; then
     wasm-pack build --target nodejs --scope polkadot "$SCRIPT_DIR"
 else
     echo "Fee debugging enabled"
-    wasm-pack build --target nodejs --scope polkadot "$SCRIPT_DIR" -- --features debug
+    wasm-pack build --debug --target nodejs --scope polkadot "$SCRIPT_DIR" -- --features debug
 fi


### PR DESCRIPTION
The fee calculation of the first block of a new runtime did not work because its parent falsely proclaims to be produced under the new runtime. This workaround therefore uses the parent of the parent in order to determine the correct runtime under which the current block was produced.