### PR TITLE
 Add `at` field to `runtime/spec`

### DIFF
--- a/src/services/runtime/RuntimeSpecService.ts
+++ b/src/services/runtime/RuntimeSpecService.ts
@@ -14,13 +14,19 @@ export class RuntimeSpecService extends AbstractService {
 			},
 			chainType,
 			properties,
+			{ number },
 		] = await Promise.all([
 			this.api.rpc.state.getRuntimeVersion(hash),
 			this.api.rpc.system.chainType(),
 			this.api.rpc.system.properties(),
+			this.api.rpc.chain.getHeader(hash),
 		]);
 
 		return {
+			at: {
+				height: number.unwrap().toString(10),
+				hash,
+			},
 			authoringVersion,
 			transactionVersion,
 			implVersion,

--- a/src/services/test-helpers/responses/runtime/spec.json
+++ b/src/services/test-helpers/responses/runtime/spec.json
@@ -1,4 +1,8 @@
 {
+  "at": {
+    "hash": "0x7b713de604a99857f6c25eacc115a4f28d2611a23d9ddff99ab0e4f1c17a8578",
+    "height": "789629"
+  },
   "authoringVersion": "0",
   "transactionVersion": "2",
   "implVersion": "0",

--- a/src/types/responses/RuntimeSpec.ts
+++ b/src/types/responses/RuntimeSpec.ts
@@ -1,7 +1,10 @@
 import { ChainProperties, ChainType } from '@polkadot/types/interfaces';
 import { Text, u32 } from '@polkadot/types/primitive';
 
+import { IAt } from '.';
+
 export interface IRuntimeSpec {
+	at: IAt;
 	authoringVersion: u32;
 	transactionVersion: u32;
 	implVersion: u32;


### PR DESCRIPTION
Closes #243 

The `runtime/spec` lets the user query for runtime version info at a specific block. As such, it should return information about the block the query was made at. Additionally, the `openapi-proposal.yaml` actually specifies the response have the `at` field.