### PR TITLE
Implement better `/` endpoint

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -7,6 +7,7 @@ import {
 	Response,
 } from 'express';
 
+import * as packageJson from '../package.json';
 import AbstractController from './controllers/AbstractController';
 import { AbstractService } from './services/AbstractService';
 
@@ -39,15 +40,21 @@ export default class App {
 
 		this.initMiddleware(preMiddleware);
 
+		this.initControllers(controllers);
+		this.initRoot();
+		this.initErrorMiddleware(postMiddleware);
+	}
+
+	private initRoot() {
 		// Set up a root route
 		this.app.get('/', (_req: Request, res: Response) =>
-			res.send(
-				'Sidecar is running, go to /block to get latest finalized block'
-			)
+			res.send({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+				routes: this.app._router?.stack,
+				docs: 'https://paritytech.github.io/substrate-api-sidecar/dist',
+				version: packageJson.version,
+			})
 		);
-
-		this.initControllers(controllers);
-		this.initErrorMiddleware(postMiddleware);
 	}
 
 	/**

--- a/src/App.ts
+++ b/src/App.ts
@@ -87,16 +87,17 @@ export default class App {
 		});
 	}
 
+	/**
+	 * Mount the root route.
+	 */
 	private initRoot() {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-
 		// Set up a root route
 		this.app.get('/', (_req: Request, res: Response) =>
 			res.send({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-				routes: this.getRoutes(),
 				docs: 'https://paritytech.github.io/substrate-api-sidecar/dist',
 				version: packageJson.version,
+				listen: `${this.host}:${this.port}`,
+				routes: this.getRoutes(),
 			})
 		);
 	}

--- a/src/types/util/RegisteredRoutes.ts
+++ b/src/types/util/RegisteredRoutes.ts
@@ -1,0 +1,21 @@
+export interface IRouteInfo {
+	path: string;
+	methods: Record<string, boolean>;
+}
+export interface IRegisteredRoutes {
+	stack: IRouterStackMiddleware[];
+}
+
+interface IRouterStackMiddleware {
+	route?: IRouteInfo;
+	name?: string;
+	handle?: IHandle;
+}
+
+interface IHandle {
+	stack: IHandler[];
+}
+
+interface IHandler {
+	route?: IRouteInfo;
+}

--- a/src/types/util/index.ts
+++ b/src/types/util/index.ts
@@ -1,2 +1,3 @@
 export * from './ToString';
 export * from './PaysFee';
+export * from './RegisteredRoutes';


### PR DESCRIPTION
Closes # 256

This PR adds a much more helpful root endpoint, that will hopefully give the user useful information about how to use the service.

Both the github and docs link are hardcoded, while the routes are dynamically generated. I chose to dynamically generate the routes because in the future routes will likely be mounted dependent on the chain sidecar is connected to. It should be noted that in order to grab the mounted routes we have to reach into a private property, so we have no guarantees it will be stable in future releases of Sidecar. Since this is non-critical piece to functionality I think it is an ok trade off, we just need to be mindfully sit it doesn't silently break. 

Follow up TODOs:
- Have github pages read from master branch (cc @dvdplm) 
- Integration tests for this route.
---
Sample response:
```
{
    "docs": "https://paritytech.github.io/substrate-api-sidecar/dist",
    "github": "https://github.com/paritytech/substrate-api-sidecar",
    "version": "0.16.0",
    "listen": "127.0.0.1:8080",
    "routes": [
        {
            "path": "/blocks/head",
            "method": "get"
        },
        {
            "path": "/blocks/:number",
            "method": "get"
        },
        {
            "path": "/accounts/:address/staking-payouts",
            "method": "get"
        },
        {
            "path": "/accounts/:address/balance-info",
            "method": "get"
        },
        {
            "path": "/accounts/:address/staking-info",
            "method": "get"
        },
        {
            "path": "/accounts/:address/vesting-info",
            "method": "get"
        },
        {
            "path": "/node/network",
            "method": "get"
        },
        {
            "path": "/node/version",
            "method": "get"
        },
        {
            "path": "/node/transaction-pool",
            "method": "get"
        },
        {
            "path": "/runtime/code",
            "method": "get"
        },
        {
            "path": "/runtime/spec",
            "method": "get"
        },
        {
            "path": "/runtime/metadata",
            "method": "get"
        },
        {
            "path": "/transaction/dry-run",
            "method": "post"
        },
        {
            "path": "/transaction/material",
            "method": "get"
        },
        {
            "path": "/transaction/fee-estimate",
            "method": "post"
        },
        {
            "path": "/transaction",
            "method": "post"
        },
        {
            "path": "/pallets/staking/progress",
            "method": "get"
        },
        {
            "path": "/claims/:address",
            "method": "get"
        },
        {
            "path": "/claims/:address/:number",
            "method": "get"
        },
        {
            "path": "/tx/artifacts",
            "method": "get"
        },
        {
            "path": "/tx/artifacts/:number",
            "method": "get"
        },
        {
            "path": "/tx/fee-estimate",
            "method": "post"
        },
        {
            "path": "/tx",
            "method": "post"
        },
        {
            "path": "/staking/:address",
            "method": "get"
        },
        {
            "path": "/staking/:address/:number",
            "method": "get"
        },
        {
            "path": "/vesting/:address",
            "method": "get"
        },
        {
            "path": "/vesting/:address/:number",
            "method": "get"
        },
        {
            "path": "/balance/:address",
            "method": "get"
        },
        {
            "path": "/balance/:address/:number",
            "method": "get"
        },
        {
            "path": "/block",
            "method": "get"
        },
        {
            "path": "/block/:number",
            "method": "get"
        },
        {
            "path": "/staking-info",
            "method": "get"
        },
        {
            "path": "/staking-info/:number",
            "method": "get"
        },
        {
            "path": "/metadata",
            "method": "get"
        },
        {
            "path": "/metadata/:number",
            "method": "get"
        },
        {
            "path": "/",
            "method": "get"
        }
    ]
}
```