### PR TITLE
Add config validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/http-errors": "^1.6.3",
     "@types/morgan": "^1.9.1",
     "body-parser": "^1.19.0",
-    "confmgr": "^1.0.5",
+    "confmgr": "^1.0.6",
     "express": "^4.17.1",
     "http-errors": "^1.8.0",
     "morgan": "^1.10.0",

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -1,5 +1,5 @@
 // File for creating an exportable object that stores all config information
-import { ConfigManager } from 'confmgr';
+import { ConfigManager, ConfigObject } from 'confmgr';
 
 import * as configTypes from '../config/types.json';
 
@@ -13,6 +13,7 @@ export interface SidecarConfig {
 	WS_URL: string;
 	CUSTOM_TYPES: Record<string, string> | undefined;
 	NAME: string;
+	config: ConfigObject;
 }
 
 /**
@@ -27,18 +28,16 @@ export enum MODULES {
  * Names of config env vars of Sidecar.
  */
 export enum CONFIG {
-	WS_URL = 'WS_URL',
 	LOG_MODE = 'LOG_MODE',
 	BIND_HOST = 'BIND_HOST',
 	PORT = 'PORT',
-	NAME = 'NAME',
+	WS_URL = 'WS_URL',
 	CUSTOM_TYPES = 'CUSTOM_TYPES',
+	NAME = 'NAME',
 }
 
 // Instantiate ConfigManager which is used to read in the specs.yml
 const config = ConfigManager.getInstance('specs.yml').getConfig();
