### PR TITLE
Deprecate `ensureMeta`; Update `method` in beta `/blocks`; Bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-rpc-proxy",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@polkadot/api": "^1.30.1",
+    "@polkadot/api": "^1.31.beta",
     "@polkadot/util-crypto": "^3.3.1",
     "@substrate/calc": "file:./calc/pkg",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@polkadot/api": "^1.31.beta.15",
+    "@polkadot/api": "^1.31.beta.16",
     "@polkadot/util-crypto": "^3.3.1",
     "@substrate/calc": "file:./calc/pkg",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@polkadot/api": "^1.31.beta",
+    "@polkadot/api": "^1.31.beta.15",
     "@polkadot/util-crypto": "^3.3.1",
     "@substrate/calc": "file:./calc/pkg",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@polkadot/api": "^1.31.beta.16",
+    "@polkadot/api": "^1.31.beta.17",
     "@polkadot/util-crypto": "^3.3.1",
     "@substrate/calc": "file:./calc/pkg",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@polkadot/api": "^1.31.beta",
+    "@polkadot/api": "^1.31.1",
     "@polkadot/util-crypto": "^3.4.1",
     "@substrate/calc": "file:./calc/pkg",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@polkadot/api": "^1.31.beta.24",
-    "@polkadot/util-crypto": "^3.3.1",
+    "@polkadot/api": "^1.31.beta",
+    "@polkadot/util-crypto": "^3.4.1",
     "@substrate/calc": "file:./calc/pkg",
     "body-parser": "^1.19.0",
     "confmgr": "^1.0.6",

