### PR TITLE
fix: Use http BadRequest (400) when balance-info not found

### DIFF
--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -1,4 +1,5 @@
 import { BlockHash } from '@polkadot/types/interfaces';
+import { BadRequest } from 'http-errors';
 import { IAccountBalanceInfo } from 'src/types/responses';
 
 import { AbstractService } from '../AbstractService';
@@ -29,7 +30,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 
 		const at = {
 			hash,
-			height: header.number.toNumber().toString(10),
+			height: header.number.unwrap().toString(10),
 		};
 
 		if (account && locks && sysAccount) {
@@ -46,10 +47,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				locks,
 			};
 		} else {
-			throw {
-				at,
-				error: 'Account not found',
-			};
+			throw new BadRequest('Account not found');
 		}
 	}
 }

--- a/src/services/accounts/AccountsVestingInfoService.ts
+++ b/src/services/accounts/AccountsVestingInfoService.ts
@@ -23,7 +23,7 @@ export class AccountsVestingInfoService extends AbstractService {
 
 		const at = {
 			hash,
-			height: number.toNumber().toString(10),
+			height: number.unwrap().toString(10),
 		};
 
 		return {


### PR DESCRIPTION
Closes #346 

Also uses `.unwrap()` on the `Compact` block number, which should be more idiomatic then using `.toNumber()`.