### PR TITLE
typo(env): SAS_EXPRESS_BIND_PORT -> SAS_EXPRESS_PORT in .env.docker

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -8,5 +8,5 @@
 SAS_EXPRESS_BIND_HOST=0.0.0.0
 
 # Port exposed by the container
-SAS_EXPRESS_BIND_PORT=8080
+SAS_EXPRESS_PORT=8080
 


### PR DESCRIPTION
Small typo i noticed that is misleading in .env.docker.

Just wanted to make a first PR for presenting myself before submitting new PRs 😄 