### PR TITLE
Implement `finalized` query param for `blocks/head`

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -267,15 +267,15 @@ paths:
       tags:
       - blocks
       summary: Get the most recently finalized block.
-      description: Returns the most recently finalized block
+      description: Returns the most recently finalized block. Replaces `/block`
+        from versions < v1.0.0.
       operationId: getHeadBlock
       parameters:
       - name: finalized
         in: query
         description: Boolean representing whether or not to get the finalized head.
           If it is not set the value defaults to true. When set to false it will attempt
-          to get the newest known block, which may not be finalized. Replaces `/block`
-          from versions < v1.0.0.
+          to get the newest known block, which may not be finalized.
         required: false
         schema:
           type: boolean

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -18,6 +18,9 @@ import AbstractController from '../AbstractController';
  * 	`docs` property with a string of the events documentation.
  * - (Optional) `extrinsicDocs`: When set to `true`, every extrinsic will have an extra
  * 	`docs` property with a string of the extrinsics documentation.
+ * - (Optional for `/blocks/head`) `finalized`: When set to `false`, it will fetch the head of
+ * 	the node's canon chain, which might not be finalized. When set to `true` it
+ * 	will fetch the head of the finalized chain.
  *
  *
  * Returns:
@@ -81,13 +84,16 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getLatestBlock: RequestHandler = async (
-		{ query: { eventDocs, extrinsicDocs } },
+		{ query: { eventDocs, extrinsicDocs, finalized } },
 		res
 	) => {
-		const hash = await this.api.rpc.chain.getFinalizedHead();
-
 		const eventDocsArg = eventDocs === 'true';
 		const extrsinsicDocsArg = extrinsicDocs === 'true';
+
+		const hash =
+			finalized === 'false'
+				? (await this.api.rpc.chain.getHeader()).hash
+				: await this.api.rpc.chain.getFinalizedHead();
 
 		BlocksController.sanitizedSend(
 			res,


### PR DESCRIPTION
Closes #266 