### PR TITLE
Allow opt out of `authorId` field in `/block` response

### DIFF
--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -24,7 +24,7 @@ type SidecarRequestHandler =
 /**
  * Abstract base class for creating controller classes.
  */
-export default abstract class AbstractController<T extends AbstractService> {
+export default abstract class AbstractController<T extends AbstractService | undefined> {
 	private _router: Router = express.Router();
 	constructor(
 		protected api: ApiPromise,

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -24,7 +24,7 @@ type SidecarRequestHandler =
 /**
  * Abstract base class for creating controller classes.
  */
-export default abstract class AbstractController<T extends AbstractService | undefined> {
+export default abstract class AbstractController<T extends AbstractService> {
 	private _router: Router = express.Router();
 	constructor(
 		protected api: ApiPromise,

--- a/src/controllers/v0/v0blocks/BlocksController.ts
+++ b/src/controllers/v0/v0blocks/BlocksController.ts
@@ -12,6 +12,11 @@ import AbstractController from '../../AbstractController';
  * - (Optional) `number`: Block hash or height at which to query. If not provided, queries
  *   finalized head.
  *
+ * Query:
+ * - (Optional) `noAuthor`: If true, skip extra queries and do not include block author in
+ * 		response. This is useful if you want the endpoint to be faster and induce less
+ * 		network traffic.
+ *
  * Returns:
  * - `number`: Block height.
  * - `hash`: The block's hash.
@@ -72,12 +77,17 @@ export default class BlocksController extends AbstractController<
 	 * @param _req Express Request
 	 * @param res Express Response
 	 */
-	private getLatestBlock: RequestHandler = async (_req, res) => {
+	private getLatestBlock: RequestHandler = async (
+		{ query: { noAuthor } },
+		res
+	) => {
 		const hash = await this.api.rpc.chain.getFinalizedHead();
+
+		const noAuthorArg = noAuthor === 'true' ? true : false;
 
 		BlocksController.sanitizedSend(
 			res,
-			await this.service.fetchBlock(hash)
+			await this.service.fetchBlock(hash, noAuthorArg)
 		);
 	};
 
@@ -88,14 +98,16 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getBlockById: RequestHandler<INumberParam> = async (
-		{ params: { number } },
+		{ params: { number }, query: { noAuthor } },
 		res
 	): Promise<void> => {
 		const hash = await this.getHashForBlock(number);
 
+		const noAuthorArg = noAuthor === 'true' ? true : false;
+
 		BlocksController.sanitizedSend(
 			res,
-			await this.service.fetchBlock(hash)
+			await this.service.fetchBlock(hash, noAuthorArg)
 		);
 	};
 }


### PR DESCRIPTION
Example usage:

`localhost:8080/block/3861985?noAuthor=true`

This will eliminate a query to `api.query.session.validators.at(hash)` and thus eliminate some network traffic.