### PR TITLE
Add configuration options for using metadata of parent block [PARENT_VERSION]

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Following ENV variables can be set:
     setting it to anything else. LOG_MODE defaults to only "errors".
 -   `SAS_SUBSTRATE_WS_URL`: WebSocket URL to which the RPC proxy will attempt to connect to, defaults to
     `ws://127.0.0.1:9944`.
+-   `SAS_SUBSTRATE_PARENT_VERSION`: wether or not to always use the version of the parent block to set
+    metadata for scale decoding. This will normally have a slight time penalty, but will guarantee that
+    extrinsics within a block that does a runtime upgrade with `set_code` are always decoded correctly.
+    If set to `off`, one can selectively hard code the hash of blocks to use the parents version of to
+    set the metadata for scale decoding. The hash for block's with `set_code` can be hardcoded in
+    `config/setCodeBlocks.ts`. Defaults to false. Note: for chains that use the `scheduler` pallet to
+    do runtime upgrades, it is very unlikely this will be an issue as `scheduler` ensures that `set_code`
+    is executed in `on_initialize` and it is highly unlikely there would be any additional room in a
+    block for other extrinsics.
 
 If you are connecting to [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template), please add the following custom types in `config/types.json`.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Following ENV variables can be set:
 -   `SAS_SUBSTRATE_WS_URL`: WebSocket URL to which the RPC proxy will attempt to connect to, defaults to
     `ws://127.0.0.1:9944`.
 -   `SAS_SUBSTRATE_PARENT_VERSION`: always use the version of the parent block to set
-    metadata for scale decoding. `on` means always fetch and use the parent blocks metadata, while `off`
+    metadata for scale decoding. `on` means always fetch and use the parent block's metadata, while `off`
     means _only_ fetch and use the parent blocks metadata for the blocks with hashes specified in
-    `config/setCodeBlocks.ts`. Fetching and using the parent blocks metadata will have a slight time
+    `config/setCodeBlocks.ts`. Fetching and using the parent block's metadata will have a slight time
     penalty, but will guarantee that extrinsics within a block that executed a runtime upgrade with
     `set_code` are always decoded correctly. Defaults to `off`. Note: for chains that use the
     `scheduler` pallet to do runtime upgrades, it is very unlikely this will be an issue as

--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ Following ENV variables can be set:
     setting it to anything else. LOG_MODE defaults to only "errors".
 -   `SAS_SUBSTRATE_WS_URL`: WebSocket URL to which the RPC proxy will attempt to connect to, defaults to
     `ws://127.0.0.1:9944`.
--   `SAS_SUBSTRATE_PARENT_VERSION`: wether or not to always use the version of the parent block to set
-    metadata for scale decoding. This will normally have a slight time penalty, but will guarantee that
-    extrinsics within a block that does a runtime upgrade with `set_code` are always decoded correctly.
-    If set to `off`, one can selectively hard code the hash of blocks to use the parents version of to
-    set the metadata for scale decoding. The hash for block's with `set_code` can be hardcoded in
-    `config/setCodeBlocks.ts`. Defaults to false. Note: for chains that use the `scheduler` pallet to
-    do runtime upgrades, it is very unlikely this will be an issue as `scheduler` ensures that `set_code`
-    is executed in `on_initialize` and it is highly unlikely there would be any additional room in a
-    block for other extrinsics.
+-   `SAS_SUBSTRATE_PARENT_VERSION`: always use the version of the parent block to set
+    metadata for scale decoding. `on` means always fetch and use the parent blocks metadata, while `off`
+    means _only_ fetch and use the parent blocks metadata for the blocks with hashes specified in
+    `config/setCodeBlocks.ts`. Fetching and using the parent blocks metadata will have a slight time
+    penalty, but will guarantee that extrinsics within a block that executed a runtime upgrade with
+    `set_code` are always decoded correctly. Defaults to `off`. Note: for chains that use the
+    `scheduler` pallet to do runtime upgrades, it is very unlikely this will be an issue as
+    `scheduler` ensures that `set_code` is executed in `on_initialize` and it is highly unlikely
+    there would be any additional room in a block for other extrinsics, but please use this info with
+    discretion.
 
 If you are connecting to [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template), please add the following custom types in `config/types.json`.
 

--- a/config/setCodeBlocks.ts
+++ b/config/setCodeBlocks.ts
@@ -1,0 +1,8 @@
+export const setCodeBlocks = {
+	Polkadot: {
+		'0x4d376613c5ef02fc927a99cdac48b2f16ad2964cde6b52af7e8648eca29c308b': true, // v1 #29231
+		'0x66917aa154172f1a5a2ba8fde1c67cce45cc58f1f43b22f7de795968a536945d': true, // v5 #188836
+	},
+	Kusama: {},
+	Westend: {},
+};

