### PR TITLE
Optimize `fetchBlock` call to getHeader by parallelize-ing

### DIFF
--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -38,15 +38,15 @@ export class BlocksService extends AbstractService {
 	 */
 	async fetchBlock(hash: BlockHash): Promise<IBlock> {
 		const api = await this.ensureMeta(hash);
-		const [{ block }, events] = await Promise.all([
+		const [{ block }, events, headerDerive] = await Promise.all([
 			api.rpc.chain.getBlock(hash),
 			this.fetchEvents(api, hash),
+			api.derive.chain.getHeader(hash),
 		]);
 
 		const { parentHash, number, stateRoot, extrinsicsRoot } = block.header;
 
-		const header = await api.derive.chain.getHeader(hash);
-		const authorId = header?.author;
+		const authorId = headerDerive?.author;
 
 		const logs = block.header.digest.logs.map((log) => {
 			const { type, index, value } = log;


### PR DESCRIPTION
Small optimization that improves response times to `/block/NUMBER` by ~100 - 200ms