-// Print some nice info that also gives informative error messages
-config.Print({ compact: true });
 
 export default {
 	HOST: config.Get(MODULES.EXPRESS, CONFIG.BIND_HOST) as string,
@@ -47,4 +46,5 @@ export default {
 	WS_URL: config.Get(MODULES.SUBSTRATE, CONFIG.WS_URL) as string,
 	CUSTOM_TYPES: configTypes[CONFIG.CUSTOM_TYPES],
 	NAME: config.Get('SUBSTRATE', CONFIG.NAME) as string,
+	config,
 } as SidecarConfig;

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -1,5 +1,5 @@
-// File for creating an exportable object that stores all config information
 import { ConfigManager } from 'confmgr';
+
 import * as configTypes from '../config/types.json';
 
 /**
@@ -35,6 +35,9 @@ export enum CONFIG {
 }
 
 export default class Config {
+	/**
+	 * Gather env vars for config and make sure they are valid.
+	 */
 	public static GetConfig(): SidecarConfig | null {
 		// Instantiate ConfigManager which is used to read in the specs.yml
 		const config = ConfigManager.getInstance('specs.yml').getConfig();

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -1,6 +1,5 @@
 // File for creating an exportable object that stores all config information
 import { ConfigManager } from 'confmgr';
-
 import * as configTypes from '../config/types.json';
 
 /**

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -1,5 +1,5 @@
 // File for creating an exportable object that stores all config information
-import { ConfigManager, ConfigObject } from 'confmgr';
+import { ConfigManager } from 'confmgr';
 
 import * as configTypes from '../config/types.json';
 
@@ -13,7 +13,6 @@ export interface SidecarConfig {
 	WS_URL: string;
 	CUSTOM_TYPES: Record<string, string> | undefined;
 	NAME: string;
-	config: ConfigObject;
 }
 
 /**
@@ -36,15 +35,26 @@ export enum CONFIG {
 	NAME = 'NAME',
 }
 
-// Instantiate ConfigManager which is used to read in the specs.yml
-const config = ConfigManager.getInstance('specs.yml').getConfig();
+export default class Config {
+	public static GetConfig(): SidecarConfig | null {
+		// Instantiate ConfigManager which is used to read in the specs.yml
+		const config = ConfigManager.getInstance('specs.yml').getConfig();
 
-export default {
-	HOST: config.Get(MODULES.EXPRESS, CONFIG.BIND_HOST) as string,
-	PORT: config.Get(MODULES.EXPRESS, CONFIG.PORT) as number,
-	LOG_MODE: config.Get(MODULES.EXPRESS, CONFIG.LOG_MODE) as string,
-	WS_URL: config.Get(MODULES.SUBSTRATE, CONFIG.WS_URL) as string,
-	CUSTOM_TYPES: configTypes[CONFIG.CUSTOM_TYPES],
-	NAME: config.Get('SUBSTRATE', CONFIG.NAME) as string,
-	config,
-} as SidecarConfig;
+		if (!config.Validate()) {
+			config.Print({ compact: false });
+			return null;
+		} else {
+			// Print some nice info that also gives informative error messages
+			config.Print({ compact: true });
+		}
+
+		return {
+			HOST: config.Get(MODULES.EXPRESS, CONFIG.BIND_HOST) as string,
+			PORT: config.Get(MODULES.EXPRESS, CONFIG.PORT) as number,
+			LOG_MODE: config.Get(MODULES.EXPRESS, CONFIG.LOG_MODE) as string,
+			WS_URL: config.Get(MODULES.SUBSTRATE, CONFIG.WS_URL) as string,
+			CUSTOM_TYPES: configTypes[CONFIG.CUSTOM_TYPES],
+			NAME: config.Get('SUBSTRATE', CONFIG.NAME) as string,
+		};
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ import * as core from 'express-serve-static-core';
 import { BadRequest, HttpError } from 'http-errors';
 
 import ApiHandler from './ApiHandler';
-import config from './config_setup';
+import Config, { SidecarConfig } from './config_setup';
 import errorMiddleware from './middleware/error_middleware';
 import {
 	developmentLoggerMiddleware,
@@ -35,14 +35,14 @@ import { TxRequest, TxRequestBody } from './types/request_types';
 import { parseBlockNumber, sanitizeNumbers } from './utils';
 
 async function main() {
-	if (!config.config.Validate()) {
-		config.config.Print({ compact: false });
+	const configOrNull = Config.GetConfig();
+
+	if (!configOrNull) {
 		console.log('Your config is NOT valid, exiting');
 		process.exit(1);
-	} else {
-		// Print some nice info that also gives informative error messages
-		config.config.Print({ compact: true });
 	}
+
+	const config: SidecarConfig = configOrNull;
 
 	console.log(`Connecting to ${config.NAME} at ${config.WS_URL}`);
 
@@ -582,7 +582,7 @@ async function getHashForBlock(
 		if (blockNumber && number.toNumber() < blockNumber) {
 			throw new BadRequest(
 				`Specified block number is higher than the current finalized block height. ` +
-				`The largest known block number is ${number.toString()}.`
+					`The largest known block number is ${number.toString()}.`
 			);
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,15 @@ import { TxRequest, TxRequestBody } from './types/request_types';
 import { parseBlockNumber, sanitizeNumbers } from './utils';
 
 async function main() {
+	if (!config.config.Validate()) {
+		config.config.Print({ compact: false });
+		console.log('Your config is NOT valid, exiting');
+		process.exit(1);
+	} else {
+		// Print some nice info that also gives informative error messages
+		config.config.Print({ compact: true });
+	}
+
 	console.log(`Connecting to ${config.NAME} at ${config.WS_URL}`);
 
 	const api = await ApiPromise.create({
@@ -573,7 +582,7 @@ async function getHashForBlock(
 		if (blockNumber && number.toNumber() < blockNumber) {
 			throw new BadRequest(
 				`Specified block number is higher than the current finalized block height. ` +
-					`The largest known block number is ${number.toString()}.`
+				`The largest known block number is ${number.toString()}.`
 			);
 		}
 


### PR DESCRIPTION
It is important to abort if the config is not valid.
This PR shows the compact version of the config if the config is ok, as info for the user.
However, if the config is NOT ok, it will show the full (= not compact) version to help the user figure out the issue then exit.

Here is a run where I am passing a bad W_URL:
```
$ NODE_ENV=web3 SAS_SUBSTRATE_WS_URL=BAD y start
yarn run v1.22.4
$ yarn run build && yarn run main
$ tsc
$ node ./build/src/main.js
SAS:
  📦 EXPRESS:
     ✅ LOG_MODE: errors
    Log level
 
     ✅ BIND_HOST: 127.0.0.1
    Network interface we bind to
 
     ✅ PORT: 8080
    Port of the web service
    regexp: ^\d{2,6}$
 
  📦 SUBSTRATE:
     ✅ NAME: Default Substrate Dev Node
    Name for our node endpoint
 
     ❌ WS_URL: BAD
    Websocket URL
    regexp: ^wss?:\/\/.*(:\d{4,5})?$
 
Your config is NOT valid, exiting
error Command failed with exit code 1.
```
 