### PR TITLE
feat: Add Public URL notice

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,9 @@ async function main() {
 	const isSecure: boolean = splitUrl[0] === 'wss';
 	// Check if its a local IP.
 	const isLocal: boolean =
-		splitUrl[1] === '//0.0.0.0' || splitUrl[1] === '//127.0.0.1';
+		splitUrl[1] === '//0.0.0.0' ||
+		splitUrl[1] === '//127.0.0.1' ||
+		splitUrl[1] === '//localhost';
 
 	if (!isSecure && !isLocal) {
 		logger.warn(

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,11 @@ async function main() {
 	const { config } = Config;
 
 	const { logger } = Log;
-
+ 
+	/**
+	 * Best effort list of known public nodes that do not encourage high traffic
+	 * sidecar installations connecting to them for non - testing / development purposes.
+	 */
 	const publicWsUrls: string[] = [
 		'wss://rpc.polkadot.io',
 		'wss://cc1-1.polkadot.network',

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,19 @@ async function main() {
 		);
 	}
 
+	// Split the Url to check for 2 things. Secure connection, and if its a local IP. 
+	const splitUrl: string[] = config.SUBSTRATE.WS_URL.split(':');
+	// If its 'ws' its not a secure connection.
+	const isSecure: boolean = splitUrl[0] === 'wss';
+	// Check if its a local IP.
+	const isLocal: boolean = splitUrl[1] === '//0.0.0.0' || splitUrl[1] === '//127.0.0.1';
+
+	if(!isSecure && !isLocal) {
+		logger.warn(
+			`Using unencrypted connection to a public node (${config.SUBSTRATE.WS_URL}); All traffic is sent over the internet in cleartext.`
+		);
+	}
+
 	// Instantiate v0 controllers (note these will be removed upon the release of v1.0.0)
 	const claimsController = new controllers.v0.v0Claims(api);
 	const txArtifactsController = new controllers.v0.v0TransactionMaterial(api);

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,22 @@ async function main() {
 
 	const { logger } = Log;
 
+	const publicWsUrls: string[] = [
+		'wss://rpc.polkadot.io',
+		'wss://cc1-1.polkadot.network',
+		'wss://kusama-rpc.polkadot.io',
+		'wss://cc3-5.kusama.network',
+		'wss://fullnode.centrifuge.io',
+		'wss://crab.darwinia.network',
+		'wss://mainnet-node.dock.io',
+		'wss://mainnet1.edgewa.re',
+		'wss://rpc.kulupu.corepaper.org/ws',
+		'wss://main1.nodleprotocol.io',
+		'wss://rpc.plasmnet.io/',
+		'wss://mainnet-rpc.stafi.io',
+		'wss://rpc.subsocial.network'
+	];
+
 	// Overide console.{log, error, warn, etc}
 	consoleOverride(logger);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,13 +70,14 @@ async function main() {
 		}`
 	);
 
-	const isPublicUrl: string = publicWsUrls.includes(config.SUBSTRATE.WS_URL)
-		? 'PUBLIC'
-		: 'PRIVATE';
+	const isPublicUrl: boolean = publicWsUrls.includes(config.SUBSTRATE.WS_URL);
 
-	logger.info(
-		`[${isPublicUrl} URL] ${config.SUBSTRATE.WS_URL} is a ${isPublicUrl} URL`
-	);
+	if (isPublicUrl) {
+		logger.info(
+			`${config.SUBSTRATE.WS_URL} is a public node. Too many users will 
+			overload this public endpoint. Switch to a privately hosted node when possible.`
+		);
+	}
 
 	// Instantiate v0 controllers (note these will be removed upon the release of v1.0.0)
 	const claimsController = new controllers.v0.v0Claims(api);

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,14 +82,15 @@ async function main() {
 		);
 	}
 
-	// Split the Url to check for 2 things. Secure connection, and if its a local IP. 
+	// Split the Url to check for 2 things. Secure connection, and if its a local IP.
 	const splitUrl: string[] = config.SUBSTRATE.WS_URL.split(':');
 	// If its 'ws' its not a secure connection.
 	const isSecure: boolean = splitUrl[0] === 'wss';
 	// Check if its a local IP.
-	const isLocal: boolean = splitUrl[1] === '//0.0.0.0' || splitUrl[1] === '//127.0.0.1';
+	const isLocal: boolean =
+		splitUrl[1] === '//0.0.0.0' || splitUrl[1] === '//127.0.0.1';
 
-	if(!isSecure && !isLocal) {
+	if (!isSecure && !isLocal) {
 		logger.warn(
 			`Using unencrypted connection to a public node (${config.SUBSTRATE.WS_URL}); All traffic is sent over the internet in cleartext.`
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,12 @@ async function main() {
 		}`
 	);
 
+	const isPublicUrl: string = publicWsUrls.includes(config.SUBSTRATE.WS_URL) ? 'PUBLIC' : 'PRIVATE';
+
+	logger.info(
+		`[${isPublicUrl} URL] ${config.SUBSTRATE.WS_URL} is a ${isPublicUrl} URL`
+	);
+
 	// Instantiate v0 controllers (note these will be removed upon the release of v1.0.0)
 	const claimsController = new controllers.v0.v0Claims(api);
 	const txArtifactsController = new controllers.v0.v0TransactionMaterial(api);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ async function main() {
 	const { config } = Config;
 
 	const { logger } = Log;
- 
+
 	/**
 	 * Best effort list of known public nodes that do not encourage high traffic
 	 * sidecar installations connecting to them for non - testing / development purposes.

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,8 +78,7 @@ async function main() {
 
 	if (isPublicUrl) {
 		logger.info(
-			`${config.SUBSTRATE.WS_URL} is a public node. Too many users will 
-			overload this public endpoint. Switch to a privately hosted node when possible.`
+			`${config.SUBSTRATE.WS_URL} is a public node. Too many users will overload this public endpoint. Switch to a privately hosted node when possible.`
 		);
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ async function main() {
 		'wss://main1.nodleprotocol.io',
 		'wss://rpc.plasmnet.io/',
 		'wss://mainnet-rpc.stafi.io',
-		'wss://rpc.subsocial.network'
+		'wss://rpc.subsocial.network',
 	];
 
 	// Overide console.{log, error, warn, etc}
@@ -70,7 +70,9 @@ async function main() {
 		}`
 	);
 
-	const isPublicUrl: string = publicWsUrls.includes(config.SUBSTRATE.WS_URL) ? 'PUBLIC' : 'PRIVATE';
+	const isPublicUrl: string = publicWsUrls.includes(config.SUBSTRATE.WS_URL)
+		? 'PUBLIC'
+		: 'PRIVATE';
 
 	logger.info(
 		`[${isPublicUrl} URL] ${config.SUBSTRATE.WS_URL} is a ${isPublicUrl} URL`


### PR DESCRIPTION
# What Issue is addressed?
When a user is using a public known url, it is important for them to know they are accessing a public domain, and contributing to the traffic. If they are not using it for testing/development that it is advised to switch nodes. Currently there was no information added to the logger. In addition, when a user is accessing a url that is prefixed with `ws` and is not running on either `0.0.0.0`, `127.0.0.1`, or `localhost` there is no warning that states they are on an unsecure connection. 

# What does this PR do?
In this PR, we are notifying the end user that they are using a public url. If they are not on a public known url it wont say anything. Also, we are adding a warning to the logger that warns the user they are on an unencrypted/unsecure connection if they fulfill the conditions stated above in the issue. 

# Changelog
Add ```const publicWsUrls``` -> An array of all the known public urls.
Add ```const isPublicUrl```     -> Returns a string denoting ```PUBLIC``` or ```PRIVATE```.
Add ```logger.info~```             -> Log the notification of where the url is public or private.

Add ```splitUrl```                     -> Split the ```SUBSTRATE.WS_URL``` by ```:```.
Add ```isSecure```.                 -> Check if its a secure websocket or not.
Add ```isLocal```                     -> Check if the url contains ```0.0.0.0```, ```127.0.0.1```, ```localhost```
Add ```logger.warn```             -> Log a warning is its not secure and not local

# Notes to reviewers
Because the list of known urls is short I have hard coded the values at the top of the ```main``` function in ```src/main.ts```.

closes #163 