### PR TITLE
Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 !.env-sample
 .github
 .git
+**/target
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.env*
+!.env-sample
+.github
+.git

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,6 @@
+# This profile helps you connect to a local Node
+# Start with: 
+#   NODE_ENV=local yarn start
+
+SAS_SUBSTRATE_NAME=Local Node
+SAS_SUBSTRATE_WS_URL=ws://127.0.0.1:9944

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:12 as builder
+LABEL author="chevdor@gmail.com"
+
+WORKDIR /opt/builder
+
+RUN echo 1 && \
+    echo 2 && \
+    echo 3
+
+COPY . .
+RUN yarn install && \
+    yarn build
+
+# ---------------------------------
+
+FROM node:12-alpine
+WORKDIR /usr/src/app
+
+COPY --from=builder /opt/builder /usr/src/app
+
+ENV SAS_MAIN_PORT=3000
+
+EXPOSE ${SAS_MAIN_PORT}
+CMD [ "node", "build/src/main.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ LABEL author="chevdor@gmail.com"
 
 WORKDIR /opt/builder
 
-RUN echo 1 && \
-    echo 2 && \
-    echo 3
-
 COPY . .
-RUN yarn install && \
+RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . $HOME/.cargo/env && \
+    cargo install wasm-pack && \
+    yarn install && \
     yarn build
 
 # ---------------------------------

--- a/README.md
+++ b/README.md
@@ -151,3 +151,9 @@ We welcome contributions. Before submitting your PR, make sure to run the follow
 
 - `yarn lint`: Make sure your code follows our linting rules. You can also run `yarn lint --fix` to automatically fix some of those errors.
 - Testing coming soon!
+
+## Docker
+
+```bash
+
+```

--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ We welcome contributions. Before submitting your PR, make sure to run the follow
 
 ## Docker
 
-```bash
+### Build
 
+```bash
+yarn build:docker
 ```
+
+### Run
+
+```bash
+export VERSION=`cat package.json | jq -r .version`
+docker run --rm -it -p 8080:8080 substrate-api-sidecar:$VERSION
+```
+
+then you can test with:
+```bash
+curl -s http://127.0.0.1:8080/block | jq
+```
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preinstall": "./calc-fee/build.sh",
     "postinstall": "yarn upgrade @polkadot/calc-fee",
     "build": "tsc",
+    "build:docker": "VERSION=`cat package.json | jq -r .version`; docker build -t substrate-api-sidecar:$VERSION .",
     "main": "node ./build/src/main.js",
     "lint": "tsc && eslint . --ext ts",
     "start": "yarn run build && yarn run main",

--- a/specs.yml
+++ b/specs.yml
@@ -3,10 +3,11 @@ SAS:
     LOG_MODE:
       description: Log level
       default: errors
+      regexp: ^error|all|none$
 
     BIND_HOST:
       description: Network interface we bind to
-      default: 127.0.0.1
+      default: 0.0.0.0
       type: string
 
     PORT:
@@ -19,9 +20,9 @@ SAS:
     NAME:
       description: Name for our node endpoint
       type: string
-      default: Default Substrate Dev Node
+      default: Parity Polkadot node
 
     WS_URL:
       description: Websocket URL
-      default: ws://127.0.0.1:9944
+      default: wss://rpc.polkadot.io
       regexp: ^wss?:\/\/.*(:\d{4,5})?$

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -41,4 +41,5 @@ export default {
 	WS_URL: config.Get(MODULES.SUBSTRATE, CONFIG.WS_URL) as string,
 	CUSTOM_TYPES: configTypes['CUSTOM_TYPES'],
 	NAME: config.Get('SUBSTRATE', CONFIG.NAME) as string,
+	valid: config.Validate()
 };

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -41,5 +41,4 @@ export default {
 	WS_URL: config.Get(MODULES.SUBSTRATE, CONFIG.WS_URL) as string,
 	CUSTOM_TYPES: configTypes['CUSTOM_TYPES'],
 	NAME: config.Get('SUBSTRATE', CONFIG.NAME) as string,
-	valid: config.Validate()
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -572,4 +572,9 @@ async function getHashForBlock(
 	}
 }
 
+process.on('SIGINT', function () {
+	console.log('Caught interrupt signal, exiting...');
+	process.exit(0);
+});
+
 main().catch(console.log);


### PR DESCRIPTION
This PR adds docker support:

 - `yarn build:docker` will build the image (you need `jq` installed)
 - I added code to handle SIGINT (= CTRL+C), which is especially important while running in a container
 - I fixed the default config so "it works ™" right away without any config/profile or local node(nice for demos...)
 - I added a default local profile to easily switch to a local node (`NODE_ENV=local yarn start`)

Once the image has been built, you may test it with:
```
export VERSION=`cat package.json | jq -r .version`
docker run --rm -it -p 8080:8080 substrate-api-sidecar:$VERSION
```

You may also test without building anything with:
```
docker run --rm -it -p 8080:8080 chevdor/substrate-api-sidecar
curl -s http://127.0.0.1:8080/block | jq
```
