### PR TITLE
Add explicit return types for public functions in ApiHandler

### DIFF
--- a/src/ApiHandler.ts
+++ b/src/ApiHandler.ts
@@ -35,7 +35,7 @@ import * as BN from 'bn.js';
 
 import * as errors from '../config/errors-en.json';
 import {
-	IAccountBalance,
+	IAccountBalanceSummary,
 	IAccountStakingSummary,
 	IAccountVestingSummary,
 	IBlock,
@@ -305,7 +305,7 @@ export default class ApiHandler {
 	async fetchBalance(
 		hash: BlockHash,
 		address: string
-	): Promise<IAccountBalance> {
+	): Promise<IAccountBalanceSummary> {
 		const api = await this.ensureMeta(hash);
 
 		const [header, locks, sysAccount] = await Promise.all([

--- a/src/types/response_types.ts
+++ b/src/types/response_types.ts
@@ -13,6 +13,7 @@ import {
 	Hash,
 	Index,
 	RewardDestination,
+	RuntimeDispatchInfo,
 	Sr25519Signature,
 	StakingLedger,
 	VestingInfo,
@@ -128,6 +129,9 @@ interface IExtrinsic {
 	newArgs: ISanitizedArgs;
 	tip: Compact<Balance>;
 	hash: string;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	info: RuntimeDispatchInfo | { error: string } | {};
 	events: ISanitizedEvent[];
+	success: string | false;
 	paysFee: boolean | null;
 }

--- a/src/types/response_types.ts
+++ b/src/types/response_types.ts
@@ -132,6 +132,6 @@ interface IExtrinsic {
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	info: RuntimeDispatchInfo | { error: string } | {};
 	events: ISanitizedEvent[];
-	success: string | false;
+	success: string | boolean;
 	paysFee: boolean | null;
 }

--- a/src/types/response_types.ts
+++ b/src/types/response_types.ts
@@ -1,12 +1,25 @@
-import { AnyJson } from '@polkadot/types/types';
+import { Compact } from '@polkadot/types';
+import Address from '@polkadot/types/generic/Address';
+import { EventData } from '@polkadot/types/generic/Event';
+import {
+	AccountId,
+	BlockHash,
+	BlockNumber,
+	EcdsaSignature,
+	Ed25519Signature,
+	Hash,
+	Index,
+	Sr25519Signature,
+} from '@polkadot/types/interfaces';
+import { AnyJson, Codec } from '@polkadot/types/types';
 
-interface At {
+interface IAt {
 	hash: string;
 	height: string;
 }
 
-export interface StakingInfo {
-	at: At;
+export interface IStakingInfo {
+	at: IAt;
 	idealValidatorCount?: string | null;
 	activeEra: string | null;
 	forceEra: AnyJson;
@@ -18,4 +31,58 @@ export interface StakingInfo {
 		toggleEstimate: string | null;
 	};
 	validatorSet?: string[] | null;
+}
+
+export interface ISanitizedEvent {
+	method: string;
+	data: EventData;
+}
+
+export interface ISanitizedCall {
+	[key: string]: unknown;
+	method: string;
+	callIndex: Uint8Array | string;
+	args: ISanitizedArgs;
+}
+
+export interface IBlockResponse {
+	number: Compact<BlockNumber>;
+	hash: BlockHash;
+	parentHash: Hash;
+	stateRoot: Hash;
+	extrinsicsRoot: Hash;
+	authorId: AccountId | undefined;
+	logs: ILog[];
+	onInitialize: IOnInitializeOrFinalize;
+	extrinsics: IExtrinsic[];
+	onFinalize: IOnInitializeOrFinalize;
+}
+
+interface ILog {
+	type: string;
+	index: number;
+	value: Codec;
+}
+
+interface IOnInitializeOrFinalize {
+	events: ISanitizedEvent[];
+}
+
+interface ISignature {
+	signature: EcdsaSignature | Ed25519Signature | Sr25519Signature;
+	signer: Address;
+}
+
+interface ISanitizedArgs {
+	call?: ISanitizedCall;
+	calls?: ISanitizedCall[];
+	[key: string]: unknown;
+}
+
+interface IExtrinsic {
+	method: string;
+	signature: ISignature | null;
+	nonce: Compact<Index>;
+	args: Codec[];
+	newArgs: ISanitizedArgs;
 }

--- a/src/types/response_types.ts
+++ b/src/types/response_types.ts
@@ -65,7 +65,7 @@ export interface IBlock {
 	onFinalize: IOnInitializeOrFinalize;
 }
 
-export interface IAccountBalance {
+export interface IAccountBalanceSummary {
 	at: IAt;
 	nonce: Index;
 	free: Balance;
@@ -126,4 +126,8 @@ interface IExtrinsic {
 	nonce: Compact<Index>;
 	args: Codec[];
 	newArgs: ISanitizedArgs;
+	tip: Compact<Balance>;
+	hash: string;
+	events: ISanitizedEvent[];
+	paysFee: boolean | null;
 }

--- a/src/types/response_types.ts
+++ b/src/types/response_types.ts
@@ -1,20 +1,27 @@
-import { Compact } from '@polkadot/types';
+import { Compact, Vec } from '@polkadot/types';
+import { Option } from '@polkadot/types/codec';
 import Address from '@polkadot/types/generic/Address';
 import { EventData } from '@polkadot/types/generic/Event';
 import {
 	AccountId,
+	Balance,
+	BalanceLock,
 	BlockHash,
 	BlockNumber,
 	EcdsaSignature,
 	Ed25519Signature,
 	Hash,
 	Index,
+	RewardDestination,
 	Sr25519Signature,
+	StakingLedger,
+	VestingInfo,
 } from '@polkadot/types/interfaces';
+import U32 from '@polkadot/types/primitive/U32';
 import { AnyJson, Codec } from '@polkadot/types/types';
 
 interface IAt {
-	hash: string;
+	hash: string | BlockHash;
 	height: string;
 }
 
@@ -45,7 +52,7 @@ export interface ISanitizedCall {
 	args: ISanitizedArgs;
 }
 
-export interface IBlockResponse {
+export interface IBlock {
 	number: Compact<BlockNumber>;
 	hash: BlockHash;
 	parentHash: Hash;
@@ -56,6 +63,40 @@ export interface IBlockResponse {
 	onInitialize: IOnInitializeOrFinalize;
 	extrinsics: IExtrinsic[];
 	onFinalize: IOnInitializeOrFinalize;
+}
+
+export interface IAccountBalance {
+	at: IAt;
+	nonce: Index;
+	free: Balance;
+	reserved: Balance;
+	miscFrozen: Balance;
+	feeFrozen: Balance;
+	locks: Vec<BalanceLock>;
+}
+
+export interface IAccountStakingSummary {
+	at: IAt;
+	controller: AccountId;
+	rewardDestination: RewardDestination;
+	numSlashingSpans: number;
+	staking: StakingLedger;
+}
+
+export interface IAccountVestingSummary {
+	at: IAt;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	vesting: Option<VestingInfo> | {};
+}
+
+export interface ITxConstructionMaterial {
+	at: IAt;
+	genesisHash: BlockHash;
+	chainName: string;
+	specName: string;
+	specVersion: U32;
+	txVersion: U32;
+	metadata: string;
 }
 
 interface ILog {

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,14 +51,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@7.8.7":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
-  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.3":
+"@babel/runtime@7.10.4", "@babel/runtime@^7.10.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
@@ -313,7 +306,7 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@types/yaml@^1.2.0":
+"@types/yaml@1.9.7":
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/@types/yaml/-/yaml-1.9.7.tgz#2331f36e0aac91311a63d33eb026c21687729679"
   integrity sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==
@@ -438,11 +431,6 @@ ansi-styles@^4.1.0:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
-
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -558,11 +546,6 @@ bs58@^4.0.1:
   dependencies:
     base-x "^3.0.2"
 
-buffer-from@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
@@ -578,6 +561,14 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+chalk@4.1.0, chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -586,22 +577,6 @@ chalk@^2.0.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -640,18 +615,17 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-confmgr@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/confmgr/-/confmgr-1.0.5.tgz#9b039c8ef62bce349292fd4ec91783ea483c6f05"
-  integrity sha512-G3eDWg5tT9O4N6K6H/SJn5ZYew5LKXhuB/hE3i54wa/1YbRjb6BXTiZEeSzanFFMkAEZUC3jWII/mkTQjAycOw==
+confmgr@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/confmgr/-/confmgr-1.0.6.tgz#d94e58dca6e9b6054a89c28eab50a93acb2b9741"
+  integrity sha512-acY0rWPHJCEruIxYQUUK17iwB1SAundkBAi47N16RIxdgLuEfbJO6flJUui0l1HeX2HvVupaz7iT1yVnzSFU1A==
   dependencies:
-    "@babel/runtime" "7.8.7"
-    "@types/yaml" "^1.2.0"
-    chalk "^3.0.0"
+    "@babel/runtime" "7.10.4"
+    "@types/yaml" "1.9.7"
+    chalk "4.1.0"
     dotenv "8.2.0"
-    ts-node "8.6.2"
-    typescript "^3.8.3"
-    yaml "^1.8.2"
+    typescript "3.9.6"
+    yaml "1.10.0"
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -760,11 +734,6 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -1519,11 +1488,6 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
-make-error@^1.1.1:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
@@ -2052,19 +2016,6 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-source-map-support@^0.5.6:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
@@ -2204,17 +2155,6 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-ts-node@8.6.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.6"
-    yn "3.1.1"
-
 tsc-watch@^4.2.8:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-4.2.9.tgz#d93fc74233ca4ef7ee6b12d08c0fe6aca3e19044"
@@ -2280,7 +2220,12 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.3, typescript@^3.9.5:
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
+typescript@^3.9.5:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
@@ -2369,12 +2314,7 @@ yaeti@^0.0.6:
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
   integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
 
-yaml@*, yaml@^1.8.2:
+yaml@*, yaml@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
-
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Closes #145 

In an effort to clean up all the `eslint-disable` and just generally have better typescript code, I added types for all public functions in ApiHandler. 

New code is straightforward. The main thing I want to discuss is the naming conventions this PR establishes. 

In order to prevent naming collisions with polkadot-js types, I prefixed `I` in front of all the new interfaces I introduced. Just from my last month of writing TS I have seen this pattern fairly often while perusing the inter-webs, however not sure if this is the right use. I would say this establishes the precedent that all future interfaces should be prefixed with an `I`.

I realize that many of these don't have polkadot-js name space collisions, however for the sake of consistency I feel we should either go all or nothing.