### PR TITLE
Parse `OpaqueCall` in `asMulti` call argument

### DIFF
--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -116,14 +116,14 @@ describe('BlocksService', () => {
 
 		it('does not handle an empty object', () =>
 			expect(() =>
-				BlocksService['parseGenericCall'](
+				blocksService['parseGenericCall'](
 					({} as unknown) as GenericCall
 				)
 			).toThrow());
 
 		it('parses a simple balances.transfer', () => {
 			expect(
-				JSON.stringify(BlocksService['parseGenericCall'](transfer))
+				JSON.stringify(blocksService['parseGenericCall'](transfer))
 			).toBe(JSON.stringify(transferOutput));
 		});
 
@@ -153,7 +153,7 @@ describe('BlocksService', () => {
 			};
 
 			expect(
-				JSON.stringify(BlocksService['parseGenericCall'](batch4))
+				JSON.stringify(blocksService['parseGenericCall'](batch4))
 			).toBe(
 				JSON.stringify({
 					...baseBatch,
@@ -222,7 +222,7 @@ describe('BlocksService', () => {
 			};
 
 			expect(
-				JSON.stringify(BlocksService['parseGenericCall'](batch))
+				JSON.stringify(blocksService['parseGenericCall'](batch))
 			).toEqual(
 				JSON.stringify({
 					method: 'utility.batch',

--- a/src/test-helpers/createCall.ts
+++ b/src/test-helpers/createCall.ts
@@ -4,7 +4,13 @@ import { stringCamelCase } from '@polkadot/util';
 
 import { decoratedKusamaMetadata } from './metadata/decorated';
 
-type CallArgValues = string | number | Codec | Call | CallArgValues[];
+type CallArgValues =
+	| string
+	| number
+	| Codec
+	| Call
+	| CallArgValues[]
+	| Uint8Array;
 type CallArgs = { [i: string]: CallArgValues | CallArgs };
 
 /**


### PR DESCRIPTION
The dispatchable multisig.asMulti takes a call argument, (type alias `OpaqueCall`) that is a `Vec<u8>`. Sidecar currently responds with a hex blob representing the byte array. In order to increase readability and usability, this PR ensures that any argument with the parameter name `"call"` and a raw type of `Bytes` will be serialized to a polkadot-js `Call` and then parsed
This argument can be decoded to a polkadot-js `Call` type.