### PR TITLE
Move logger middleware to their own file

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -7,6 +7,3 @@ SAS_SUBSTRATE_WS_URL=wss://rpc.polkadot.io
 
 # Name of the node we are connected to for our own clarity
 SAS_SUBSTRATE_NAME="Polkadot Public Parity Node"
-
-# Express Port
-SAS_EXPRESS_BIND_PORT=6060

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,11 +22,14 @@ import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as core from 'express-serve-static-core';
 import { BadRequest, HttpError } from 'http-errors';
-import * as morgan from 'morgan';
 
 import ApiHandler from './ApiHandler';
 import config from './config_setup';
 import errorMiddleware from './middleware/error_middleware';
+import {
+	developmentLoggerMiddleware,
+	productionLoggerMiddleware,
+} from './middleware/logger_middleware';
 import { validateAddressMiddleware } from './middleware/validations_middleware';
 import { TxRequest, TxRequestBody } from './types/request_types';
 import { parseBlockNumber, sanitizeNumbers } from './utils';
@@ -46,18 +49,10 @@ async function main() {
 
 	switch (config.LOG_MODE) {
 		case 'errors':
-			app.use(
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-				morgan('combined', {
-					skip: function (_: express.Request, res: express.Response) {
-						return res.statusCode < 400; // Only log errors
-					},
-				})
-			);
+			app.use(productionLoggerMiddleware);
 			break;
 		case 'all':
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			app.use(morgan('dev'));
+			app.use(developmentLoggerMiddleware);
 			break;
 		default:
 			break;

--- a/src/middleware/logger_middleware.ts
+++ b/src/middleware/logger_middleware.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+import * as morgan from 'morgan';
+import { NormalMiddleware } from 'src/types/middleware_types';
+
+export const productionLoggerMiddleware = morgan('combined', {
+	skip: function (_: Request, res: Response) {
+		return res.statusCode < 400; // Only log errors
+	},
+}) as NormalMiddleware;
+
+export const developmentLoggerMiddleware = morgan('dev') as NormalMiddleware;

--- a/src/types/middleware_types.ts
+++ b/src/types/middleware_types.ts
@@ -1,0 +1,7 @@
+import { NextFunction, Request, Response } from 'express';
+
+export type NormalMiddleware = (
+	req: Request,
+	_res: Response,
+	next: NextFunction
+) => void | Promise<void>;


### PR DESCRIPTION
To create a consistent directory structure in which all middleware functions are housed within the middleware folder, the logger middleware is moved in that folder. Additionally, a middleware type is added.