### PR TITLE
Remove useless `await`s in `Promise.all`s

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,8 +41,8 @@ async function main() {
 	});
 
 	const [chainName, { implName }] = await Promise.all([
-		await api.rpc.system.chain(),
-		await api.rpc.state.getRuntimeVersion(),
+		api.rpc.system.chain(),
+		api.rpc.state.getRuntimeVersion(),
 	]);
 
 	console.log(

--- a/src/services/accounts/AccountsStakingInfoService.ts
+++ b/src/services/accounts/AccountsStakingInfoService.ts
@@ -41,9 +41,9 @@ export class AccountsStakingInfoService extends AbstractService {
 			rewardDestination,
 			slashingSpansOption,
 		] = await Promise.all([
-			await api.query.staking.ledger.at(hash, controller),
-			await api.query.staking.payee.at(hash, stash),
-			await api.query.staking.slashingSpans.at(hash, stash),
+			api.query.staking.ledger.at(hash, controller),
+			api.query.staking.payee.at(hash, stash),
+			api.query.staking.slashingSpans.at(hash, stash),
 		]);
 
 		const stakingLedger = stakingLedgerOption.unwrapOr(null);

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -24,11 +24,11 @@ export class PalletsStakingProgressService extends AbstractService {
 			validators,
 			{ number },
 		] = await Promise.all([
-			await api.query.staking.validatorCount.at(hash),
-			await api.query.staking.forceEra.at(hash),
-			await api.query.staking.eraElectionStatus.at(hash),
-			await api.query.session.validators.at(hash),
-			await api.rpc.chain.getHeader(hash),
+			api.query.staking.validatorCount.at(hash),
+			api.query.staking.forceEra.at(hash),
+			api.query.staking.eraElectionStatus.at(hash),
+			api.query.session.validators.at(hash),
+			api.rpc.chain.getHeader(hash),
 		]);
 
 		const {
@@ -131,11 +131,11 @@ export class PalletsStakingProgressService extends AbstractService {
 			currentIndex,
 			activeEraOption,
 		] = await Promise.all([
-			await api.query.babe.currentSlot.at(hash),
-			await api.query.babe.epochIndex.at(hash),
-			await api.query.babe.genesisSlot.at(hash),
-			await api.query.session.currentIndex.at(hash),
-			await api.query.staking.activeEra.at(hash),
+			api.query.babe.currentSlot.at(hash),
+			api.query.babe.epochIndex.at(hash),
+			api.query.babe.genesisSlot.at(hash),
+			api.query.session.currentIndex.at(hash),
+			api.query.staking.activeEra.at(hash),
 		]);
 
 		if (activeEraOption.isNone) {


### PR DESCRIPTION
There are some unnecessary `await`s. This PR removes them. 