### PR TITLE
Add links to controllers for path description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,42 +75,44 @@ FEE_DEBUG=1 yarn
 
 ## Available paths
 
+Path descriptions link to controllers for detailed docs with usage information.
+
 Block IDs may take two forms: a non-negative decimal integer that denotes the block _height_ **or**
 a 32-byte hex string (`0x` followed by 64 hexadecimal digits) that denotes the block _hash_.
 
--   `/block` fetch latest finalized block details.
+-   [`/block` fetch latest finalized block details.](/src/controllers/blocks/BlocksController.ts)
 
--   `/block/NUMBER` fetch block details at the block identified by 'NUMBER`.
+-   [`/block/NUMBER` fetch block details at the block identified by 'NUMBER`.](/src/controllers/blocks/BlocksController.ts)
 
--   `/balance/ADDRESS` fetch balances for `ADDRESS` at latest finalized block.
+-   [`/balance/ADDRESS` fetch balances for `ADDRESS` at latest finalized block.](src/controllers/accounts/AccountsBalanceInfoController.ts)
 
--   `/balance/ADDRESS/NUMBER` fetch balances for `ADDRESS` at the block identified by 'NUMBER`.
+-   [`/balance/ADDRESS/NUMBER` fetch balances for `ADDRESS` at the block identified by 'NUMBER`.](src/controllers/accounts/AccountsBalanceInfoController.ts)
 
--   `/staking/ADDRESS` fetch the staking info for `ADDRESS` at latest finalized block.
+-   [`/staking/ADDRESS` fetch the staking info for `ADDRESS` at latest finalized block.](src/controllers/accounts/AccountsStakingInfoController.ts)
 
--   `/staking/ADDRESS/NUMBER` fetch the staking info for `ADDRESS` at the block identified by 'NUMBER`.
+-   [`/staking/ADDRESS/NUMBER` fetch the staking info for `ADDRESS` at the block identified by 'NUMBER`.](src/controllers/accounts/AccountsStakingInfoController.ts)
 
--  `/staking-info` fetch information on general staking progress at the latest finalized block.
+-  [`/staking-info` fetch information on general staking progress at the latest finalized block.](src/controllers/pallets/PalletsStakingProgressController.ts)
 
--  `/staking-info/NUMBER` fetch information on general staking progress at the block identified by 'NUMBER`.
+-  [`/staking-info/NUMBER` fetch information on general staking progress at the block identified by 'NUMBER`.](src/controllers/pallets/PalletsStakingProgressController.ts)
 
--   `/vesting/ADDRESS` fetch the vesting info for `ADDRESS` at latest finalized block.
+-   [`/vesting/ADDRESS` fetch the vesting info for `ADDRESS` at latest finalized block.](src/controllers/accounts/AccountsVestingInfoController.ts)
 
--   `/vesting/ADDRESS/NUMBER` fetch the vesting info for `ADDRESS` at the block identified by 'NUMBER`.
+-   [`/vesting/ADDRESS/NUMBER` fetch the vesting info for `ADDRESS` at the block identified by 'NUMBER`.](src/controllers/accounts/AccountsVestingInfoController.ts)
 
--   `/metadata` fetch chain metadata at latest finalized block.
+-   [`/metadata` fetch chain metadata at latest finalized block.](src/controllers/runtime/RuntimeMetadataController.ts)
 
--   `/metadata/NUMBER` fetch chain metadata at the block identified by 'NUMBER`.
+-   [`/metadata/NUMBER` fetch chain metadata at the block identified by 'NUMBER`.](src/controllers/runtime/RuntimeMetadataController.ts)
 
--   `/claims/ADDRESS` fetch claims data for an Ethereum `ADDRESS`.
+-   [`/claims/ADDRESS` fetch claims data for an Ethereum `ADDRESS`.](src/controllers/claims/ClaimsController.ts)
 
--   `/claims/ADDRESS/NUMBER` fetch claims data for an Ethereum `ADDRESS` at the block identified by 'NUMBER`.
+-   [`/claims/ADDRESS/NUMBER` fetch claims data for an Ethereum `ADDRESS` at the block identified by 'NUMBER`.](src/controllers/claims/ClaimsController.ts)
 
--   `/tx/artifacts/` fetch artifacts used for creating transactions at latest finalized block.
+-   [`/tx/artifacts/` fetch artifacts used for creating transactions at latest finalized block.](src/controllers/transaction/TransactionMaterialController.ts)
 
--   `/tx/artifacts/NUMBER` fetch artifacts used for creating transactions at the block identified by 'NUMBER`.
+-   [`/tx/artifacts/NUMBER` fetch artifacts used for creating transactions at the block identified by 'NUMBER`.](src/controllers/transaction/TransactionMaterialController.ts)
 
--   `/tx/fee-estimate` submit a transaction in order to get back a fee estimation. Expects a string
+-   [`/tx/fee-estimate` submit a transaction in order to get back a fee estimation.](src/controllers/transaction/TransactionFeeEstimateController.ts) Expects a string
     with a hex-encoded transaction in a JSON POST body:
 
     ```
@@ -127,7 +129,7 @@ a 32-byte hex string (`0x` followed by 64 hexadecimal digits) that denotes the b
     }
     ```
 
--   `/tx/` submit a signed transaction, expects a string with hex-encoded transaction in a JSON POST
+-   [`/tx/` submit a signed transaction.](src/controllers/transaction/TransactionSubmitController.ts) Expects a string with hex-encoded transaction in a JSON POST
     body:
     ```
     curl localhost:8080/tx/ -X POST --data '{"tx": "0x..."}' -H 'Content-Type: application/json'


### PR DESCRIPTION
This PR adds relative to links to controllers from path descriptions. This will help README.md users navigate to the detailed docs in the controllers.

Follow up PRs:
- Implement Swagger UI once all v1 routes are ready