### PR TITLE
fix: Catch errors decoding opaque calls

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -937,7 +937,7 @@ components:
         args:
           type: object
           description: >-
-            Object of arguments keyed by parameter name. Note: if you are expecting a [`OpaqueCall`](https://substrate.dev/rustdocs/v2.0.0/pallet_multisig/type.OpaqueCall.html)
+            Object of arguments keyed by parameter name. Note: if you are expecting an [`OpaqueCall`](https://substrate.dev/rustdocs/v2.0.0/pallet_multisig/type.OpaqueCall.html)
             and it is not decoded in the response (i.e. it is just a hex string), then Sidecar was
             not able to decode it and likely that it is not a valid call for the runtime.
         tip:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -936,7 +936,10 @@ components:
           format: unsignedInteger
         args:
           type: object
-          description: Object of arguments keyed by parameter name.
+          description: >-
+            Object of arguments keyed by parameter name. Note: if you are expecting a [`OpaqueCall`](https://substrate.dev/rustdocs/v2.0.0/pallet_multisig/type.OpaqueCall.html)
+            and it is not decoded in the response (i.e. it is just a hex string), then Sidecar was
+            not able to decode it and likely that it is not a valid call for the runtime.
         tip:
           type: string
           description: Any tip added to the transaction.

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -38,7 +38,7 @@ import AbstractController from '../AbstractController';
  *   - `method`: Extrinsic method.
  *   - `signature`: Object with `signature` and `signer`, or `null` if unsigned.
  *   - `nonce`: Account nonce, if applicable.
- *   - `args`: Array of arguments. Note: if you are expecting a [`OpaqueCall`](https://substrate.dev/rustdocs/v2.0.0/pallet_multisig/type.OpaqueCall.html)
+ *   - `args`: Array of arguments. Note: if you are expecting an [`OpaqueCall`](https://substrate.dev/rustdocs/v2.0.0/pallet_multisig/type.OpaqueCall.html)
  * 			and it is not decoded in the response (i.e. it is just a hex string), then Sidecar was not
  * 			able to decode it and likely that it is not a valid call for the runtime.
  *   - `tip`: Any tip added to the transaction.

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -38,7 +38,9 @@ import AbstractController from '../AbstractController';
  *   - `method`: Extrinsic method.
  *   - `signature`: Object with `signature` and `signer`, or `null` if unsigned.
  *   - `nonce`: Account nonce, if applicable.
- *   - `args`: Array of arguments.
+ *   - `args`: Array of arguments. Note: if you are expecting a [`OpaqueCall`](https://substrate.dev/rustdocs/v2.0.0/pallet_multisig/type.OpaqueCall.html)
+ * 			and it is not decoded in the response (i.e. it is just a hex string), then Sidecar was not
+ * 			able to decode it and likely that it is not a valid call for the runtime.
  *   - `tip`: Any tip added to the transaction.
  *   - `hash`: The transaction's hash.
  *   - `info`: `RuntimeDispatchInfo` for the transaction. Includes the `partialFee`.

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -448,8 +448,18 @@ export class BlocksService extends AbstractService {
 				) {
 					// multiSig.asMulti.args.call is an OpaqueCall (Vec<u8>) that we
 					// serialize to a polkadot-js Call and parse so it is not a hex blob.
-					const call = registry.createType('Call', argument.toHex());
-					newArgs[paramName] = this.parseGenericCall(call, registry);
+					try {
+						const call = registry.createType(
+							'Call',
+							argument.toHex()
+						);
+						newArgs[paramName] = this.parseGenericCall(
+							call,
+							registry
+						);
+					} catch {
+						newArgs[paramName] = argument;
+					}
 				} else {
 					newArgs[paramName] = argument;
 				}


### PR DESCRIPTION
Currently we decode `OpaqueCall`s in order to give more meaningful responses.

Recently, we ran into a scenario where the `OpaqueCall` argument simply appears to be invalid (see #343, https://github.com/polkadot-js/api/issues/2858). In this case the decoding will always fail. 

In the current release the whole endpoint will fail when the `OpaqueCall` is bad. This PR introduces a `catch` for the throw, and will now respond with the raw, hex encoded scale when the decoding fails.