### PR TITLE
feat: Remove authorId query param; Bump version in package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ where reviewers will be able to review your changes made.
 -   `yarn lint`: Make sure your code follows our linting rules. You can also run `yarn lint --fix` to
     automatically fix some of those errors.
 -   `yarn test`: Make sure all tests pass.
+-   `yarn build:docs`: If any changes are made to the OpenApi specs make sure to rebuild the UI.
 
 ## Rules
 

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -251,16 +251,6 @@ paths:
         schema:
           type: boolean
           default: false
-      - name: authorId
-        in: query
-        description: When set to `false`, there will be no `authorId` in the response
-          object. This eliminates an expensive RPC call to the node and thus
-          recommended that this query param be set to `false` if the consumer is 
-          not using the `authorId`.
-        required: false
-        schema:
-          type: boolean
-          default: true
       responses:
         "200":
           description: successful operation
@@ -308,16 +298,6 @@ paths:
         schema:
           type: boolean
           default: false
-      - name: authorId
-        in: query
-        description: When set to `false`, there will be no `authorId` in the response
-          object. This eliminates an expensive RPC call to the node and thus
-          recommended that this query param be set to `false` if the consumer is 
-          not using the `authorId`.
-        required: false
-        schema:
-          type: boolean
-          default: true
       responses:
         "200":
           description: successful operation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substrate-api-sidecar",
-  "version": "0.18.0",
+  "version": "v1.0.0-rc1",
   "description": "REST service that makes it easy to interact with blockchain nodes built using Substrate's FRAME framework.",
   "scripts": {
     "preinstall": "yarn build:calc",

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -84,12 +84,11 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getLatestBlock: RequestHandler = async (
-		{ query: { eventDocs, extrinsicDocs, finalized, authorId } },
+		{ query: { eventDocs, extrinsicDocs, finalized } },
 		res
 	) => {
 		const eventDocsArg = eventDocs === 'true';
 		const extrsinsicDocsArg = extrinsicDocs === 'true';
-		const includeAuthorId = authorId !== 'false';
 
 		const hash =
 			finalized === 'false'
@@ -98,12 +97,7 @@ export default class BlocksController extends AbstractController<
 
 		BlocksController.sanitizedSend(
 			res,
-			await this.service.fetchBlock(
-				hash,
-				eventDocsArg,
-				extrsinsicDocsArg,
-				includeAuthorId
-			)
+			await this.service.fetchBlock(hash, eventDocsArg, extrsinsicDocsArg)
 		);
 	};
 
@@ -114,22 +108,20 @@ export default class BlocksController extends AbstractController<
 	 * @param res Express Response
 	 */
 	private getBlockById: RequestHandler<INumberParam> = async (
-		{ params: { number }, query: { eventDocs, extrinsicDocs, authorId } },
+		{ params: { number }, query: { eventDocs, extrinsicDocs } },
 		res
 	): Promise<void> => {
 		const hash = await this.getHashForBlock(number);
 
 		const eventDocsArg = eventDocs === 'true';
 		const extrinsinsicDocsArg = extrinsicDocs === 'true';
-		const includeAuthorId = authorId !== 'false';
 
 		BlocksController.sanitizedSend(
 			res,
 			await this.service.fetchBlock(
 				hash,
 				eventDocsArg,
-				extrinsinsicDocsArg,
-				includeAuthorId
+				extrinsinsicDocsArg
 			)
 		);
 	};

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -37,12 +37,7 @@ describe('BlocksService', () => {
 		it('works when ApiPromise works (block 789629)', async () => {
 			expect(
 				sanitizeNumbers(
-					await blocksService.fetchBlock(
-						blockHash789629,
-						true,
-						true,
-						true
-					)
+					await blocksService.fetchBlock(blockHash789629, true, true)
 				)
 			).toMatchObject(blocks789629Response);
 		});
@@ -66,7 +61,7 @@ describe('BlocksService', () => {
 				}) as unknown) as GetBlock;
 
 			await expect(
-				blocksService.fetchBlock(blockHash789629, false, false, true)
+				blocksService.fetchBlock(blockHash789629, false, false)
 			).rejects.toThrow(
 				new Error(
 					`Cannot destructure property 'method' of 'extrinsic' as it is undefined.`

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -42,24 +42,15 @@ export class BlocksService extends AbstractService {
 	async fetchBlock(
 		hash: BlockHash,
 		eventDocs: boolean,
-		extrinsicDocs: boolean,
-		includeAuthorId: boolean
+		extrinsicDocs: boolean
 	): Promise<IBlock> {
 		const { api } = this;
 
-		let block, events, validators;
-		if (includeAuthorId) {
-			[{ block }, events, validators] = await Promise.all([
-				api.rpc.chain.getBlock(hash),
-				this.fetchEvents(api, hash),
-				api.query.session.validators.at(hash),
-			]);
-		} else {
-			[{ block }, events] = await Promise.all([
-				api.rpc.chain.getBlock(hash),
-				this.fetchEvents(api, hash),
-			]);
-		}
+		const [{ block }, events, validators] = await Promise.all([
+			api.rpc.chain.getBlock(hash),
+			this.fetchEvents(api, hash),
+			api.query.session.validators.at(hash),
+		]);
 
 		const {
 			parentHash,
@@ -69,9 +60,7 @@ export class BlocksService extends AbstractService {
 			digest,
 		} = block.header;
 
-		const authorId = validators
-			? this.extractAuthor(validators, digest)
-			: undefined;
+		const authorId = this.extractAuthor(validators, digest);
 
 		const logs = digest.logs.map((log) => {
 			const { type, index, value } = log;


### PR DESCRIPTION
Removes the authorId query param - it did not makes its way into any release so it is non api breaking. Also bumps the version in package.json to v1.0.0-rc1 in prep for release.