### PR TITLE
feat: Add `authorId` query param to `/blocks` endpoint

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -251,16 +251,16 @@ paths:
         schema:
           type: boolean
           default: false
-      - name: noAuthor
+      - name: authorId
         in: query
-        description: When set to `true`, there will be no `authorId` in the response
+        description: When set to `false`, there will be no `authorId` in the response
           object. This eliminates an expensive RPC call to the node and thus
-          recommended that this query param be set to `true` if the consumer is 
+          recommended that this query param be set to `false` if the consumer is 
           not using the `authorId`.
         required: false
         schema:
           type: boolean
-          default: false
+          default: true
       responses:
         "200":
           description: successful operation
@@ -308,16 +308,16 @@ paths:
         schema:
           type: boolean
           default: false
-      - name: noAuthor
+      - name: authorId
         in: query
-        description: When set to `true`, there will be no `authorId` in the response
-          object. This eliminates an expensive RPC call to the node and thus it is
-          recommended that this query param be set to `true` if the consumer is
+        description: When set to `false`, there will be no `authorId` in the response
+          object. This eliminates an expensive RPC call to the node and thus
+          recommended that this query param be set to `false` if the consumer is 
           not using the `authorId`.
         required: false
         schema:
           type: boolean
-          default: false
+          default: true
       responses:
         "200":
           description: successful operation

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -242,6 +242,7 @@ paths:
         required: false
         schema:
           type: boolean
+          default: false
       - name: extrinsicDocs
         in: query
         description: When set to `true`, every extrinsic will have an extra `docs`
@@ -249,6 +250,17 @@ paths:
         required: false
         schema:
           type: boolean
+          default: false
+      - name: noAuthor
+        in: query
+        description: When set to `true`, there will be no `authorId` in the response
+          object. This eliminates an expensive RPC call to the node and thus
+          recommended that this query param be set to `true` if the consumer is 
+          not using the `authorId`.
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         "200":
           description: successful operation
@@ -287,6 +299,7 @@ paths:
         required: false
         schema:
           type: boolean
+          default: false
       - name: extrinsicDocs
         in: query
         description: When set to `true`, every extrinsic will have an extra `docs`
@@ -294,6 +307,17 @@ paths:
         required: false
         schema:
           type: boolean
+          default: false
+      - name: noAuthor
+        in: query
+        description: When set to `true`, there will be no `authorId` in the response
+          object. This eliminates an expensive RPC call to the node and thus it is
+          recommended that this query param be set to `true` if the consumer is
+          not using the `authorId`.
+        required: false
+        schema:
+          type: boolean
+          default: false
       responses:
         "200":
           description: successful operation

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -84,11 +84,12 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getLatestBlock: RequestHandler = async (
-		{ query: { eventDocs, extrinsicDocs, finalized } },
+		{ query: { eventDocs, extrinsicDocs, finalized, noAuthor } },
 		res
 	) => {
 		const eventDocsArg = eventDocs === 'true';
 		const extrsinsicDocsArg = extrinsicDocs === 'true';
+		const noAuthorArg = noAuthor === 'true';
 
 		const hash =
 			finalized === 'false'
@@ -97,7 +98,12 @@ export default class BlocksController extends AbstractController<
 
 		BlocksController.sanitizedSend(
 			res,
-			await this.service.fetchBlock(hash, eventDocsArg, extrsinsicDocsArg)
+			await this.service.fetchBlock(
+				hash,
+				eventDocsArg,
+				extrsinsicDocsArg,
+				noAuthorArg
+			)
 		);
 	};
 
@@ -108,20 +114,22 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getBlockById: RequestHandler<INumberParam> = async (
-		{ params: { number }, query: { eventDocs, extrinsicDocs } },
+		{ params: { number }, query: { eventDocs, extrinsicDocs, noAuthor } },
 		res
 	): Promise<void> => {
 		const hash = await this.getHashForBlock(number);
 
 		const eventDocsArg = eventDocs === 'true';
 		const extrinsinsicDocsArg = extrinsicDocs === 'true';
+		const noAuthorArg = noAuthor === 'true';
 
 		BlocksController.sanitizedSend(
 			res,
 			await this.service.fetchBlock(
 				hash,
 				eventDocsArg,
-				extrinsinsicDocsArg
+				extrinsinsicDocsArg,
+				noAuthorArg
 			)
 		);
 	};

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -84,12 +84,12 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getLatestBlock: RequestHandler = async (
-		{ query: { eventDocs, extrinsicDocs, finalized, noAuthor } },
+		{ query: { eventDocs, extrinsicDocs, finalized, authorId } },
 		res
 	) => {
 		const eventDocsArg = eventDocs === 'true';
 		const extrsinsicDocsArg = extrinsicDocs === 'true';
-		const noAuthorArg = noAuthor === 'true';
+		const authorIdArg = authorId !== 'false';
 
 		const hash =
 			finalized === 'false'
@@ -102,7 +102,7 @@ export default class BlocksController extends AbstractController<
 				hash,
 				eventDocsArg,
 				extrsinsicDocsArg,
-				noAuthorArg
+				authorIdArg
 			)
 		);
 	};
