### PR TITLE
config: Enhance CUSTOM_TYPES to take Object too.

### DIFF
--- a/src/types/config/SidecarConfig.ts
+++ b/src/types/config/SidecarConfig.ts
@@ -1,3 +1,5 @@
+import { AnyJson } from '@polkadot/types/types';
+
 /**
  * Object to house the values of all the configurable components for Sidecar.
  */
@@ -9,7 +11,7 @@ export interface ISidecarConfig {
 
 interface ISidecarConfigSubstrate {
 	WS_URL: string;
-	CUSTOM_TYPES: Record<string, string> | undefined;
+	CUSTOM_TYPES: AnyJson;
 }
 
 interface ISidecarConfigExpress {

--- a/src/types/config/SidecarConfig.ts
+++ b/src/types/config/SidecarConfig.ts
@@ -1,4 +1,4 @@
-import { AnyJson } from '@polkadot/types/types';
+import { RegistryTypes } from '@polkadot/types/types';
 
 /**
  * Object to house the values of all the configurable components for Sidecar.
@@ -11,7 +11,7 @@ export interface ISidecarConfig {
 
 interface ISidecarConfigSubstrate {
 	WS_URL: string;
-	CUSTOM_TYPES: AnyJson;
+	CUSTOM_TYPES: RegistryTypes | undefined;
 }
 
 interface ISidecarConfigExpress {


### PR DESCRIPTION
If a pallet is updating a block with type Object (Record<string, string>),
there is currently no way to provide a structure/Object interface type.
Enhancing the type of the CUSTOM_TYPES to take json object with
`Record<string, string>` type would fix the issues.

Signed-off-by: Amar Tumballi <amar@dhiway.com>