### PR TITLE
Remove NAME env var

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -6,5 +6,3 @@
 # Endpoint of the node we are connected to
 SAS_SUBSTRATE_WS_URL=ws://127.0.0.1:9944
 
-# Name of the node we are connected to for our own clarity
-SAS_SUBSTRATE_NAME="My local node"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Following ENV variables can be set:
   setting it to anything else. LOG_MODE defaults to only "errors".
 - `SAS_SUBSTRATE_WS_URL`: WebSocket URL to which the RPC proxy will attempt to connect to, defaults to
   `ws://127.0.0.1:9944`.
-- `SAS_SUBSTRATE_NAME`: name for the substrate node sidecar is connected to; just for ease of use.
 
 If you are connecting to [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template), please add the following  custom types in `config/types.json`.
 

--- a/specs.yml
+++ b/specs.yml
@@ -17,11 +17,6 @@ SAS:
       regexp: ^\d{2,6}$
 
   SUBSTRATE:
-    NAME:
-      description: Name for our node endpoint
-      type: string
-      default: Default Substrate Dev Node
-
     WS_URL:
       description: Websocket URL
       default: ws://127.0.0.1:9944

--- a/src/config_setup.ts
+++ b/src/config_setup.ts
@@ -11,7 +11,6 @@ export interface ISidecarConfig {
 	LOG_MODE: string;
 	WS_URL: string;
 	CUSTOM_TYPES: Record<string, string> | undefined;
-	NAME: string;
 }
 
 /**
@@ -31,7 +30,6 @@ export enum CONFIG {
 	PORT = 'PORT',
 	WS_URL = 'WS_URL',
 	CUSTOM_TYPES = 'CUSTOM_TYPES',
-	NAME = 'NAME',
 }
 
 export default class Config {
@@ -56,7 +54,6 @@ export default class Config {
 			LOG_MODE: config.Get(MODULES.EXPRESS, CONFIG.LOG_MODE) as string,
 			WS_URL: config.Get(MODULES.SUBSTRATE, CONFIG.WS_URL) as string,
 			CUSTOM_TYPES: configTypes[CONFIG.CUSTOM_TYPES],
-			NAME: config.Get(MODULES.SUBSTRATE, CONFIG.NAME) as string,
 		};
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,12 +51,6 @@ async function main() {
 		}`
 	);
 
-	console.log(
-		`Connecting to ${chainName.toString()} via ${config.NAME} at ${
-			config.WS_URL
-		}`
-	);
-
 	// Create array of middleware that is to be mounted before the routes
 	const preMiddleware: RequestHandler[] = [bodyParser.json()];
 	if (config.LOG_MODE === 'errors') {


### PR DESCRIPTION
This PR removes the NAME env var because there is not a clear use for it now that we display the type of client and the chain name. Additionally it removes the `console.log` in `main` starting with `Connecting...`.