### PR TITLE
build: Trim npm package with `.npmignore` & remove build stage from start script

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+*.ts
+/src
+/config
+Dockerfile
+docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ yarn
 yarn dev
 
 # To build and run
+yarn build
 yarn start
 ```
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "main": "node ./build/src/main.js",
     "lint": "tsc && eslint . --ext ts",
     "deploy": "yarn build && standard-version",
-    "start": "yarn run build && yarn run main",
+    "start": "yarn run main",
     "start:log-rpc": "yarn run build && NODE_ENV=test yarn run main ",
     "dev": "tsc-watch --onSuccess \"yarn run main\"",
     "test": "jest --silent"


### PR DESCRIPTION
closes #336 

This PR focuses on two changes that should make things smoother for end users

- By adding a `.npmignore`, we remove all the TS files from the npm package and thus reduce the packages size - making it quicker to download and reducing the footprint.

- With the `start` script in the `package.json`, we used to always build the JS target files every time the service was started. While this may ease careless mistakes in development, it makes no sense for end users as the npm package ships with the already built JS and those using github only need to build once per release. This significantly reduces the start up time of the service and may be particularly helpful for those who regularly restart the service with something like cron job