### PR TITLE
Extract `authorId` without `api.derive.chain.getHeader`

### DIFF
--- a/src/services/v0/v0blocks/BlocksService.ts
+++ b/src/services/v0/v0blocks/BlocksService.ts
@@ -2,8 +2,10 @@ import { ApiPromise } from '@polkadot/api';
 import { Struct } from '@polkadot/types';
 import { GenericCall } from '@polkadot/types';
 import {
+	AccountId,
 	Block,
 	BlockHash,
+	Digest,
 	DispatchInfo,
 	EventRecord,
 	Hash,
@@ -38,17 +40,23 @@ export class BlocksService extends AbstractService {
 	 */
 	async fetchBlock(hash: BlockHash): Promise<IBlock> {
 		const api = await this.ensureMeta(hash);
-		const [{ block }, events, headerDerive] = await Promise.all([
+		const [{ block }, events, validators] = await Promise.all([
 			api.rpc.chain.getBlock(hash),
 			this.fetchEvents(api, hash),
-			api.derive.chain.getHeader(hash),
+			api.query.session.validators.at(hash),
 		]);
 
-		const { parentHash, number, stateRoot, extrinsicsRoot } = block.header;
+		const {
+			parentHash,
+			number,
+			stateRoot,
+			extrinsicsRoot,
+			digest,
+		} = block.header;
 
-		const authorId = headerDerive?.author;
+		const authorId = this.extractAuthor(validators, digest);
 
-		const logs = block.header.digest.logs.map((log) => {
+		const logs = digest.logs.map((log) => {
 			const { type, index, value } = log;
 
 			return { type, index, value };
@@ -408,5 +416,34 @@ export class BlocksService extends AbstractService {
 			callIndex,
 			args: newArgs,
 		};
+	}
+
+	// Almost exact mimic of https://github.com/polkadot-js/api/blob/master/packages/api-derive/src/chain/getHeader.ts#L27
+	// but we save a call to `getHeader` by hardcoding the logic here and using the digest from the blocks header.
+	private extractAuthor(
+		sessionValidators: AccountId[],
+		digest: Digest
+	): AccountId | undefined {
+		const [pitem] = digest.logs.filter(({ type }) => type === 'PreRuntime');
+
+		// extract from the substrate 2.0 PreRuntime digest
+		if (pitem) {
+			const [engine, data] = pitem.asPreRuntime;
+
+			return engine.extractAuthor(data, sessionValidators);
+		} else {
+			const [citem] = digest.logs.filter(
+				({ type }) => type === 'Consensus'
+			);
+
+			// extract author from the consensus (substrate 1.0, digest)
+			if (citem) {
+				const [engine, data] = citem.asConsensus;
+
+				return engine.extractAuthor(data, sessionValidators);
+			}
+		}
+
+		return undefined;
 	}
 }


### PR DESCRIPTION
This pr adds a function that extracts the authorId from the digest logs using the validator set. In doing so we no longer rely on `api.derive.chain.getHeader`. This also results in a slight performance gain and also avoid reliance on the derive method (in cases where it might have issues).