### PR TITLE
fix: Increase node.js stack size in order to decode election solutioins

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:calc": "bash ./calc/build.sh",
     "build:docker": "docker build -t substrate-api-sidecar .",
     "build:docs": "(cd docs && yarn && yarn build)",
-    "main": "node ./build/src/main.js",
+    "main": "node --stack_size=1300 ./build/src/main.js",
     "lint": "tsc && eslint . --ext ts",
     "deploy": "yarn build && standard-version",
     "start": "yarn run main",


### PR DESCRIPTION
closes #389 

The other option is we can just add a note in the README.md pointing people to use `node --stack_size=1300` if they want to decode blocks that contains elections solutions.

lmk if you have thoughts @dvdplm 