### PR TITLE
Build a default config

### DIFF
--- a/specs.yml
+++ b/specs.yml
@@ -6,7 +6,7 @@ SAS:
       regexp: ^error|all|none$
 
     BIND_HOST:
-      description: Network interface we bind to
+      description: Network interface we bind to. You *MUST* use 0.0.0.0 if you are using Docker.
       default: 127.0.0.1
       type: string
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -32,6 +32,10 @@ export enum CONFIG {
 	CUSTOM_TYPES = 'CUSTOM_TYPES',
 }
 
+function hr(): string {
+	return Array(80).fill('━').join('');
+}
+
 export default class Config {
 	/**
 	 * Gather env vars for config and make sure they are valid.
@@ -42,9 +46,17 @@ export default class Config {
 
 		if (!config.Validate()) {
 			config.Print({ compact: false });
-			return null;
+			console.log('Invalid config, we expect something like:');
+			console.log(hr());
+			console.log(config.GenEnv().join('\n'));
+			console.log(hr());
+			console.log(
+				'You may copy the snippet above in a .env.foobar file, then use it with:'
+			);
+			console.log('    NODE_ENV=foobar yarn start\n');
+			console.log('Invalid config, exiting...');
+			process.exit(1);
 		} else {
-			// Print some nice info that also gives informative error messages
 			config.Print({ compact: true });
 		}
 


### PR DESCRIPTION
Fix #165

This PR is aimed at helping the users with configuration.
Failing the config (you may trigger that with `SAS_SUBSTRATE_WS_URL=BAD yarn start` for instance) will show the following:
```
SAS:
  📦 EXPRESS:
     ✅ LOG_MODE: "errors"
    Log level
 
     ✅ BIND_HOST: "127.0.0.1"
    Network interface we bind to
 
     ✅ PORT: 8080
    Port of the web service
    regexp: ^\d{2,6}$
 
  📦 SUBSTRATE:
     ✅ NAME: "Default Substrate Dev Node"
    Name for our node endpoint
 
     ❌ WS_URL: "BAD"
    Websocket URL
    regexp: ^wss?:\/\/.*(:\d{4,5})?$
 
Invalid config, we expect something like:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
SAS_EXPRESS_LOG_MODE="errors"
SAS_EXPRESS_BIND_HOST="127.0.0.1"
SAS_EXPRESS_PORT=8080
SAS_SUBSTRATE_NAME="Default Substrate Dev Node"
SAS_SUBSTRATE_WS_URL="ws://127.0.0.1:9944"
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
You may copy the snippet above in a .env.foobar file, then use it with:
    NODE_ENV=foobar yarn start
```

So not only the user knows (❌  above...) what is wrong but also gets a sample (between the ━━━━) of what a config should be. The expected config is dynamic and matches the content of `specs.yml`