--- a/specs.yml
+++ b/specs.yml
@@ -23,7 +23,7 @@ SAS:
       mandatory: true
       regexp: ^wss?:\/\/.*(:\d{4,5})?$
     PARENT_VERSION:
-      description: Wether or not to always use the version of the parent block to set metadata for
+      description: Always use the version of the parent block to set metadata for
         scale decoding.
       default: 'off'
       mandatory: false

--- a/specs.yml
+++ b/specs.yml
@@ -22,3 +22,9 @@ SAS:
       default: ws://127.0.0.1:9944
       mandatory: true
       regexp: ^wss?:\/\/.*(:\d{4,5})?$
+    PARENT_VERSION:
+      description: Wether or not to always use the version of the parent block to set metadata for
+        scale decoding.
+      default: 'off'
+      mandatory: false
+      regexp: ^on|off$

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -50,7 +50,7 @@ function hr(): string {
 export default class Config {
 	static UPGRADE_BLOCKS: Record<string, true> | undefined;
 	static PARENT_VERSION: ParentVersion;
-	/*
+	/**
 	 * Gather env vars for config and make sure they are valid.
 	 */
 	public static GetConfig(): ISidecarConfig | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ async function main() {
 		api.rpc.state.getRuntimeVersion(),
 	]);
 
-	// Dynamically UPGRADE_BLOCKS using the chainName from the node Sidecar is connected to
+	// Dynamically read in UPGRADE_BLOCKS based on the chainName
 	Config.SetUpgradeBlocks(chainName.toString());
 
 	console.log(

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,9 +41,12 @@ async function main() {
 	});
 
 	const [chainName, { implName }] = await Promise.all([
-		await api.rpc.system.chain(),
-		await api.rpc.state.getRuntimeVersion(),
+		api.rpc.system.chain(),
+		api.rpc.state.getRuntimeVersion(),
 	]);
+
+	// Dynamically UPGRADE_BLOCKS using the chainName from the node Sidecar is connected to
+	Config.SetUpgradeBlocks(chainName.toString());
 
 	console.log(
 		`Connected to chain ${chainName.toString()} on the ${implName.toString()} client at ${

--- a/src/services/AbstractService.ts
+++ b/src/services/AbstractService.ts
@@ -3,6 +3,8 @@ import { u32 } from '@polkadot/types';
 import { getSpecTypes } from '@polkadot/types-known';
 import { BlockHash } from '@polkadot/types/interfaces';
 
+import Config, { ParentVersion } from '../Config';
+
 export abstract class AbstractService {
 	private readonly versionReset = 99999999;
 	private specVersion: u32;
@@ -17,26 +19,43 @@ export abstract class AbstractService {
 		const { api } = this;
 
 		try {
-			const version = await api.rpc.state.getRuntimeVersion(hash);
-			const blockSpecVersion = version.specVersion;
-			const blockTxVersion = version.transactionVersion;
-
-			// Swap metadata if tx version is different. This block of code should never execute, as
-			// specVersion always increases when txVersion increases, but specVersion may increase
-			// without an increase in txVersion. Defensive only.
+			let checkVersion;
 			if (
-				!this.txVersion.eq(blockTxVersion) &&
-				this.specVersion.eq(blockSpecVersion)
+				Config.PARENT_VERSION === ParentVersion.on ||
+				(Config.UPGRADE_BLOCKS && hash.toHex() in Config.UPGRADE_BLOCKS)
 			) {
+				// Get the version info for the previous block if this block has a call to `set_code`.
+				// Blocks with `set_code` have the version of the new runtime code, but the extrinsics within
+				// (normally there are none since set_code takes up the whole block) are executed with the
+				// runtime code of the previous block. Here we fetch the runtime version of the previous block.
+				// The block numbers are hardcoded because otherwise we would face the time penalty on every
+				// call that uses `ensureMeta`
+				const { parentHash } = await this.api.rpc.chain.getHeader(hash);
+				checkVersion = await api.rpc.state.getRuntimeVersion(
+					parentHash
+				);
+			} else {
+				checkVersion = await api.rpc.state.getRuntimeVersion(hash);
+			}
+
+			const { specVersion, transactionVersion } = checkVersion;
+
+			if (
+				!this.txVersion.eq(transactionVersion) &&
+				this.specVersion.eq(specVersion)
+			) {
+				// Swap metadata if tx version is different. This block of code should never execute, as
+				// specVersion always increases when txVersion increases, but specVersion may increase
+				// without an increase in txVersion. Defensive only.
 				console.warn('txVersion bumped without specVersion bumping');
-				this.txVersion = blockTxVersion;
+				this.txVersion = transactionVersion;
 				const meta = await api.rpc.state.getMetadata(hash);
 				api.registry.setMetadata(meta);
 			}
 			// Swap metadata and confirm txVersion if specVersion is different.
-			else if (!this.specVersion.eq(blockSpecVersion)) {
-				this.specVersion = blockSpecVersion;
-				this.txVersion = blockTxVersion;
+			else if (!this.specVersion.eq(specVersion)) {
+				this.specVersion = specVersion;
+				this.txVersion = transactionVersion;
 				const meta = await api.rpc.state.getMetadata(hash);
 				const chain = await api.rpc.system.chain();
 
@@ -44,8 +63,8 @@ export abstract class AbstractService {
 					getSpecTypes(
 						api.registry,
 						chain,
-						version.specName,
-						blockSpecVersion
+						checkVersion.specName,
+						specVersion
 					)
 				);
 				api.registry.setMetadata(meta);

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -38,15 +38,15 @@ export class BlocksService extends AbstractService {
 	 */
 	async fetchBlock(hash: BlockHash): Promise<IBlock> {
 		const api = await this.ensureMeta(hash);
-		const [{ block }, events] = await Promise.all([
+		const [{ block }, events, deriveHeader] = await Promise.all([
 			api.rpc.chain.getBlock(hash),
 			this.fetchEvents(api, hash),
+			api.derive.chain.getHeader(hash),
 		]);
 
 		const { parentHash, number, stateRoot, extrinsicsRoot } = block.header;
 
-		const header = await api.derive.chain.getHeader(hash);
-		const authorId = header?.author;
+		const authorId = deriveHeader?.author;
 
 		const logs = block.header.digest.logs.map((log) => {
 			const { type, index, value } = log;


### PR DESCRIPTION
Fixes #231

## Issue

Runtime upgrades are done by passing a massive Wasm blob of the runtime code to the dispatchable `set_code`. The block that processes `set_code` will have the runtime version information of the passed in Wasm blob, meaning the version of the block will be different than the version of its parent. Despite this new versioning, any extrinsics within the block are executed using the old runtime version.

In most circumstances no other extrinsics will make there way into a block with `set_code` for a combination of reasons:

1) The `set_code` call with the Wasm blob is (under normal circumstances) always well over the weight limit of the block, meaning after it is executed there will not be any more room for other extrinsics in the block.

2) There is an edge case where some other extrinsic(s) are put into the block prior to `set_code` being called. With chains that use the `scheduler` pallet for runtime upgrades this should not be an issue as the call to `set_code` is done in `on_initialize`, thus it should be executed before other extrinsics and leave no extra room. (N.B. this is not totally guaranteed, so use this info at your discretion) 

* Worth noting here that `scheduler` pallet is used by Polkadot, newer versions of Kusama, and others.

## Presented solution

At the beginning of almost every public service function `ensureMeta` is called to ensure that the polkadot-js registry has the proper metadata to decode the scale codec. In order to fix this issue, `ensureMeta` needs to know the version of the parent block. To get this information reliably `ensureMeta` needs 2 additional, synchronously executed, RPC calls. On my machine they added ~200ms, which is ~200ms for almost ever single Sidecar route.

Due to this performance degradation, this solution proposes an approach that allows a user to either
1) Opt-in to fetching the parent blocks version info for every block (see `SAS_SUBSTRATE_PARENT_VERSION=on`)
2) Fetch the parent blocks version info for blocks with hashes the are listed in a dedicated config file (see `config/setCodeBlocks.ts`). Maintainers and developers of various substrate chains may make PRs to add block hashes to the config in the standard code shipment. The user can add block hashes themselves as well to their own `config/setCodeBlocks.ts`.

It will be up to users to determine what option fits there use case, system setup, and priorities best. e.g. users may want to test how much time penalty there is for `SAS_SUBSTRATE_PARENT_VERSION=on` on there systems and make a judgement with that in mind.

## Downsides

The major downfall of this current implementation, is that for the aforementioned option 2 one needs a block hash, which can only be known once the block is made (and gossiped). This means that users will have to manually add the block hash to the config after seeing it and then restart Sidecar in order to read some queries made at a runtime upgrade block.

I can think of a few potential solutions to get around this, but they would entail significant RPC traffic to determine if `set_code` happened at a given block height, and therefore are not desirable.

## TODO:
- [ ] Add block hashes to `config/setCodeBlocks.ts`
- [ ] List versions of Kusama/Westend that are known not to use the scheduler pallet so we users can have a warning 