@@ -114,14 +114,14 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getBlockById: RequestHandler<INumberParam> = async (
-		{ params: { number }, query: { eventDocs, extrinsicDocs, noAuthor } },
+		{ params: { number }, query: { eventDocs, extrinsicDocs, authorId } },
 		res
 	): Promise<void> => {
 		const hash = await this.getHashForBlock(number);
 
 		const eventDocsArg = eventDocs === 'true';
 		const extrinsinsicDocsArg = extrinsicDocs === 'true';
-		const noAuthorArg = noAuthor === 'true';
+		const authorIdArg = authorId !== 'false';
 
 		BlocksController.sanitizedSend(
 			res,
@@ -129,7 +129,7 @@ export default class BlocksController extends AbstractController<
 				hash,
 				eventDocsArg,
 				extrinsinsicDocsArg,
-				noAuthorArg
+				authorIdArg
 			)
 		);
 	};

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -89,7 +89,7 @@ export default class BlocksController extends AbstractController<
 	) => {
 		const eventDocsArg = eventDocs === 'true';
 		const extrsinsicDocsArg = extrinsicDocs === 'true';
-		const authorIdArg = authorId !== 'false';
+		const includeAuthorId = authorId !== 'false';
 
 		const hash =
 			finalized === 'false'
@@ -102,7 +102,7 @@ export default class BlocksController extends AbstractController<
 				hash,
 				eventDocsArg,
 				extrsinsicDocsArg,
-				authorIdArg
+				includeAuthorId
 			)
 		);
 	};
@@ -121,7 +121,7 @@ export default class BlocksController extends AbstractController<
 
 		const eventDocsArg = eventDocs === 'true';
 		const extrinsinsicDocsArg = extrinsicDocs === 'true';
