### PR TITLE
fix: Find pallets with index 0

### DIFF
--- a/src/services/pallets/PalletsStorageItemService.ts
+++ b/src/services/pallets/PalletsStorageItemService.ts
@@ -134,7 +134,7 @@ export class PalletsStorageItemService extends AbstractService {
 			}
 		}
 
-		if (!palletMeta || !palletIdx) {
+		if (!palletMeta || palletIdx === undefined || palletIdx < 0) {
 			throw new InternalServerError(
 				`Could not find pallet ("${palletId}")in metadata.`
 			);


### PR DESCRIPTION
Previously in `PalletStorageItemService.findPalletMeta`, we checked if the found index was a falsey value (`!palledIdx`), however this check will throw on 0 since it is a falsey value in JS; meaning the user would get an error when trying to retrieve the first pallet. This PR introduces a fix by explicitly checking for undefined or an invalid number.