### PR TITLE
Add `TxRequest` type

### DIFF
--- a/src/types/request_types.ts
+++ b/src/types/request_types.ts
@@ -1,0 +1,13 @@
+import { Request } from 'express';
+import { ParamsDictionary, Query } from 'express-serve-static-core';
+
+export type TxRequestBody = {
+	tx: string;
+};
+
+export type TxRequest = Request<
+	ParamsDictionary,
+	unknown,
+	TxRequestBody,
+	Query
+>;


### PR DESCRIPTION
Currently the body of post requests are just `any`. Since all posts request are for `tx` submission or estimate, we can change this any to a type that is specific to the `tx` request body format. I introduced `TxRequest` and `TxRequestBody` as types and added them to `post` and the handlers for `/tx` and `/tx/fee-estimate`