-		const authorIdArg = authorId !== 'false';
+		const includeAuthorId = authorId !== 'false';
 
 		BlocksController.sanitizedSend(
 			res,
@@ -129,7 +129,7 @@ export default class BlocksController extends AbstractController<
 				hash,
 				eventDocsArg,
 				extrinsinsicDocsArg,
-				authorIdArg
+				includeAuthorId
 			)
 		);
 	};

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -37,7 +37,12 @@ describe('BlocksService', () => {
 		it('works when ApiPromise works (block 789629)', async () => {
 			expect(
 				sanitizeNumbers(
-					await blocksService.fetchBlock(blockHash789629, true, true)
+					await blocksService.fetchBlock(
+						blockHash789629,
+						true,
+						true,
+						false
+					)
 				)
 			).toMatchObject(blocks789629Response);
 		});
@@ -61,7 +66,7 @@ describe('BlocksService', () => {
 				}) as unknown) as GetBlock;
 
 			await expect(
-				blocksService.fetchBlock(blockHash789629, false, false)
+				blocksService.fetchBlock(blockHash789629, false, false, false)
 			).rejects.toThrow(
 				new Error(
 					`Cannot destructure property 'method' of 'extrinsic' as it is undefined.`

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -41,7 +41,7 @@ describe('BlocksService', () => {
 						blockHash789629,
 						true,
 						true,
-						false
+						true
 					)
 				)
 			).toMatchObject(blocks789629Response);
@@ -66,7 +66,7 @@ describe('BlocksService', () => {
 				}) as unknown) as GetBlock;
 
 			await expect(
-				blocksService.fetchBlock(blockHash789629, false, false, false)
+				blocksService.fetchBlock(blockHash789629, false, false, true)
 			).rejects.toThrow(
 				new Error(
 					`Cannot destructure property 'method' of 'extrinsic' as it is undefined.`

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -42,15 +42,24 @@ export class BlocksService extends AbstractService {
 	async fetchBlock(
 		hash: BlockHash,
 		eventDocs: boolean,
-		extrinsicDocs: boolean
+		extrinsicDocs: boolean,
+		noAuthor: boolean
 	): Promise<IBlock> {
 		const { api } = this;
 
-		const [{ block }, events, validators] = await Promise.all([
-			api.rpc.chain.getBlock(hash),
-			this.fetchEvents(api, hash),
-			api.query.session.validators.at(hash),
-		]);
+		let block, events, validators;
+		if (noAuthor) {
+			[{ block }, events] = await Promise.all([
+				api.rpc.chain.getBlock(hash),
+				this.fetchEvents(api, hash),
+			]);
+		} else {
+			[{ block }, events, validators] = await Promise.all([
+				api.rpc.chain.getBlock(hash),
+				this.fetchEvents(api, hash),
+				api.query.session.validators.at(hash),
+			]);
+		}
 
 		const {
 			parentHash,
@@ -60,7 +69,9 @@ export class BlocksService extends AbstractService {
 			digest,
 		} = block.header;
 
-		const authorId = this.extractAuthor(validators, digest);
+		const authorId = validators
+			? this.extractAuthor(validators, digest)
+			: undefined;
 
 		const logs = digest.logs.map((log) => {
 			const { type, index, value } = log;

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -43,21 +43,21 @@ export class BlocksService extends AbstractService {
 		hash: BlockHash,
 		eventDocs: boolean,
 		extrinsicDocs: boolean,
-		noAuthor: boolean
+		includeAuthorId: boolean
 	): Promise<IBlock> {
 		const { api } = this;
 
 		let block, events, validators;
-		if (noAuthor) {
-			[{ block }, events] = await Promise.all([
-				api.rpc.chain.getBlock(hash),
-				this.fetchEvents(api, hash),
-			]);
-		} else {
+		if (includeAuthorId) {
 			[{ block }, events, validators] = await Promise.all([
 				api.rpc.chain.getBlock(hash),
 				this.fetchEvents(api, hash),
 				api.query.session.validators.at(hash),
+			]);
+		} else {
+			[{ block }, events] = await Promise.all([
+				api.rpc.chain.getBlock(hash),
+				this.fetchEvents(api, hash),
 			]);
 		}
 


### PR DESCRIPTION
Closes #288

This PR introduces the ~`noAuthor`~ `authorId` query param to the `/blocks` endpoint. 

For some users the `authorId` field may not be necessary, and since it requires a rather slow RPC query to the validators storage item in the sessions pallet, I believe it makes sense to give the option to opt out of it.

---
Below shows the difference in response times I got when using `noAuthor=true`
```
 📦 SUBSTRATE:
     ✅ WS_URL: "wss://rpc.polkadot.io"
2020-09-18 14:17:23 info: Connected to chain Polkadot on the parity-polkadot client at wss://rpc.polkadot.io
2020-09-18 14:17:23 info: Listening on http://127.0.0.1:8080/
2020-09-18 14:17:25 http: GET /blocks/1603921 200 1408ms
2020-09-18 14:17:31 http: GET /blocks/1603921 200 2009ms
2020-09-18 14:17:35 http: GET /blocks/1603921 200 1346ms
2020-09-18 14:17:37 http: GET /blocks/1603921 200 1322ms
2020-09-18 14:17:39 http: GET /blocks/1603921 200 1326ms
2020-09-18 14:17:55 http: GET /blocks/1603921?noAuthor=true 200 1229ms
2020-09-18 14:17:59 http: GET /blocks/1603921?noAuthor=true 200 1205ms
2020-09-18 14:18:01 http: GET /blocks/1603921?noAuthor=true 200 1256ms
2020-09-18 14:18:04 http: GET /blocks/1603921?noAuthor=true 200 1207ms
2020-09-18 14:18:06 http: GET /blocks/1603921?noAuthor=true 200 1225ms
2020-09-18 14:18:07 http: GET /blocks/1603921?noAuthor=true 200 1196ms
2020-09-18 14:18:14 http: GET /blocks/1603921 200 1375ms
2020-09-18 14:18:16 http: GET /blocks/1603921 200 1673ms
2020-09-18 14:18:19 http: GET /blocks/1603921 200 1358ms
2020-09-18 14:18:21 http: GET /blocks/1603921 200 1362ms
2020-09-18 14:18:23 http: GET /blocks/1603921 200 1651ms
2020-09-18 14:18:25 http: GET /blocks/1603921 200 1337ms
2020-09-18 14:18:28 http: GET /blocks/1603921 200 1318ms
2020-09-18 14:19:02 http: GET /blocks/1603921?noAuthor=true 200 1209ms
2020-09-18 14:19:04 http: GET /blocks/1603921?noAuthor=true 200 1200ms
2020-09-18 14:19:06 http: GET /blocks/1603921?noAuthor=true 200 1195ms
2020-09-18 14:19:08 http: GET /blocks/1603921?noAuthor=true 200 1199ms