--- a/src/controllers/node/NodeTransactionPoolController.ts
+++ b/src/controllers/node/NodeTransactionPoolController.ts
@@ -38,11 +38,9 @@ export default class NodeTransactionPoolController extends AbstractController<
 		_req,
 		res
 	): Promise<void> => {
-		const hash = await this.api.rpc.chain.getFinalizedHead();
-
 		NodeTransactionPoolController.sanitizedSend(
 			res,
-			await this.service.fetchTransactionPool(hash)
+			await this.service.fetchTransactionPool()
 		);
 	};
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,14 @@ async function main() {
 	// Instantiate a web socket connection to the node for basic polkadot-js use
 	const api = await ApiPromise.create({
 		provider: new WsProvider(config.WS_URL),
-		types: config.CUSTOM_TYPES,
+		types: {
+			Announcement: {
+				real: 'AccountId',
+				call_hash: 'Hash',
+				height: 'BlockNumber',
+			},
+			...config.CUSTOM_TYPES,
+		},
 	});
 
 	const [chainName, { implName }] = await Promise.all([

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ async function main() {
 		types: {
 			Announcement: {
 				real: 'AccountId',
-				call_hash: 'Hash',
+				callHash: 'Hash',
 				height: 'BlockNumber',
 			},
 			...config.CUSTOM_TYPES,

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -34,7 +34,8 @@ export class AccountsStakingPayoutsService extends AbstractService {
 		unclaimedOnly: boolean,
 		currentEra: number
 	): Promise<IAccountStakingPayouts> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const [{ number }, historyDepth] = await Promise.all([
 			api.rpc.chain.getHeader(hash),

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -106,7 +106,10 @@ describe('BlocksService', () => {
 		});
 
 		const transferOutput = {
-			method: 'balances.transfer',
+			method: {
+				pallet: 'balances',
+				methodName: 'transfer',
+			},
 			args: {
 				dest: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
 				value: 12,
@@ -144,7 +147,10 @@ describe('BlocksService', () => {
 			});
 
 			const baseBatch = {
-				method: 'utility.batch',
+				method: {
+					pallet: 'utility',
+					methodName: 'batch',
+				},
 				args: {
 					calls: [],
 				},
@@ -203,10 +209,16 @@ describe('BlocksService', () => {
 			});
 
 			const sudoOutput = {
-				method: 'sudo.sudo',
+				method: {
+					pallet: 'sudo',
+					methodName: 'sudo',
+				},
 				args: {
 					call: {
-						method: 'proxy.proxy',
+						method: {
+							pallet: 'proxy',
+							methodName: 'proxy',
+						},
 						args: {
 							real:
 								'5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM',
@@ -221,7 +233,10 @@ describe('BlocksService', () => {
 				JSON.stringify(blocksService['parseGenericCall'](batch))
 			).toEqual(
 				JSON.stringify({
-					method: 'utility.batch',
+					method: {
+						pallet: 'utility',
+						methodName: 'batch',
+					},
 					args: {
 						calls: [sudoOutput, sudoOutput, sudoOutput],
 					},

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -39,7 +39,8 @@ export class BlocksService extends AbstractService {
 	 * @param hash `BlockHash` of the block to fetch.
 	 */
 	async fetchBlock(hash: BlockHash): Promise<IBlock> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 		const [{ block }, events, validators] = await Promise.all([
 			api.rpc.chain.getBlock(hash),
 			this.fetchEvents(api, hash),

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -236,7 +236,10 @@ export class BlocksService extends AbstractService {
 			for (const record of events) {
 				const { event, phase } = record;
 				const sanitizedEvent = {
-					method: `${event.section}.${event.method}`,
+					method: {
+						pallet: event.section,
+						methodName: event.method,
+					},
 					data: event.data,
 				};
 
@@ -416,7 +419,10 @@ export class BlocksService extends AbstractService {
 		}
 
 		return {
-			method: `${sectionName}.${methodName}`,
+			method: {
+				pallet: sectionName,
+				methodName: methodName,
+			},
 			args: newArgs,
 		};
 	}

--- a/src/services/node/NodeTransactionPoolService.spec.ts
+++ b/src/services/node/NodeTransactionPoolService.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import {
-	blockHash789629,
+	// blockHash789629,
 	mockApi,
 	pendingExtrinsics,
 } from '../test-helpers/mock';
@@ -16,9 +16,10 @@ describe('NodeTransactionPoolService', () => {
 		it('works when ApiPromiseWorks (no txs)', async () => {
 			expect(
 				sanitizeNumbers(
-					await nodeTranstionPoolService.fetchTransactionPool(
-						blockHash789629
-					)
+					await nodeTranstionPoolService
+						.fetchTransactionPool
+						// blockHash789629
+						()
 				)
 			).toStrictEqual({ pool: [] });
 		});
@@ -35,9 +36,10 @@ describe('NodeTransactionPoolService', () => {
 
 			expect(
 				sanitizeNumbers(
-					await nodeTranstionPoolService.fetchTransactionPool(
-						blockHash789629
-					)
+					await nodeTranstionPoolService
+						.fetchTransactionPool
+						// blockHash789629
+						()
 				)
 			).toStrictEqual(transactionPoolResponse);
 

--- a/src/services/node/NodeTransactionPoolService.ts
+++ b/src/services/node/NodeTransactionPoolService.ts
@@ -1,11 +1,11 @@
-import { BlockHash } from '@polkadot/types/interfaces';
 import { INodeTransactionPool } from 'src/types/responses';
 
 import { AbstractService } from '../AbstractService';
 
 export class NodeTransactionPoolService extends AbstractService {
-	async fetchTransactionPool(hash: BlockHash): Promise<INodeTransactionPool> {
-		const api = await this.ensureMeta(hash);
+	async fetchTransactionPool(): Promise<INodeTransactionPool> {
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const extrinsics = await api.rpc.author.pendingExtrinsics();
 

--- a/src/services/runtime/RuntimeCodeService.ts
+++ b/src/services/runtime/RuntimeCodeService.ts
@@ -14,7 +14,8 @@ export class RuntimeCodeService extends AbstractService {
 	 * @param hash `BlockHash` to make call at
 	 */
 	async fetchCode(hash: BlockHash): Promise<IMetadataCode> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const [code, { number }] = await Promise.all([
 			api.rpc.state.getStorage(CODE_KEY, hash),

--- a/src/services/runtime/RuntimeMetadataService.ts
+++ b/src/services/runtime/RuntimeMetadataService.ts
@@ -10,7 +10,8 @@ export class RuntimeMetadataService extends AbstractService {
 	 * @param hash `BlockHash` to make call at
 	 */
 	async fetchMetadata(hash: BlockHash): Promise<Metadata> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const metadata = await api.rpc.state.getMetadata(hash);
 

--- a/src/services/test-helpers/responses/blocks/blocks789629.json
+++ b/src/services/test-helpers/responses/blocks/blocks789629.json
@@ -42,7 +42,10 @@
       "info": {},
       "events": [
         {
-          "method": "system.ExtrinsicSuccess",
+          "method": {
+            "pallet": "system",
+            "methodName": "ExtrinsicSuccess"
+          },
           "data": [
             {
               "weight": "158000000",
@@ -70,7 +73,10 @@
       "info": {},
       "events": [
         {
-          "method": "system.ExtrinsicSuccess",
+          "method": {
+            "pallet": "system",
+            "methodName": "ExtrinsicSuccess"
+          },
           "data": [
             {
               "weight": "0",
@@ -98,7 +104,10 @@
       "info": {},
       "events": [
         {
-          "method": "system.ExtrinsicSuccess",
+          "method": {
+            "pallet": "system",
+            "methodName": "ExtrinsicSuccess"
+          },
           "data": [
             {
               "weight": "1000000000",
@@ -124,210 +133,300 @@
       "args": {
         "calls": [
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
               "era": "44"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
               "era": "44"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
               "era": "44"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
               "era": "44"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
               "era": "44"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
               "era": "44"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
               "era": "45"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
               "era": "45"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
               "era": "45"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
               "era": "45"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
               "era": "45"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
               "era": "45"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
               "era": "46"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
               "era": "46"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
               "era": "46"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
               "era": "46"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
               "era": "46"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
               "era": "46"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
               "era": "47"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
               "era": "47"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
               "era": "47"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
               "era": "47"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
               "era": "47"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
               "era": "47"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
               "era": "48"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
               "era": "48"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
               "era": "48"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
               "era": "48"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
               "era": "48"
             }
           },
           {
-            "method": "staking.payoutStakers",
+            "method": {
+              "pallet": "staking",
+              "methodName": "payoutStakers"
+            },
             "args": {
               "validator_stash": "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
               "era": "48"
@@ -338,485 +437,690 @@
       "tip": "0",
       "hash": "0xc96b4d442014fae60c932ea50cba30bf7dea3233f59d1fe98c6f6f85bfd51045",
       "info": {
-        "weight": "941325000000",
-        "class": "Normal",
-        "partialFee": "1257000075"
+        "error": "Unable to find success or failure event for extrinsic"
       },
       "events": [
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
             "10885828687302"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
             "11663389343063"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
             "11145015572556"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
             "10497049290937"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
             "8034778538608"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
             "8812337331337"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
             "11207586529668"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
             "12119832075527"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
             "9904379142071"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
             "8601169881765"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
             "9513415427624"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
             "7297962494168"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
             "11504029448815"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
             "9785036149946"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
             "9256114404846"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
             "11239567627182"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
             "11371797588916"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
             "8594964596178"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
             "10729489455200"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
             "9007472464752"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
             "9669786253100"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
             "9404861878505"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
             "8610083051000"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
             "9139935602670"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "1462Rm6ZhAeK3HVhNU4n7t2jACnm2GDgUS4BYmWMGB7Y95VY",
             "10746277048255"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16KuUsyfxgQovzp8QXgtJH1K5Tmok6M8hgSoHaGbyyTQtQg",
             "9286904915234"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "16X3K5R15mvc4SmCUKBw9WfW718fRqXdDAKim1S7TxEXCDzQ",
             "10082926425041"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "156G1ZiWHeSvLYwgbfNCknU8NfTkGZvEVvcrFs2Dn5Zm6Lus",
             "8888896065208"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "13fWfiEQ59hDRySKteLwNcadALnTCWr9YUUzUq3k9YXnMWVJ",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14gRuVzZSsFLWHCsere3DXbTwon4BK381LFbjWdG3HGvELKv",
             "10215595406758"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "143eus3Ki72VUJ9AWYsFEGvkUAjeFw8yMfTaSiuAEq3n8yZc",
             "10613606161661"
           ]
         },
         {
-          "method": "staking.Reward",
+          "method": {
+            "pallet": "staking",
+            "methodName": "Reward"
+          },
           "data": [
             "14rSLrbz47o83C9KywrHGt7cz1rXC1Bp3rLgUH6W27TNoU7U",
             "0"
           ]
         },
         {
-          "method": "utility.BatchCompleted",
+          "method": {
+            "pallet": "utility",
+            "methodName": "BatchCompleted"
+          },
           "data": []
         },
         {
-          "method": "treasury.Deposit",
+          "method": {
+            "pallet": "treasury",
+            "methodName": "Deposit"
+          },
           "data": [
             "1005600060"
           ]
         },
         {
-          "method": "balances.Deposit",
+          "method": {
+            "pallet": "balances",
+            "methodName": "Deposit"
+          },
           "data": [
             "1zugcajGg5yDD9TEqKKzGx7iKuGWZMkRbYcyaFnaUaEkwMK",
             "251400015"
           ]
         },
         {
-          "method": "system.ExtrinsicSuccess",
+          "method": {
+            "pallet": "system",
+            "methodName": "ExtrinsicSuccess"
+          },
           "data": [
             {
               "weight": "941325000000",
@@ -843,7 +1147,10 @@
         "real": "14jtNyurHjGCPkvMGnFA4npijraG3qGGtVYSA4vBcZkbU6kP",
         "force_proxy_type": null,
         "call": {
-          "method": "electionsPhragmen.vote",
+          "method": {
+            "pallet": "electionsPhragmen",
+            "methodName": "vote"
+          },
           "args": {
             "votes": [
               "1363HWTPzDrzAQ6ChFiMU6mP4b6jmQid2ae55JQcKtZnpLGv",
@@ -866,13 +1173,14 @@
       "tip": "0",
       "hash": "0x6d6c0e955650e689b14fb472daf14d2bdced258c748ded1d6cb0da3bfcc5854f",
       "info": {
-        "weight": "399480000",
-        "class": "Normal",
-        "partialFee": "544000000"
+        "error": "Unable to find success or failure event for extrinsic"
       },
       "events": [
         {
-          "method": "proxy.ProxyExecuted",
+          "method": {
+            "pallet": "proxy",
+            "methodName": "ProxyExecuted"
+          },
           "data": [
             {
               "Ok": []
@@ -880,20 +1188,29 @@
           ]
         },
         {
-          "method": "treasury.Deposit",
+          "method": {
+            "pallet": "treasury",
+            "methodName": "Deposit"
+          },
           "data": [
             "435200000"
           ]
         },
         {
-          "method": "balances.Deposit",
+          "method": {
+            "pallet": "balances",
+            "methodName": "Deposit"
+          },
           "data": [
             "1zugcajGg5yDD9TEqKKzGx7iKuGWZMkRbYcyaFnaUaEkwMK",
             "108800000"
           ]
         },
         {
-          "method": "system.ExtrinsicSuccess",
+          "method": {
+            "pallet": "system",
+            "methodName": "ExtrinsicSuccess"
+          },
           "data": [
             {
               "weight": "399480000",

--- a/src/services/transaction/TransactionDryRunService.ts
+++ b/src/services/transaction/TransactionDryRunService.ts
@@ -13,7 +13,8 @@ export class TransactionDryRunService extends AbstractService {
 		hash: BlockHash,
 		extrinsic: string
 	): Promise<ITransactionDryRun> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		try {
 			const [applyExtrinsicResult, { number }] = await Promise.all([

--- a/src/services/v0/v0accounts/AccountsBalanceInfoService.ts
+++ b/src/services/v0/v0accounts/AccountsBalanceInfoService.ts
@@ -14,7 +14,8 @@ export class AccountsBalanceInfoService extends AbstractService {
 		hash: BlockHash,
 		address: string
 	): Promise<IAccountBalanceInfo> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const [header, locks, sysAccount] = await Promise.all([
 			api.rpc.chain.getHeader(hash),

--- a/src/services/v0/v0accounts/AccountsStakingInfoService.ts
+++ b/src/services/v0/v0accounts/AccountsStakingInfoService.ts
@@ -14,7 +14,8 @@ export class AccountsStakingInfoService extends AbstractService {
 		hash: BlockHash,
 		stash: string
 	): Promise<IAccountStakingInfo> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const [header, controllerOption] = await Promise.all([
 			api.rpc.chain.getHeader(hash),

--- a/src/services/v0/v0accounts/AccountsVestingInfoService.ts
+++ b/src/services/v0/v0accounts/AccountsVestingInfoService.ts
@@ -15,7 +15,8 @@ export class AccountsVestingInfoService extends AbstractService {
 		hash: BlockHash,
 		address: string
 	): Promise<IAccountVestingInfo> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const [header, vesting] = await Promise.all([
 			api.rpc.chain.getHeader(hash),

--- a/src/services/v0/v0blocks/BlocksService.ts
+++ b/src/services/v0/v0blocks/BlocksService.ts
@@ -37,7 +37,8 @@ export class BlocksService extends AbstractService {
 	 * @param hash `BlockHash` of the block to fetch.
 	 */
 	async fetchBlock(hash: BlockHash): Promise<IBlock> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const api = this.api;
 		const [{ block }, events, headerDerive] = await Promise.all([
 			api.rpc.chain.getBlock(hash),
 			this.fetchEvents(api, hash),

--- a/src/services/v0/v0blocks/BlocksService.ts
+++ b/src/services/v0/v0blocks/BlocksService.ts
@@ -37,8 +37,8 @@ export class BlocksService extends AbstractService {
 	 * @param hash `BlockHash` of the block to fetch.
 	 */
 	async fetchBlock(hash: BlockHash): Promise<IBlock> {
-		// const api = await this.ensureMeta(hash);
-		const api = this.api;
+		const api = await this.ensureMeta(hash);
+
 		const [{ block }, events, headerDerive] = await Promise.all([
 			api.rpc.chain.getBlock(hash),
 			this.fetchEvents(api, hash),

--- a/src/services/v0/v0claims/ClaimsService.ts
+++ b/src/services/v0/v0claims/ClaimsService.ts
@@ -13,7 +13,8 @@ export class ClaimsService extends AbstractService {
 		hash: BlockHash,
 		ethAddress: string
 	): Promise<null | { type: string }> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 		const agreementType = await api.query.claims.signing.at(
 			hash,
 			ethAddress

--- a/src/services/v0/v0metadata/RuntimeMetadataService.ts
+++ b/src/services/v0/v0metadata/RuntimeMetadataService.ts
@@ -10,7 +10,8 @@ export class RuntimeMetadataService extends AbstractService {
 	 * @param hash `BlockHash` to make call at
 	 */
 	async fetchMetadata(hash: BlockHash): Promise<Metadata> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const metadata = await api.rpc.state.getMetadata(hash);
 

--- a/src/services/v0/v0pallets/PalletsStakingProgressService.ts
+++ b/src/services/v0/v0pallets/PalletsStakingProgressService.ts
@@ -15,7 +15,8 @@ export class PalletsStakingProgressService extends AbstractService {
 	async derivePalletStakingProgress(
 		hash: BlockHash
 	): Promise<IPalletStakingProgress> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		const [
 			validatorCount,

--- a/src/services/v0/v0transaction/TransactionFeeEstimateService.ts
+++ b/src/services/v0/v0transaction/TransactionFeeEstimateService.ts
@@ -15,7 +15,8 @@ export class TransactionFeeEstimateService extends AbstractService {
 		hash: BlockHash,
 		extrinsic: string
 	): Promise<RuntimeDispatchInfo> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		try {
 			return await api.rpc.payment.queryInfo(extrinsic, hash);

--- a/src/services/v0/v0transaction/TransactionMaterialService.ts
+++ b/src/services/v0/v0transaction/TransactionMaterialService.ts
@@ -14,7 +14,8 @@ export class TransactionMaterialService extends AbstractService {
 		hash: BlockHash,
 		noMeta: boolean
 	): Promise<ITransactionMaterial> {
-		const api = await this.ensureMeta(hash);
+		// const api = await this.ensureMeta(hash);
+		const { api } = this;
 
 		if (noMeta) {
 			const [header, genesisHash, name, version] = await Promise.all([

--- a/src/services/v0/v0transaction/TransactionSubmitService.ts
+++ b/src/services/v0/v0transaction/TransactionSubmitService.ts
@@ -10,9 +10,11 @@ export class TransactionSubmitService extends AbstractService {
 	 * @param extrinsic scale encoded extrinsic to submit
 	 */
 	async submitTransaction(extrinsic: string): Promise<{ hash: Hash }> {
-		const api = await this.ensureMeta(
-			await this.api.rpc.chain.getFinalizedHead() // TODO move this out to controller for consistency with other services
-		);
+		// const api = await this.ensureMeta(
+		// 	await this.api.rpc.chain.getFinalizedHead() // TODO move this out to controller for consistency with other services
+		// );
+
+		const { api } = this;
 
 		let tx;
 

--- a/src/types/responses/Dispatchable.ts
+++ b/src/types/responses/Dispatchable.ts
@@ -1,0 +1,4 @@
+export interface IDispatchable {
+	pallet: string;
+	methodName: string;
+}

--- a/src/types/responses/Extrinsic.ts
+++ b/src/types/responses/Extrinsic.ts
@@ -9,15 +9,10 @@ import {
 	Sr25519Signature,
 } from '@polkadot/types/interfaces';
 
-import { ISanitizedArgs, ISanitizedEvent } from '.';
+import { IDispatchable, ISanitizedArgs, ISanitizedEvent } from '.';
 
 export interface IExtrinsic {
-	method:
-		| string
-		| {
-				pallet: string;
-				methodName: string;
-		  };
+	method: string | IDispatchable;
 	signature: ISignature | null;
 	nonce: Compact<Index>;
 	args: ISanitizedArgs;

--- a/src/types/responses/SanitizedCall.ts
+++ b/src/types/responses/SanitizedCall.ts
@@ -1,8 +1,8 @@
-import { ISanitizedArgs } from '.';
+import { IDispatchable, ISanitizedArgs } from '.';
 
 export interface ISanitizedCall {
 	[key: string]: unknown;
-	method: string;
+	method: string | IDispatchable;
 	callIndex?: Uint8Array | string;
 	args: ISanitizedArgs;
 }

--- a/src/types/responses/SanitizedEvent.ts
+++ b/src/types/responses/SanitizedEvent.ts
@@ -1,6 +1,8 @@
 import { EventData } from '@polkadot/types/generic/Event';
 
+import { IDispatchable } from '.';
+
 export interface ISanitizedEvent {
-	method: string;
+	method: string | IDispatchable;
 	data: EventData;
 }

--- a/src/types/responses/index.ts
+++ b/src/types/responses/index.ts
@@ -18,3 +18,4 @@ export * from './NodeNetwork';
 export * from './NodeVersion';
 export * from './NodeTransactionPool';
 export * from './TransactionDryRun';
+export * from './Dispatchable';

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,35 +482,35 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.31.0-beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.24.tgz#290888e2501493e35de0c595c8d6c1336f562117"
-  integrity sha512-As3HdRVWkADfsRGp0Z17kNiHY2wVLgKH7zJjkD05AHG1v7Bv/TmzRMcFIBB3SIUYy3eGExlmitqu/iTgLZHtZg==
+"@polkadot/api-derive@1.31.0-beta.25":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.25.tgz#6f08f93e883492d08bd6743098437421168f062f"
+  integrity sha512-XQBAPB2H/aj7UY+jK9o74vefFdQEQ3yItZ3r+QeDfLxHfISt+Rh1O+U0HR/7HJ980qGfOz5qM+LieqcWMMFO8w==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api" "1.31.0-beta.24"
-    "@polkadot/rpc-core" "1.31.0-beta.24"
-    "@polkadot/rpc-provider" "1.31.0-beta.24"
-    "@polkadot/types" "1.31.0-beta.24"
+    "@polkadot/api" "1.31.0-beta.25"
+    "@polkadot/rpc-core" "1.31.0-beta.25"
+    "@polkadot/rpc-provider" "1.31.0-beta.25"
+    "@polkadot/types" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/api@1.31.0-beta.24", "@polkadot/api@^1.31.beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.24.tgz#f2ac3649a6dece4b8a58574ffb47b9abfd5cdd06"
-  integrity sha512-PE1m8SuFOm9K9i0/CtxKXnIxKlK2zligyqa16AGWoRc+tVnh37c0t93IlCSw1saoP1cvXbohFgLf+zWVL+2fEw==
+"@polkadot/api@1.31.0-beta.25", "@polkadot/api@^1.31.beta":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.25.tgz#93a29ff3b4ba5e03d1235ad7b0e6fceb851ae105"
+  integrity sha512-E7ZWCyLRWkZTQFMSVLy/NPH21M2B+q9oZxZCHv+Lh2O7sXddRnd7uxOiotud9NlEIC5ab8hcQixfFiFejm7ijQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api-derive" "1.31.0-beta.24"
+    "@polkadot/api-derive" "1.31.0-beta.25"
     "@polkadot/keyring" "^3.4.1"
-    "@polkadot/metadata" "1.31.0-beta.24"
-    "@polkadot/rpc-core" "1.31.0-beta.24"
-    "@polkadot/rpc-provider" "1.31.0-beta.24"
-    "@polkadot/types" "1.31.0-beta.24"
-    "@polkadot/types-known" "1.31.0-beta.24"
+    "@polkadot/metadata" "1.31.0-beta.25"
+    "@polkadot/rpc-core" "1.31.0-beta.25"
+    "@polkadot/rpc-provider" "1.31.0-beta.25"
+    "@polkadot/types" "1.31.0-beta.25"
+    "@polkadot/types-known" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
@@ -526,39 +526,39 @@
     "@polkadot/util" "3.4.1"
     "@polkadot/util-crypto" "3.4.1"
 
-"@polkadot/metadata@1.31.0-beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.24.tgz#110c5fa461c2b1c7b691d29255ae40acf4c8d2e2"
-  integrity sha512-MoBduxGAYz6Z9mT4B5ZJ8E/I80tNt54tUqKVpPQSoN56AV6KPaHqRqPggGC1+G/cxx6SaV+25HtjAlZWuebAzQ==
+"@polkadot/metadata@1.31.0-beta.25":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.25.tgz#49eb750b4ec31e53047b05417842a73c6bc1431f"
+  integrity sha512-B8Ov+GgtBVjFyPuTVGxbDFPPamgYELJTfdiHG5uwOZ1nmcwxSOhwKKxgtsGb4CMOgRMbSf2qaWJlZgjBJjQR0Q==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.24"
-    "@polkadot/types-known" "1.31.0-beta.24"
+    "@polkadot/types" "1.31.0-beta.25"
+    "@polkadot/types-known" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
 
-"@polkadot/rpc-core@1.31.0-beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.24.tgz#210c5416c852845b75bca6b5a816c5c3bad48f30"
-  integrity sha512-0KDcJdei1djeZPSv+q7l2AO7Y0nTGI4ZRkRmDoGeNYHMznPE8XMjB087rJXhtJBhgeuzeEAvHX4oy+sfWWJkVA==
+"@polkadot/rpc-core@1.31.0-beta.25":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.25.tgz#4c3accd1c45dc653c844c2523650cb0cdc7c0785"
+  integrity sha512-bkNgpit0hwxJIutEulj0J3rKySPzOnduV6VfbwZYOgwD65JjPxkcM8Af54bCD99xXaHBs28J7y3D4rodg3JoOw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.24"
-    "@polkadot/rpc-provider" "1.31.0-beta.24"
-    "@polkadot/types" "1.31.0-beta.24"
+    "@polkadot/metadata" "1.31.0-beta.25"
+    "@polkadot/rpc-provider" "1.31.0-beta.25"
+    "@polkadot/types" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/rpc-provider@1.31.0-beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.24.tgz#e0d6327d8fcca45c4233701a50fe3a17d00e97eb"
-  integrity sha512-kV548rBcAJhVXLcQNRu4jXHkewYDS1mp+ZJR28ugJupxpszZMNv8zakEWu/fbiiXTYaSJ46CgQVZWfSafzZwXA==
+"@polkadot/rpc-provider@1.31.0-beta.25":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.25.tgz#3553d6d2dbb8648f3d963eda867dabb6c34f6113"
+  integrity sha512-QbfOcdZOw/g8Y00a0AB38CIhS3Eqj6mu7Ty7I3EWG3Q3fmsSJhzg8NQNA8bcdgBZBppONIYrT9j7ZfjLZMOs/w==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.24"
-    "@polkadot/types" "1.31.0-beta.24"
+    "@polkadot/metadata" "1.31.0-beta.25"
+    "@polkadot/types" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
@@ -566,23 +566,23 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.31.0-beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.24.tgz#678438f410a350fcb1a0801fcdd19d9fc527c9dc"
-  integrity sha512-ZtvUZI93W7WjLtrZ3rtkj0EtJB1fJLngNKFmAErlIQWT5UAfB5YGOyAWVJrJRg8a+V2NqtxscbVzp76CJjMQog==
+"@polkadot/types-known@1.31.0-beta.25":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.25.tgz#e52d9b002bb5192ad554a520558375e2c460adce"
+  integrity sha512-qow6gdMbBGsrF8V5M4YWdrEFGizTXsBRMEF9FVrAJzHAC1/KlKI+eKhll7yd8UBCPL3z0hnfSSwchaOn1oKU+Q==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.24"
+    "@polkadot/types" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     bn.js "^5.1.3"
 
-"@polkadot/types@1.31.0-beta.24":
-  version "1.31.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.24.tgz#a2e48494913ef79495a83e6f0bba91f0c6c7de71"
-  integrity sha512-AXwF9+MiVxBVhgJFWRqOYsKHVCKWyWCxB8PQVhWauexVGWZO9Czbj3kUOPsfg7iiPqh3bZhVMdJlGpVlb0TVmQ==
+"@polkadot/types@1.31.0-beta.25":
+  version "1.31.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.25.tgz#7e6a32fc6c8de09f09a06ebee8f74f3b8b106149"
+  integrity sha512-xJ8xpuYAg97SqULPiSNVhhmnAuBW4jU1BZCQAv5fr25ftwMK7t4nJ8PiAiheaj3QuoGYllrPsj3/VfqjKuo06A==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.24"
+    "@polkadot/metadata" "1.31.0-beta.25"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     "@types/bn.js" "^4.11.6"
@@ -609,37 +609,6 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util-crypto@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-3.3.1.tgz#5d2d4a373fa864a86d1294cdf55f4a73d5854272"
-  integrity sha512-UPqG4a8OPCdwLxDqgsFFci4dm/RlvxKNS3pYiLxqMN6VL0MzIFA1XD1NAaLBMsQUzgN38fz+93ldY1MJ7vFbZQ==
-  dependencies:
-    "@babel/runtime" "^7.11.2"
-    "@polkadot/util" "3.3.1"
-    "@polkadot/wasm-crypto" "^1.3.1"
-    base-x "^3.0.8"
-    bip39 "^3.0.2"
-    blakejs "^1.1.0"
-    bn.js "^5.1.3"
-    elliptic "^6.5.3"
-    js-sha3 "^0.8.0"
-    pbkdf2 "^3.1.1"
-    scryptsy "^2.1.0"
-    tweetnacl "^1.0.3"
-    xxhashjs "^0.2.2"
-
-"@polkadot/util@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-3.3.1.tgz#d5c2da98c4ade77948a32355477f564c8c2610a4"
-  integrity sha512-rH1TbDyZHEmT9nH9dC9Y5d/WTDrKQ9nDoUihZsu9vJNe7kII6tfAzwqZcncbVUMKAj9o72VRcl4RmN5Kj456AA==
-  dependencies:
-    "@babel/runtime" "^7.11.2"
-    "@types/bn.js" "^4.11.6"
-    bn.js "^5.1.3"
-    camelcase "^5.3.1"
-    chalk "^4.1.0"
-    ip-regex "^4.1.0"
-
 "@polkadot/util@3.4.1", "@polkadot/util@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-3.4.1.tgz#8676dd49e9c2d2332dcb72239287e37f0ab2c60a"
@@ -652,7 +621,7 @@
     chalk "^4.1.0"
     ip-regex "^4.1.0"
 
-"@polkadot/wasm-crypto@^1.3.1", "@polkadot/wasm-crypto@^1.4.1":
+"@polkadot/wasm-crypto@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-1.4.1.tgz#0a053d0c2587da30fb5313cef81f8d9a52029c68"
   integrity sha512-GPBCh8YvQmA5bobI4rqRkUhrEHkEWU1+lcJVPbZYsa7jiHFaZpzCLrGQfiqW/vtbU1aBS2wmJ0x1nlt33B9QqQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,42 +482,42 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.31.0-beta.11":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.11.tgz#fd380f9ede49f108143aad2a2f1efe384d3e5d81"
-  integrity sha512-PXBSXTuP67Nnd3kdoMMNhO0Chz44O0jt7BjaFC+RTUeRbHgSEmsUy5IRQloyjvPIRqdThfNlQgC/FIUm7sFPJQ==
+"@polkadot/api-derive@1.31.0-beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.15.tgz#04d52a67cd252ea7f000a40081e8d49b7178f3ef"
+  integrity sha512-gCABSpgYoplMmKSL+omuDMFBf4SWDQ5NJXaKhLrFvbNLZxvgGScB+31kMJWcf68aN6r4w+5yA8o32OJpPx2C5A==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api" "1.31.0-beta.11"
-    "@polkadot/rpc-core" "1.31.0-beta.11"
-    "@polkadot/rpc-provider" "1.31.0-beta.11"
-    "@polkadot/types" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
-    "@polkadot/util-crypto" "^3.4.0-beta.2"
+    "@polkadot/api" "1.31.0-beta.15"
+    "@polkadot/rpc-core" "1.31.0-beta.15"
+    "@polkadot/rpc-provider" "1.31.0-beta.15"
+    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
+    "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/api@1.31.0-beta.11", "@polkadot/api@^1.31.beta":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.11.tgz#5c5cb7a9445a6e372b84d242875e1bf7b678c655"
-  integrity sha512-FJ6XzDUXNTIKbH6dG56mz4//26GdtxQuC211VnT8WdUV+IXFGhhV6aDzXPQZMVyxftMoi38M9lHr/wAnwvTWdA==
+"@polkadot/api@1.31.0-beta.15", "@polkadot/api@^1.31.beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.15.tgz#e3f7c78baaf81099b9e2225ba12fa02112509bb2"
+  integrity sha512-WjCWPkAuROgZ7mthgBiIab/jbwr7EKnG70maSgNd4P70clSwg0ZJGDtCDJ+biROTm5MahtoRlFbXZGYiucymow==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api-derive" "1.31.0-beta.11"
-    "@polkadot/keyring" "^3.4.0-beta.2"
-    "@polkadot/metadata" "1.31.0-beta.11"
-    "@polkadot/rpc-core" "1.31.0-beta.11"
-    "@polkadot/rpc-provider" "1.31.0-beta.11"
-    "@polkadot/types" "1.31.0-beta.11"
-    "@polkadot/types-known" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
-    "@polkadot/util-crypto" "^3.4.0-beta.2"
+    "@polkadot/api-derive" "1.31.0-beta.15"
+    "@polkadot/keyring" "^3.4.0-beta.3"
+    "@polkadot/metadata" "1.31.0-beta.15"
+    "@polkadot/rpc-core" "1.31.0-beta.15"
+    "@polkadot/rpc-provider" "1.31.0-beta.15"
+    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/types-known" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
+    "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
     eventemitter3 "^4.0.6"
     rxjs "^6.6.2"
 
-"@polkadot/keyring@^3.4.0-beta.2":
+"@polkadot/keyring@^3.4.0-beta.3":
   version "3.4.0-beta.3"
   resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-3.4.0-beta.3.tgz#94b63d43e4829e19b001022718541af4dae031ff"
   integrity sha512-8LSszOOubAQBHbP+U0kg4ZZIDDj2Q40jicCFDYDFOhjzKc1dJ3TPQc3/FWBTz7AR6fv+RELFuibaqIrcBGg5tg==
@@ -526,71 +526,71 @@
     "@polkadot/util" "3.4.0-beta.3"
     "@polkadot/util-crypto" "3.4.0-beta.3"
 
-"@polkadot/metadata@1.31.0-beta.11":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.11.tgz#463e47c3daab809401fc329c0b6f2ff5433c34f8"
-  integrity sha512-IYekI15yEPPDGIApZCP01IpKCn/IZXAsHnb0qIHQ/F/a2wInNGJZxo7oMqU682nbshmdqApJ3gzti3jfe4YL0w==
+"@polkadot/metadata@1.31.0-beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.15.tgz#2d5dd19a2dd278d77b9208b4bd69ffc03c1aaca1"
+  integrity sha512-6bSwOzKuQWMi59hmtKb7iiJz0zWD3Eejk4cr42+juMlotmJUJo4DbM5H9OLfBxEJHelf/RTch8gV1YfPExza5g==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.11"
-    "@polkadot/types-known" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
-    "@polkadot/util-crypto" "^3.4.0-beta.2"
+    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/types-known" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
+    "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
 
-"@polkadot/rpc-core@1.31.0-beta.11":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.11.tgz#cc0d78e1abd9d1adeef3c6a4d5ab6341c8b90769"
-  integrity sha512-Ht4MgTi77a0QCTMTbK5RI6+d0kizqHoypX6mFLVPfDN3D2UZNJnQSwRO5d+4d4wl7YWxji84ASrdIRN3UTBY5w==
+"@polkadot/rpc-core@1.31.0-beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.15.tgz#a10cf0a442ccab80179796c9e29cd34df67fab94"
+  integrity sha512-8kggugg9GdvqtRdYk60KoHjoB9Y4Ys0JzrY6ae53nyd8mjxyIK3EGGJIh5bKkJTdRVyZe74UdmIGUE8lBQzjJw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.11"
-    "@polkadot/rpc-provider" "1.31.0-beta.11"
-    "@polkadot/types" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/metadata" "1.31.0-beta.15"
+    "@polkadot/rpc-provider" "1.31.0-beta.15"
+    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/rpc-provider@1.31.0-beta.11":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.11.tgz#9f664e7a5f181da5a2b0c84adffa3e7544b4b624"
-  integrity sha512-74hMFHJA3bA+sm+2rS1dfxLSAqYx+SEMJdxQOZuB41j9GDQMdNFZ4809WHN4PHG4jHs7AX/83IxMBLrtAMno+Q==
+"@polkadot/rpc-provider@1.31.0-beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.15.tgz#f9c93438cfd770aa25319693dc6c7487571cc3f3"
+  integrity sha512-i653B2hEAYNaqL2PdX7KJOZTpNe+8xxFG6zd7EkEVNBMAtwGr+v1VM6PP0e2Zs1Qz8BbJc0LEDPEzN76BkvjJA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.11"
-    "@polkadot/types" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
-    "@polkadot/util-crypto" "^3.4.0-beta.2"
+    "@polkadot/metadata" "1.31.0-beta.15"
+    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
+    "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
     eventemitter3 "^4.0.6"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.31.0-beta.11":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.11.tgz#ff1bd1928876677a42d7b8ce2b1e81e4accb0688"
-  integrity sha512-OxM1PYQUeBZxloDfpsjgykiV9whjADsVMK8EHdgt9JUqZQ5av3cbERYdAmSC8PFTmP5urleFJ1eMLtYlltM1DA==
+"@polkadot/types-known@1.31.0-beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.15.tgz#e1e9d211231ab035f3c521379508799ccee34f98"
+  integrity sha512-ljO5+/OWYtwlVOO08VM+3UFxpx0Wi94XnRxKdE32I58m1cPc/ZXuq45FR0+FBvr1d7vILJ589sgaN/dF7/HFmA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
     bn.js "^5.1.3"
 
-"@polkadot/types@1.31.0-beta.11":
-  version "1.31.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.11.tgz#3394881cdfc549cd5717fdce2ed4f25d326eabe3"
-  integrity sha512-nQLa4X9hgLt71RINDUv9MJB5tTT4A4msIQ8CZuIdD/1zACxgk6NUAn1x9K1GKDWBl2FHZwHSTTVRMVn2tXpvnA==
+"@polkadot/types@1.31.0-beta.15":
+  version "1.31.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.15.tgz#6af13454a9af8e6a66b30da083f018707cb09f99"
+  integrity sha512-O+Au+rlKgpmX8gJ4WY5jlH4RqjHzuSy+FM+4uJxdD6fvV3wUy8gfr0+vlKl2l2u65Zzbm4/AjZeKb5bCjeYlIQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.11"
-    "@polkadot/util" "^3.4.0-beta.2"
-    "@polkadot/util-crypto" "^3.4.0-beta.2"
+    "@polkadot/metadata" "1.31.0-beta.15"
+    "@polkadot/util" "^3.4.0-beta.3"
+    "@polkadot/util-crypto" "^3.4.0-beta.3"
     "@types/bn.js" "^4.11.6"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/util-crypto@3.4.0-beta.3", "@polkadot/util-crypto@^3.4.0-beta.2":
+"@polkadot/util-crypto@3.4.0-beta.3", "@polkadot/util-crypto@^3.4.0-beta.3":
   version "3.4.0-beta.3"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-3.4.0-beta.3.tgz#72e013c061e0db6f69c47f7ba6c18b51b2f707f1"
   integrity sha512-/AMxBeSi5fcmdukgwGV0wTAkVdr1BNXdD7vgzo2nGYcopyoDi6JHgR5GIXOOo633rvK1qnK3St1H0sXfYzyNOA==
@@ -640,7 +640,7 @@
     chalk "^4.1.0"
     ip-regex "^4.1.0"
 
-"@polkadot/util@3.4.0-beta.3", "@polkadot/util@^3.4.0-beta.2":
+"@polkadot/util@3.4.0-beta.3", "@polkadot/util@^3.4.0-beta.3":
   version "3.4.0-beta.3"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-3.4.0-beta.3.tgz#2de31209319403431d2ada451e5dabc7b390466e"
   integrity sha512-IcoEi/KmsIRas4BMrb/XYU0rwhd43+jVPEdhHrNGDy4Clv/o+3LDsW9MnPQ53by7sjD+IcoraH96N9w/eEShig==

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,35 +482,35 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.31.0-beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.15.tgz#04d52a67cd252ea7f000a40081e8d49b7178f3ef"
-  integrity sha512-gCABSpgYoplMmKSL+omuDMFBf4SWDQ5NJXaKhLrFvbNLZxvgGScB+31kMJWcf68aN6r4w+5yA8o32OJpPx2C5A==
+"@polkadot/api-derive@1.31.0-beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.16.tgz#df70484c2344c68b3b5aaf9e48815d6ffc0fa239"
+  integrity sha512-My1BXm7hqES39tgq8dLtJkWrC9sf0zR+B3KeO9+MqC3VlCCm+MB+bcC13dw5cakF1UzzYn/qdVZ/UjVQFrr4Dg==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api" "1.31.0-beta.15"
-    "@polkadot/rpc-core" "1.31.0-beta.15"
-    "@polkadot/rpc-provider" "1.31.0-beta.15"
-    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/api" "1.31.0-beta.16"
+    "@polkadot/rpc-core" "1.31.0-beta.16"
+    "@polkadot/rpc-provider" "1.31.0-beta.16"
+    "@polkadot/types" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/api@1.31.0-beta.15", "@polkadot/api@^1.31.beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.15.tgz#e3f7c78baaf81099b9e2225ba12fa02112509bb2"
-  integrity sha512-WjCWPkAuROgZ7mthgBiIab/jbwr7EKnG70maSgNd4P70clSwg0ZJGDtCDJ+biROTm5MahtoRlFbXZGYiucymow==
+"@polkadot/api@1.31.0-beta.16", "@polkadot/api@^1.31.beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.16.tgz#7273c2a38c6b0de3d936f6af4b1e454d9219667f"
+  integrity sha512-GYrlUTWQ+b3aRjTuANeApxDUFg2GoxR9Hz9KNDKcvOy6n1OhFyG171zxrneYZRhrEq8vRMjzoxh9Efgn3hjXUw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api-derive" "1.31.0-beta.15"
+    "@polkadot/api-derive" "1.31.0-beta.16"
     "@polkadot/keyring" "^3.4.0-beta.3"
-    "@polkadot/metadata" "1.31.0-beta.15"
-    "@polkadot/rpc-core" "1.31.0-beta.15"
-    "@polkadot/rpc-provider" "1.31.0-beta.15"
-    "@polkadot/types" "1.31.0-beta.15"
-    "@polkadot/types-known" "1.31.0-beta.15"
+    "@polkadot/metadata" "1.31.0-beta.16"
+    "@polkadot/rpc-core" "1.31.0-beta.16"
+    "@polkadot/rpc-provider" "1.31.0-beta.16"
+    "@polkadot/types" "1.31.0-beta.16"
+    "@polkadot/types-known" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
@@ -526,39 +526,39 @@
     "@polkadot/util" "3.4.0-beta.3"
     "@polkadot/util-crypto" "3.4.0-beta.3"
 
-"@polkadot/metadata@1.31.0-beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.15.tgz#2d5dd19a2dd278d77b9208b4bd69ffc03c1aaca1"
-  integrity sha512-6bSwOzKuQWMi59hmtKb7iiJz0zWD3Eejk4cr42+juMlotmJUJo4DbM5H9OLfBxEJHelf/RTch8gV1YfPExza5g==
+"@polkadot/metadata@1.31.0-beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.16.tgz#e09e49dd5dc94924fede670791999c0bc4491286"
+  integrity sha512-xE7e6sp1KgoWgMDvUpu3dysf21oNFeog8lrgniwA7PjpyFK3llJPKDMIls9x9/KcL8tOTC1eO9I0q7mu/pC7Pw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.15"
-    "@polkadot/types-known" "1.31.0-beta.15"
+    "@polkadot/types" "1.31.0-beta.16"
+    "@polkadot/types-known" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
 
-"@polkadot/rpc-core@1.31.0-beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.15.tgz#a10cf0a442ccab80179796c9e29cd34df67fab94"
-  integrity sha512-8kggugg9GdvqtRdYk60KoHjoB9Y4Ys0JzrY6ae53nyd8mjxyIK3EGGJIh5bKkJTdRVyZe74UdmIGUE8lBQzjJw==
+"@polkadot/rpc-core@1.31.0-beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.16.tgz#2afd9debafecbdf6548fa0e10f8f112dcb8466e2"
+  integrity sha512-q12IivlxY15ofJCFmRiloyjp0Qz9Td78Hcfux6xiSnfbd1dYn2WZ3FUlQjjORlDuRLAUQwu2yw6ELJJayCD/iw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.15"
-    "@polkadot/rpc-provider" "1.31.0-beta.15"
-    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/metadata" "1.31.0-beta.16"
+    "@polkadot/rpc-provider" "1.31.0-beta.16"
+    "@polkadot/types" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/rpc-provider@1.31.0-beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.15.tgz#f9c93438cfd770aa25319693dc6c7487571cc3f3"
-  integrity sha512-i653B2hEAYNaqL2PdX7KJOZTpNe+8xxFG6zd7EkEVNBMAtwGr+v1VM6PP0e2Zs1Qz8BbJc0LEDPEzN76BkvjJA==
+"@polkadot/rpc-provider@1.31.0-beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.16.tgz#51b4068bc82643bd675479c1d2a529ae44932b04"
+  integrity sha512-dSSuMI1L4P9GhN3mFE/4bBTg6XVXgFxPdTRlinrKMVMAwQiavFFZQLFwzwrSUiQAtUNwTfHhseaiw0Bun8GXLQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.15"
-    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/metadata" "1.31.0-beta.16"
+    "@polkadot/types" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
@@ -566,23 +566,23 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.31.0-beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.15.tgz#e1e9d211231ab035f3c521379508799ccee34f98"
-  integrity sha512-ljO5+/OWYtwlVOO08VM+3UFxpx0Wi94XnRxKdE32I58m1cPc/ZXuq45FR0+FBvr1d7vILJ589sgaN/dF7/HFmA==
+"@polkadot/types-known@1.31.0-beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.16.tgz#ba3f7278601dc7ddea9a345d6f7a060efa7674c7"
+  integrity sha512-33XBhgrjD9kDI8f2wqNUGL4jGCSF4ecjhFwEnq+8utotudqQZwXKqiUMVSt2OU5p7t1OTyQvAh2ZrIt1PpcMgw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.15"
+    "@polkadot/types" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     bn.js "^5.1.3"
 
-"@polkadot/types@1.31.0-beta.15":
-  version "1.31.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.15.tgz#6af13454a9af8e6a66b30da083f018707cb09f99"
-  integrity sha512-O+Au+rlKgpmX8gJ4WY5jlH4RqjHzuSy+FM+4uJxdD6fvV3wUy8gfr0+vlKl2l2u65Zzbm4/AjZeKb5bCjeYlIQ==
+"@polkadot/types@1.31.0-beta.16":
+  version "1.31.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.16.tgz#cd356b83ad8081c85a3943dd4edc8f1a0b548b61"
+  integrity sha512-jDduBFcGBZzvplxjJTJ9/beOIJmraCpkuD342a9jiywB5XxxRb/SnK9qnlRXAQO1LNcbvheZHgYW+oa/jPl92A==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.15"
+    "@polkadot/metadata" "1.31.0-beta.16"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     "@types/bn.js" "^4.11.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,115 +482,134 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.30.1.tgz#4ff40135b058f947ca00e615ed0ce49bb9629172"
-  integrity sha512-qjr2rdMYkEerEvjPNfxa7VOROOt5sPmo3lQCuIH5emjr4bRI79M6sCY/XZR1ISxmdNr5/muqGQyCPmKp/Iav4A==
+"@polkadot/api-derive@1.31.0-beta.11":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.11.tgz#fd380f9ede49f108143aad2a2f1efe384d3e5d81"
+  integrity sha512-PXBSXTuP67Nnd3kdoMMNhO0Chz44O0jt7BjaFC+RTUeRbHgSEmsUy5IRQloyjvPIRqdThfNlQgC/FIUm7sFPJQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api" "1.30.1"
-    "@polkadot/rpc-core" "1.30.1"
-    "@polkadot/rpc-provider" "1.30.1"
-    "@polkadot/types" "1.30.1"
-    "@polkadot/util" "^3.3.1"
-    "@polkadot/util-crypto" "^3.3.1"
+    "@polkadot/api" "1.31.0-beta.11"
+    "@polkadot/rpc-core" "1.31.0-beta.11"
+    "@polkadot/rpc-provider" "1.31.0-beta.11"
+    "@polkadot/types" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/util-crypto" "^3.4.0-beta.2"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/api@1.30.1", "@polkadot/api@^1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.30.1.tgz#19aed18f3bf7cd6beec12690c5cb866673bbd8dd"
-  integrity sha512-fbybLuI+T1Ow14sHJwyO4eQBF7+oMpjmRXfmIOrFjAm11YJxeQQd+W9i5FNdB9LugdxDG4nQZDYZ+7VaFWUsGQ==
+"@polkadot/api@1.31.0-beta.11", "@polkadot/api@^1.31.beta":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.11.tgz#5c5cb7a9445a6e372b84d242875e1bf7b678c655"
+  integrity sha512-FJ6XzDUXNTIKbH6dG56mz4//26GdtxQuC211VnT8WdUV+IXFGhhV6aDzXPQZMVyxftMoi38M9lHr/wAnwvTWdA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api-derive" "1.30.1"
-    "@polkadot/keyring" "^3.3.1"
-    "@polkadot/metadata" "1.30.1"
-    "@polkadot/rpc-core" "1.30.1"
-    "@polkadot/rpc-provider" "1.30.1"
-    "@polkadot/types" "1.30.1"
-    "@polkadot/types-known" "1.30.1"
-    "@polkadot/util" "^3.3.1"
-    "@polkadot/util-crypto" "^3.3.1"
+    "@polkadot/api-derive" "1.31.0-beta.11"
+    "@polkadot/keyring" "^3.4.0-beta.2"
+    "@polkadot/metadata" "1.31.0-beta.11"
+    "@polkadot/rpc-core" "1.31.0-beta.11"
+    "@polkadot/rpc-provider" "1.31.0-beta.11"
+    "@polkadot/types" "1.31.0-beta.11"
+    "@polkadot/types-known" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/util-crypto" "^3.4.0-beta.2"
     bn.js "^5.1.3"
-    eventemitter3 "^4.0.5"
+    eventemitter3 "^4.0.6"
     rxjs "^6.6.2"
 
-"@polkadot/keyring@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-3.3.1.tgz#7e37f86804c75043bc800db1fb3149421b571c47"
-  integrity sha512-k0FwkvNNE3cgeDaWjfgxhXGPkiPsXpObyrjA2jod/tkh4PMsHxs5c0J9z/eMjby1+cn1ZqmOa4NROD2wFEnU+Q==
+"@polkadot/keyring@^3.4.0-beta.2":
+  version "3.4.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-3.4.0-beta.3.tgz#94b63d43e4829e19b001022718541af4dae031ff"
+  integrity sha512-8LSszOOubAQBHbP+U0kg4ZZIDDj2Q40jicCFDYDFOhjzKc1dJ3TPQc3/FWBTz7AR6fv+RELFuibaqIrcBGg5tg==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/util" "3.3.1"
-    "@polkadot/util-crypto" "3.3.1"
+    "@polkadot/util" "3.4.0-beta.3"
+    "@polkadot/util-crypto" "3.4.0-beta.3"
 
-"@polkadot/metadata@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.30.1.tgz#12de91c535d322d0b049ab2d20de35b5e46ffa00"
-  integrity sha512-Z6/Sw7+sZ6sbhC5BlG22ilWcrb9pTTbBTl2llbzjenPkbymFycon7JaDpPMkfq+WwfHtFb/0jsvDZBDgEY7cWg==
+"@polkadot/metadata@1.31.0-beta.11":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.11.tgz#463e47c3daab809401fc329c0b6f2ff5433c34f8"
+  integrity sha512-IYekI15yEPPDGIApZCP01IpKCn/IZXAsHnb0qIHQ/F/a2wInNGJZxo7oMqU682nbshmdqApJ3gzti3jfe4YL0w==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.30.1"
-    "@polkadot/types-known" "1.30.1"
-    "@polkadot/util" "^3.3.1"
-    "@polkadot/util-crypto" "^3.3.1"
+    "@polkadot/types" "1.31.0-beta.11"
+    "@polkadot/types-known" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/util-crypto" "^3.4.0-beta.2"
     bn.js "^5.1.3"
 
-"@polkadot/rpc-core@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.30.1.tgz#2d2458f65388230dce76174484c6ce8d086c20e3"
-  integrity sha512-XW1sNBPKALpK5RbyDozOeno5L9nvKguJRqbF81HlcvJA7sNBX/TZENqlJyCGQabHiSmswrfksh0q8dlv6xs8oA==
+"@polkadot/rpc-core@1.31.0-beta.11":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.11.tgz#cc0d78e1abd9d1adeef3c6a4d5ab6341c8b90769"
+  integrity sha512-Ht4MgTi77a0QCTMTbK5RI6+d0kizqHoypX6mFLVPfDN3D2UZNJnQSwRO5d+4d4wl7YWxji84ASrdIRN3UTBY5w==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.30.1"
-    "@polkadot/rpc-provider" "1.30.1"
-    "@polkadot/types" "1.30.1"
-    "@polkadot/util" "^3.3.1"
+    "@polkadot/metadata" "1.31.0-beta.11"
+    "@polkadot/rpc-provider" "1.31.0-beta.11"
+    "@polkadot/types" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/rpc-provider@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.30.1.tgz#51a532edcf80545d3a0c4bd29876a5893f76fc9d"
-  integrity sha512-lL5hhbIFgqeECUl6JcYTasAfGaraPVcmZatmTkO5+4URtJMI1CKK5alcbpOEDH8zgO8seaNQUTRCf4jRQUUTXQ==
+"@polkadot/rpc-provider@1.31.0-beta.11":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.11.tgz#9f664e7a5f181da5a2b0c84adffa3e7544b4b624"
+  integrity sha512-74hMFHJA3bA+sm+2rS1dfxLSAqYx+SEMJdxQOZuB41j9GDQMdNFZ4809WHN4PHG4jHs7AX/83IxMBLrtAMno+Q==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.30.1"
-    "@polkadot/types" "1.30.1"
-    "@polkadot/util" "^3.3.1"
-    "@polkadot/util-crypto" "^3.3.1"
+    "@polkadot/metadata" "1.31.0-beta.11"
+    "@polkadot/types" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/util-crypto" "^3.4.0-beta.2"
     bn.js "^5.1.3"
-    eventemitter3 "^4.0.5"
+    eventemitter3 "^4.0.6"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.30.1.tgz#f399a48d4eac818bb6a81f98d36d9f9b5d862a0a"
-  integrity sha512-SFbflleTZgfnkf4kJ2ka4FbqlERKKIabC6fJVgCXiGiFFcscO4xfGTVNalRnfKzfr/JS99M8I14H5IcbDeaq8A==
+"@polkadot/types-known@1.31.0-beta.11":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.11.tgz#ff1bd1928876677a42d7b8ce2b1e81e4accb0688"
+  integrity sha512-OxM1PYQUeBZxloDfpsjgykiV9whjADsVMK8EHdgt9JUqZQ5av3cbERYdAmSC8PFTmP5urleFJ1eMLtYlltM1DA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.30.1"
-    "@polkadot/util" "^3.3.1"
+    "@polkadot/types" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
     bn.js "^5.1.3"
 
-"@polkadot/types@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.30.1.tgz#3ba4f9af8a786817db6f78dcd7718f950a43b776"
-  integrity sha512-0HAsedW35HICz5t5HW9RT/bPYHdp0SWInHG2/D0DT4mnjnnmJ0KsZEPQ803Pg2srzgGfnqlDRgN6NoPYR/wjAw==
+"@polkadot/types@1.31.0-beta.11":
+  version "1.31.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.11.tgz#3394881cdfc549cd5717fdce2ed4f25d326eabe3"
+  integrity sha512-nQLa4X9hgLt71RINDUv9MJB5tTT4A4msIQ8CZuIdD/1zACxgk6NUAn1x9K1GKDWBl2FHZwHSTTVRMVn2tXpvnA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.30.1"
-    "@polkadot/util" "^3.3.1"
-    "@polkadot/util-crypto" "^3.3.1"
+    "@polkadot/metadata" "1.31.0-beta.11"
+    "@polkadot/util" "^3.4.0-beta.2"
+    "@polkadot/util-crypto" "^3.4.0-beta.2"
     "@types/bn.js" "^4.11.6"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/util-crypto@3.3.1", "@polkadot/util-crypto@^3.3.1":
+"@polkadot/util-crypto@3.4.0-beta.3", "@polkadot/util-crypto@^3.4.0-beta.2":
+  version "3.4.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-3.4.0-beta.3.tgz#72e013c061e0db6f69c47f7ba6c18b51b2f707f1"
+  integrity sha512-/AMxBeSi5fcmdukgwGV0wTAkVdr1BNXdD7vgzo2nGYcopyoDi6JHgR5GIXOOo633rvK1qnK3St1H0sXfYzyNOA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@polkadot/util" "3.4.0-beta.3"
+    "@polkadot/wasm-crypto" "^1.4.1"
+    base-x "^3.0.8"
+    bip39 "^3.0.2"
+    blakejs "^1.1.0"
+    bn.js "^5.1.3"
+    elliptic "^6.5.3"
+    js-sha3 "^0.8.0"
+    pbkdf2 "^3.1.1"
+    scryptsy "^2.1.0"
+    tweetnacl "^1.0.3"
+    xxhashjs "^0.2.2"
+
+"@polkadot/util-crypto@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-3.3.1.tgz#5d2d4a373fa864a86d1294cdf55f4a73d5854272"
   integrity sha512-UPqG4a8OPCdwLxDqgsFFci4dm/RlvxKNS3pYiLxqMN6VL0MzIFA1XD1NAaLBMsQUzgN38fz+93ldY1MJ7vFbZQ==
@@ -609,7 +628,7 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@3.3.1", "@polkadot/util@^3.3.1":
+"@polkadot/util@3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-3.3.1.tgz#d5c2da98c4ade77948a32355477f564c8c2610a4"
   integrity sha512-rH1TbDyZHEmT9nH9dC9Y5d/WTDrKQ9nDoUihZsu9vJNe7kII6tfAzwqZcncbVUMKAj9o72VRcl4RmN5Kj456AA==
@@ -621,7 +640,19 @@
     chalk "^4.1.0"
     ip-regex "^4.1.0"
 
-"@polkadot/wasm-crypto@^1.3.1":
+"@polkadot/util@3.4.0-beta.3", "@polkadot/util@^3.4.0-beta.2":
+  version "3.4.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-3.4.0-beta.3.tgz#2de31209319403431d2ada451e5dabc7b390466e"
+  integrity sha512-IcoEi/KmsIRas4BMrb/XYU0rwhd43+jVPEdhHrNGDy4Clv/o+3LDsW9MnPQ53by7sjD+IcoraH96N9w/eEShig==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^5.1.3"
+    camelcase "^5.3.1"
+    chalk "^4.1.0"
+    ip-regex "^4.1.0"
+
+"@polkadot/wasm-crypto@^1.3.1", "@polkadot/wasm-crypto@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-1.4.1.tgz#0a053d0c2587da30fb5313cef81f8d9a52029c68"
   integrity sha512-GPBCh8YvQmA5bobI4rqRkUhrEHkEWU1+lcJVPbZYsa7jiHFaZpzCLrGQfiqW/vtbU1aBS2wmJ0x1nlt33B9QqQ==
@@ -792,9 +823,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "14.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.1.tgz#fdf6f6c6c73d3d8eee9c98a9a0485bc524b048d7"
-  integrity sha512-HnYlg/BRF8uC1FyKRFZwRaCPTPYKa+6I8QiUZFLredaGOou481cgFS4wKRFyKvQtX8xudqkSdBczJHIYSQYKrQ==
+  version "14.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.2.tgz#264b44c5a28dfa80198fc2f7b6d3c8a054b9491f"
+  integrity sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==
 
 "@types/node@11.11.6":
   version "11.11.6"
@@ -1285,6 +1316,13 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+bufferutil@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.1.tgz#3a177e8e5819a1243fe16b63a199951a7ad8d4a7"
+  integrity sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==
+  dependencies:
+    node-gyp-build "~3.7.0"
 
 bytes@3.1.0:
   version "3.1.0"
@@ -2001,7 +2039,7 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter3@^4.0.5:
+eventemitter3@^4.0.6:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -3608,11 +3646,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.14.0:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -3667,6 +3700,11 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-gyp-build@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.7.0.tgz#daa77a4f547b9aed3e2aac779eaf151afd60ec8d"
+  integrity sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4673,9 +4711,9 @@ supports-color@^5.3.0:
     has-flag "^3.0.0"
 
 supports-color@^7.0.0, supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -4979,6 +5017,13 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utf-8-validate@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.2.tgz#63cfbccd85dc1f2b66cf7a1d0eebc08ed056bfb3"
+  integrity sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==
+  dependencies:
+    node-gyp-build "~3.7.0"
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5067,14 +5112,15 @@ webidl-conversions@^6.1.0:
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 websocket@^1.0.31:
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.31.tgz#e5d0f16c3340ed87670e489ecae6144c79358730"
-  integrity sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
+  integrity sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==
   dependencies:
+    bufferutil "^4.0.1"
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
     yaeti "^0.0.6"
 
 whatwg-encoding@^1.0.5:

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,35 +482,35 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.31.0-beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.16.tgz#df70484c2344c68b3b5aaf9e48815d6ffc0fa239"
-  integrity sha512-My1BXm7hqES39tgq8dLtJkWrC9sf0zR+B3KeO9+MqC3VlCCm+MB+bcC13dw5cakF1UzzYn/qdVZ/UjVQFrr4Dg==
+"@polkadot/api-derive@1.31.0-beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.17.tgz#5ac515f2c11fe670eaa7ebb447779f06b31f5a44"
+  integrity sha512-BhnHqKvIbwm2Xggw/kQHz7GeH9QPWtINA2TxFhkrRKqPq8PTlxzR4+9v4FnND9i6X9GyMbMhCp4DCnyzcabyEQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api" "1.31.0-beta.16"
-    "@polkadot/rpc-core" "1.31.0-beta.16"
-    "@polkadot/rpc-provider" "1.31.0-beta.16"
-    "@polkadot/types" "1.31.0-beta.16"
+    "@polkadot/api" "1.31.0-beta.17"
+    "@polkadot/rpc-core" "1.31.0-beta.17"
+    "@polkadot/rpc-provider" "1.31.0-beta.17"
+    "@polkadot/types" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/api@1.31.0-beta.16", "@polkadot/api@^1.31.beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.16.tgz#7273c2a38c6b0de3d936f6af4b1e454d9219667f"
-  integrity sha512-GYrlUTWQ+b3aRjTuANeApxDUFg2GoxR9Hz9KNDKcvOy6n1OhFyG171zxrneYZRhrEq8vRMjzoxh9Efgn3hjXUw==
+"@polkadot/api@1.31.0-beta.17", "@polkadot/api@^1.31.beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.17.tgz#a09b335f4590a846d89cc5e5bd67a12209f7d5b3"
+  integrity sha512-WCirymFA3w1R6wg9/GtTwMsbMWSJ73weUHsNPlzWhxVGUBYWc6hNXcQIHr1F+kevX0nEXxDdgIwe+ARIb9ezvw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api-derive" "1.31.0-beta.16"
+    "@polkadot/api-derive" "1.31.0-beta.17"
     "@polkadot/keyring" "^3.4.0-beta.3"
-    "@polkadot/metadata" "1.31.0-beta.16"
-    "@polkadot/rpc-core" "1.31.0-beta.16"
-    "@polkadot/rpc-provider" "1.31.0-beta.16"
-    "@polkadot/types" "1.31.0-beta.16"
-    "@polkadot/types-known" "1.31.0-beta.16"
+    "@polkadot/metadata" "1.31.0-beta.17"
+    "@polkadot/rpc-core" "1.31.0-beta.17"
+    "@polkadot/rpc-provider" "1.31.0-beta.17"
+    "@polkadot/types" "1.31.0-beta.17"
+    "@polkadot/types-known" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
@@ -526,39 +526,39 @@
     "@polkadot/util" "3.4.0-beta.3"
     "@polkadot/util-crypto" "3.4.0-beta.3"
 
-"@polkadot/metadata@1.31.0-beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.16.tgz#e09e49dd5dc94924fede670791999c0bc4491286"
-  integrity sha512-xE7e6sp1KgoWgMDvUpu3dysf21oNFeog8lrgniwA7PjpyFK3llJPKDMIls9x9/KcL8tOTC1eO9I0q7mu/pC7Pw==
+"@polkadot/metadata@1.31.0-beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.17.tgz#529d2b0ded76396dc19bcdb0f0c610621e8d174c"
+  integrity sha512-MOItQOUDqwZUV7qrMnCdRSUIFneUtiAJo/JvcBGaVNsFTz0TFSbsmDu3GhDNzhlg9mxGq0V/c3TmgXgVgzaAlQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.16"
-    "@polkadot/types-known" "1.31.0-beta.16"
+    "@polkadot/types" "1.31.0-beta.17"
+    "@polkadot/types-known" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
 
-"@polkadot/rpc-core@1.31.0-beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.16.tgz#2afd9debafecbdf6548fa0e10f8f112dcb8466e2"
-  integrity sha512-q12IivlxY15ofJCFmRiloyjp0Qz9Td78Hcfux6xiSnfbd1dYn2WZ3FUlQjjORlDuRLAUQwu2yw6ELJJayCD/iw==
+"@polkadot/rpc-core@1.31.0-beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.17.tgz#a127896af1bf0a475706c7ea8c6e5bfc2df97c99"
+  integrity sha512-a7W0U1uLxOvocVfptzF7o5GManjlicvYQAsGNiC6LVxNjs8+ZH5ZYv/NTM1MaqnS9bZDKBYBmM+lDfg4ZEeQDw==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.16"
-    "@polkadot/rpc-provider" "1.31.0-beta.16"
-    "@polkadot/types" "1.31.0-beta.16"
+    "@polkadot/metadata" "1.31.0-beta.17"
+    "@polkadot/rpc-provider" "1.31.0-beta.17"
+    "@polkadot/types" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/rpc-provider@1.31.0-beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.16.tgz#51b4068bc82643bd675479c1d2a529ae44932b04"
-  integrity sha512-dSSuMI1L4P9GhN3mFE/4bBTg6XVXgFxPdTRlinrKMVMAwQiavFFZQLFwzwrSUiQAtUNwTfHhseaiw0Bun8GXLQ==
+"@polkadot/rpc-provider@1.31.0-beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.17.tgz#417384aa42b96a6ff2b2032a9ef0f12eb66c9666"
+  integrity sha512-SB7U9JOUeBPWMSDpQX8ssHymAIMdDIUmNAqHb7HcvFbSuBbBF8NCIRrAjyJCin6+N6Dzf7x7IzUF3fU7Fnzz9Q==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.16"
-    "@polkadot/types" "1.31.0-beta.16"
+    "@polkadot/metadata" "1.31.0-beta.17"
+    "@polkadot/types" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     bn.js "^5.1.3"
@@ -566,23 +566,23 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.31.0-beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.16.tgz#ba3f7278601dc7ddea9a345d6f7a060efa7674c7"
-  integrity sha512-33XBhgrjD9kDI8f2wqNUGL4jGCSF4ecjhFwEnq+8utotudqQZwXKqiUMVSt2OU5p7t1OTyQvAh2ZrIt1PpcMgw==
+"@polkadot/types-known@1.31.0-beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.17.tgz#00bac7939a999221b8942a907b98ee2c338d9219"
+  integrity sha512-3j7F4k0YRSOtATb2UwS1Uh54Fiaefgx8u9BKsLgBDxifn8RJPEatVpue651Vqdp83iN3IbzL/K33P/A2DUETrA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.16"
+    "@polkadot/types" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     bn.js "^5.1.3"
 
-"@polkadot/types@1.31.0-beta.16":
-  version "1.31.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.16.tgz#cd356b83ad8081c85a3943dd4edc8f1a0b548b61"
-  integrity sha512-jDduBFcGBZzvplxjJTJ9/beOIJmraCpkuD342a9jiywB5XxxRb/SnK9qnlRXAQO1LNcbvheZHgYW+oa/jPl92A==
+"@polkadot/types@1.31.0-beta.17":
+  version "1.31.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.17.tgz#8dab42650cc37d8a49267704c3480bb782bd32f3"
+  integrity sha512-ich1p+Au5VRr4ZDOjKqu1SgdyB5kMuR1yusFLHIzqIkOrxvERP9+R2aDNJVehODF/Xs7ozqFy817gXuQ0nsN/Q==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.16"
+    "@polkadot/metadata" "1.31.0-beta.17"
     "@polkadot/util" "^3.4.0-beta.3"
     "@polkadot/util-crypto" "^3.4.0-beta.3"
     "@types/bn.js" "^4.11.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,35 +482,35 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@1.31.0-beta.25":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.0-beta.25.tgz#6f08f93e883492d08bd6743098437421168f062f"
-  integrity sha512-XQBAPB2H/aj7UY+jK9o74vefFdQEQ3yItZ3r+QeDfLxHfISt+Rh1O+U0HR/7HJ980qGfOz5qM+LieqcWMMFO8w==
+"@polkadot/api-derive@1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-1.31.1.tgz#a02ad5bfdc9064d1a63dafd9c1738b7e1c022216"
+  integrity sha512-6cMqPb914CXf/QMXhQpuLCSwy4UPX6hKuNe+w93LUoNPXR86vdsgExyuOEEA/s6T1BSHPTbqsTfpPSRUv/DApA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api" "1.31.0-beta.25"
-    "@polkadot/rpc-core" "1.31.0-beta.25"
-    "@polkadot/rpc-provider" "1.31.0-beta.25"
-    "@polkadot/types" "1.31.0-beta.25"
+    "@polkadot/api" "1.31.1"
+    "@polkadot/rpc-core" "1.31.1"
+    "@polkadot/rpc-provider" "1.31.1"
+    "@polkadot/types" "1.31.1"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/api@1.31.0-beta.25", "@polkadot/api@^1.31.beta":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.0-beta.25.tgz#93a29ff3b4ba5e03d1235ad7b0e6fceb851ae105"
-  integrity sha512-E7ZWCyLRWkZTQFMSVLy/NPH21M2B+q9oZxZCHv+Lh2O7sXddRnd7uxOiotud9NlEIC5ab8hcQixfFiFejm7ijQ==
+"@polkadot/api@1.31.1", "@polkadot/api@^1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-1.31.1.tgz#bba04a221d224d9037a50e5d892cacd6cb4d982d"
+  integrity sha512-By6IS5Y2PNSQLfq4a7i3Tp2TUV0vSLzI1U/MBiE3bCIPl5XBj7pH6Ko0Unxx2XFHpBJ35CTzM2q/Gag7i7imKQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/api-derive" "1.31.0-beta.25"
+    "@polkadot/api-derive" "1.31.1"
     "@polkadot/keyring" "^3.4.1"
-    "@polkadot/metadata" "1.31.0-beta.25"
-    "@polkadot/rpc-core" "1.31.0-beta.25"
-    "@polkadot/rpc-provider" "1.31.0-beta.25"
-    "@polkadot/types" "1.31.0-beta.25"
-    "@polkadot/types-known" "1.31.0-beta.25"
+    "@polkadot/metadata" "1.31.1"
+    "@polkadot/rpc-core" "1.31.1"
+    "@polkadot/rpc-provider" "1.31.1"
+    "@polkadot/types" "1.31.1"
+    "@polkadot/types-known" "1.31.1"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
@@ -526,39 +526,39 @@
     "@polkadot/util" "3.4.1"
     "@polkadot/util-crypto" "3.4.1"
 
-"@polkadot/metadata@1.31.0-beta.25":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.0-beta.25.tgz#49eb750b4ec31e53047b05417842a73c6bc1431f"
-  integrity sha512-B8Ov+GgtBVjFyPuTVGxbDFPPamgYELJTfdiHG5uwOZ1nmcwxSOhwKKxgtsGb4CMOgRMbSf2qaWJlZgjBJjQR0Q==
+"@polkadot/metadata@1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-1.31.1.tgz#1539777b5a5d62a06d9ef70f28901d525aa12e57"
+  integrity sha512-pzsxRerriU/jA36JUv4YSL1XpYoA01wPsYxMXO+Q0Z2RSaZPf/AmZHzJ4/cA39EjR6LhAoUQroOclJaFgT2C6Q==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.25"
-    "@polkadot/types-known" "1.31.0-beta.25"
+    "@polkadot/types" "1.31.1"
+    "@polkadot/types-known" "1.31.1"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
 
-"@polkadot/rpc-core@1.31.0-beta.25":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.0-beta.25.tgz#4c3accd1c45dc653c844c2523650cb0cdc7c0785"
-  integrity sha512-bkNgpit0hwxJIutEulj0J3rKySPzOnduV6VfbwZYOgwD65JjPxkcM8Af54bCD99xXaHBs28J7y3D4rodg3JoOw==
+"@polkadot/rpc-core@1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-1.31.1.tgz#a3c6be98185d95ca1b3e478c0125814406c0fcd5"
+  integrity sha512-m4ZBsLtYukflL03P6IO6B1qFqce3wBP5xxWh2n5ig3/CA+673xa0aXh0rYPQVU4J0sEZT3ktKwZW/MKmBC7J3A==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.25"
-    "@polkadot/rpc-provider" "1.31.0-beta.25"
-    "@polkadot/types" "1.31.0-beta.25"
+    "@polkadot/metadata" "1.31.1"
+    "@polkadot/rpc-provider" "1.31.1"
+    "@polkadot/types" "1.31.1"
     "@polkadot/util" "^3.4.1"
     memoizee "^0.4.14"
     rxjs "^6.6.2"
 
-"@polkadot/rpc-provider@1.31.0-beta.25":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.0-beta.25.tgz#3553d6d2dbb8648f3d963eda867dabb6c34f6113"
-  integrity sha512-QbfOcdZOw/g8Y00a0AB38CIhS3Eqj6mu7Ty7I3EWG3Q3fmsSJhzg8NQNA8bcdgBZBppONIYrT9j7ZfjLZMOs/w==
+"@polkadot/rpc-provider@1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-1.31.1.tgz#d292ed906afe1812f7ff2ad2dd956c6cec7c57b3"
+  integrity sha512-bh49hQx9W8e8UDOzAZm/tXEfSOWclEYdrCDDehMWBckVPvE5G5uQNTlJzumLY6bW5CE19UbVs/7sxo51Y6jghQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.25"
-    "@polkadot/types" "1.31.0-beta.25"
+    "@polkadot/metadata" "1.31.1"
+    "@polkadot/types" "1.31.1"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     bn.js "^5.1.3"
@@ -566,23 +566,23 @@
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.31"
 
-"@polkadot/types-known@1.31.0-beta.25":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.0-beta.25.tgz#e52d9b002bb5192ad554a520558375e2c460adce"
-  integrity sha512-qow6gdMbBGsrF8V5M4YWdrEFGizTXsBRMEF9FVrAJzHAC1/KlKI+eKhll7yd8UBCPL3z0hnfSSwchaOn1oKU+Q==
+"@polkadot/types-known@1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-1.31.1.tgz#cc8923aa9bd880b2e71e855c24e52f521f564bef"
+  integrity sha512-XunXiPsq3nm5TABLIEAeLsSdY234dkXJcAUAK3ZwZQFtBc17+BjZrXQTtgUbG8rAQIDz1hWT12NWsPQTiLFWww==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/types" "1.31.0-beta.25"
+    "@polkadot/types" "1.31.1"
     "@polkadot/util" "^3.4.1"
     bn.js "^5.1.3"
 
-"@polkadot/types@1.31.0-beta.25":
-  version "1.31.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.0-beta.25.tgz#7e6a32fc6c8de09f09a06ebee8f74f3b8b106149"
-  integrity sha512-xJ8xpuYAg97SqULPiSNVhhmnAuBW4jU1BZCQAv5fr25ftwMK7t4nJ8PiAiheaj3QuoGYllrPsj3/VfqjKuo06A==
+"@polkadot/types@1.31.1":
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-1.31.1.tgz#227de8250ca21c9f0ef2b1c94b6c6162aa449a10"
+  integrity sha512-dOHo7NOHjr3w03RjY2uMA8EbisIKx4aIs54aPPoefm9EYO4A1oWb6edUZ6PyrclDLR9easaFWMgYo/GER4wIrA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@polkadot/metadata" "1.31.0-beta.25"
+    "@polkadot/metadata" "1.31.1"
     "@polkadot/util" "^3.4.1"
     "@polkadot/util-crypto" "^3.4.1"
     "@types/bn.js" "^4.11.6"
@@ -4970,9 +4970,9 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.0.tgz#aa714261de793e8a82347a7bcc9ce74e86f28602"
+  integrity sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
   dependencies:
     punycode "^2.1.0"
 


### PR DESCRIPTION
Types: https://github.com/polkadot-js/api/pull/2550

Other changes:
- deprecate `ensureMeta` entirely because `@polkadot/api` now updates registry with metadata automatically Relates to: https://github.com/polkadot-js/api/pull/2545, https://github.com/polkadot-js/api/pull/2534, https://github.com/polkadot-js/api/pull/2535, https://github.com/polkadot-js/api/pull/2543/files, https://github.com/polkadot-js/api/pull/2539
- Update extrinsic and section method in beta `/blocks`
