### PR TITLE
Add `sanitizeNumber` support for HashMap, js native Map, and BN.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "tsc && eslint . --ext ts",
     "start": "yarn run build && yarn run main",
     "dev": "tsc-watch --onSuccess \"yarn run main\"",
-    "test": "yarn run build && jest"
+    "test": "jest"
   },
   "author": "",
   "license": "GPL-3.0-or-later",

--- a/src/utils/test_util.ts
+++ b/src/utils/test_util.ts
@@ -24,6 +24,20 @@ function createKusamaRegistry(): TypeRegistry {
 
 export const kusamaRegistry = createKusamaRegistry();
 
+export const MAX_U128 = '340282366920938463463374607431768211455';
+
+export const MAX_I128 = '170141183460469231731687303715884105727';
+export const MIN_I128 = '-170141183460469231731687303715884105728';
+
+export const MAX_U64 = '18446744073709551615';
+
+export const MAX_I64 = '9223372036854775807';
+export const MIN_I64 = '-9223372036854775808';
+
+export const MAX_U32 = '4294967295';
+
+export const MIN_I32 = '-2147483648';
+export const MAX_I32 = '2147483647';
 /**
  * An 'at' object, which has not been sanitized by `sanitizeNumbers`.
  */
@@ -75,7 +89,7 @@ export const PRE_SANITIZED_OPTION_VESTING_INFO = kusamaRegistry.createType(
 export const PRE_SANITIZED_RUNTIME_DISPATCH_INFO = kusamaRegistry.createType(
 	'RuntimeDispatchInfo',
 	{
-		weight: '0xFFFFFFFFFFFFFFFF',
+		weight: MAX_U64,
 		class: 'operational',
 		partialFee: '0xffffffffffffffffffffffffffffffff',
 	}

--- a/src/utils/test_util.ts
+++ b/src/utils/test_util.ts
@@ -36,8 +36,9 @@ export const MIN_I64 = '-9223372036854775808';
 
 export const MAX_U32 = '4294967295';
 
-export const MIN_I32 = '-2147483648';
 export const MAX_I32 = '2147483647';
+export const MIN_I32 = '-2147483648';
+
 /**
  * An 'at' object, which has not been sanitized by `sanitizeNumbers`.
  */
@@ -91,6 +92,6 @@ export const PRE_SANITIZED_RUNTIME_DISPATCH_INFO = kusamaRegistry.createType(
 	{
 		weight: MAX_U64,
 		class: 'operational',
-		partialFee: '0xffffffffffffffffffffffffffffffff',
+		partialFee: MAX_U128,
 	}
 );


### PR DESCRIPTION
- Add support for 
    - Codec HashMap
    - BN
    - native js Map (alot of Codec is derivative of Map so I think this is good to support)
- DRY, reorganize test code with constants for commonly used numbers. No tests are removed, but some are moved for better organization.
- Add test coverage 
- Add future todos for areas of polkadot-js types that still need more coverage
- Document (with testing) native javascript types that are not supported