### PR TITLE
fix: Revert stack limit increase and use updated polkadot-js/api instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:calc": "bash ./calc/build.sh",
     "build:docker": "docker build -t substrate-api-sidecar .",
     "build:docs": "(cd docs && yarn && yarn build)",
-    "main": "node --stack_size=1300 ./build/src/main.js",
+    "main": "node ./build/src/main.js",
     "lint": "tsc && eslint . --ext ts",
     "deploy": "yarn build && standard-version",
     "start": "yarn run main",
@@ -36,7 +36,7 @@
     "test": "jest --silent"
   },
   "dependencies": {
-    "@polkadot/api": "^3.4.1",
+    "@polkadot/api": "^3.4.2-14",
     "@polkadot/apps-config": "^0.75.1",
     "@polkadot/util-crypto": "^5.2.3",
     "@substrate/calc": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "test": "jest --silent"
   },
   "dependencies": {
-    "@polkadot/api": "^3.4.2-14",
-    "@polkadot/apps-config": "^0.75.1",
-    "@polkadot/util-crypto": "^5.2.3",
+    "@polkadot/api": "^3.5.1",
+    "@polkadot/apps-config": "^0.76.1",
+    "@polkadot/util-crypto": "^5.3.1",
     "@substrate/calc": "^0.1.3",
     "confmgr": "^1.0.6",
     "express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@acala-network/type-definitions@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@acala-network/type-definitions/-/type-definitions-0.6.1.tgz#d850dd030c045e3f49c1b71183e79a624084303f"
-  integrity sha512-bh2e8GkNWhM3qsIpYqZ6ABXxWTokjaCnxCs+X8BKjBlVcuODBEj6Q3VHanTuyvoJVG6SRcUxsHvNm9utzdWHQQ==
+"@acala-network/type-definitions@^0.6.2-7":
+  version "0.6.2-7"
+  resolved "https://registry.yarnpkg.com/@acala-network/type-definitions/-/type-definitions-0.6.2-7.tgz#4a335d831f74999db2ed19d3bd5a1bb3a1b1833c"
+  integrity sha512-01HZuh3qaA1hkj3cmzeg9WJgno8f+a5An3qFwRdJVJyCRtvRqqH5XyB04/oNDfzgQdHPdE6R3LkpTZvGOH8pOA==
   dependencies:
-    "@open-web3/orml-type-definitions" "^0.8.2-4"
+    "@open-web3/orml-type-definitions" "^0.8.2-6"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11":
   version "7.12.11"
@@ -554,256 +554,146 @@
   resolved "https://registry.yarnpkg.com/@open-web3/orml-type-definitions/-/orml-type-definitions-0.6.1.tgz#eb7fadf598f24f5024f5d2a1fd39ccc97c801104"
   integrity sha512-6asf2W/sluGQ6LNiGSdCg/Xop54mq/Q2FcV2Z9cBxys6QC4qXfo4JwUL6kJsRh/vcIIbUxoyGgKUrU/6Xdm7wA==
 
-"@open-web3/orml-type-definitions@^0.8.2-4":
+"@open-web3/orml-type-definitions@^0.8.2-6":
   version "0.8.2-6"
   resolved "https://registry.yarnpkg.com/@open-web3/orml-type-definitions/-/orml-type-definitions-0.8.2-6.tgz#ee1df60a55f9239217948248d402ea76e1c7974b"
   integrity sha512-44GH7qvNKvASOHHkRXWMcEUze58xR5+nkWuAAlMhSEUmQWeX+mlXdORfexGtC3abKvK5QNyCNmyrDcT+DEYb3g==
 
-"@polkadot/api-derive@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-3.4.1.tgz#58cd106fb22461802b85e3297d3977542bce641f"
-  integrity sha512-rkquelXpdUGA6s1eA6Pjyo94kzm+v02hK5AbFwX+miPzMJWPwDgPwHRFe93v9qDmqtjMEyPkuryF72XSIY7lWw==
+"@polkadot/api-derive@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-3.5.1.tgz#8c939caf6662ca6c37f271ae79f9c3c97fc54751"
+  integrity sha512-hZlWc05+td1SikFdKH0v9sTd5lz0s5LF+JHJNA35m07zG3MISEByxGhEbGDtBtCe5k4e8CL9JNgw4GcdGVOKiA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/api" "3.4.1"
-    "@polkadot/rpc-core" "3.4.1"
-    "@polkadot/types" "3.4.1"
-    "@polkadot/util" "^5.2.3"
-    "@polkadot/util-crypto" "^5.2.3"
-    "@polkadot/x-rxjs" "3.4.1"
+    "@polkadot/api" "3.5.1"
+    "@polkadot/rpc-core" "3.5.1"
+    "@polkadot/types" "3.5.1"
+    "@polkadot/util" "^5.3.1"
+    "@polkadot/util-crypto" "^5.3.1"
+    "@polkadot/x-rxjs" "3.5.1"
     bn.js "^4.11.9"
 
-"@polkadot/api-derive@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-3.4.2-14.tgz#ca13760d05042094f285d6d92dbc9150c84c3d73"
-  integrity sha512-KgN81i/F6b8awvbvaNnwemjKmAiqs+VeF7KV07f7BUhfhZI13UCWPAq4YosaDQBJJdML/TiLJM0JhJUUthxX7g==
+"@polkadot/api@3.5.1", "@polkadot/api@^3.2.3", "@polkadot/api@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.5.1.tgz#a03c754107d413520037da13de85a1d1eb409a20"
+  integrity sha512-prnWXjzMBZczpIhnF4dgamWAUOn5V4Fhv/D85QyEcrloiLgC5JBhXgdhDwHcESh+fkw8+gFptkuIMu3emWVaHg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/api" "3.4.2-14"
-    "@polkadot/rpc-core" "3.4.2-14"
-    "@polkadot/types" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    "@polkadot/util-crypto" "^5.2.4-6"
-    "@polkadot/x-rxjs" "3.4.2-14"
-    bn.js "^4.11.9"
-
-"@polkadot/api@3.4.1", "@polkadot/api@^3.2.3":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.4.1.tgz#9f1a2846dd80f184169d87127b8f724aff54e727"
-  integrity sha512-LmlSaOF6QomTAKW96J5MhPgOV8XkH6PClsi5x802G4CKXYYtr65D3CyWsNykpLHFd/h/TTUb+8Cpk3zvSWDg7A==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/api-derive" "3.4.1"
-    "@polkadot/keyring" "^5.2.3"
-    "@polkadot/metadata" "3.4.1"
-    "@polkadot/rpc-core" "3.4.1"
-    "@polkadot/rpc-provider" "3.4.1"
-    "@polkadot/types" "3.4.1"
-    "@polkadot/types-known" "3.4.1"
-    "@polkadot/util" "^5.2.3"
-    "@polkadot/util-crypto" "^5.2.3"
-    "@polkadot/x-rxjs" "3.4.1"
+    "@polkadot/api-derive" "3.5.1"
+    "@polkadot/keyring" "^5.3.1"
+    "@polkadot/metadata" "3.5.1"
+    "@polkadot/rpc-core" "3.5.1"
+    "@polkadot/rpc-provider" "3.5.1"
+    "@polkadot/types" "3.5.1"
+    "@polkadot/types-known" "3.5.1"
+    "@polkadot/util" "^5.3.1"
+    "@polkadot/util-crypto" "^5.3.1"
+    "@polkadot/x-rxjs" "3.5.1"
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/api@3.4.2-14", "@polkadot/api@^3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.4.2-14.tgz#21c274b6140f109c39568bce3ceb293e7e8473fb"
-  integrity sha512-m1JopdXcJHj+I9khsvVr7N7lkHEjbOCLuMGiXz4hqrRrWqPJF49ZnAC6NZx4gM0eMLqWsSlVrG6Mmp3rX1xlhw==
+"@polkadot/apps-config@^0.76.1":
+  version "0.76.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/apps-config/-/apps-config-0.76.1.tgz#d09305dbf626868278d52c150cdc3bde2433332b"
+  integrity sha512-+IGxMYLiYLAmFhP4vZe7QCkevBOHlnJkVM4lDo0mZcr7syi/FoHmmRBirly715k2iX87V1DelqacwvFU+r7y7Q==
   dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/api-derive" "3.4.2-14"
-    "@polkadot/keyring" "^5.2.4-6"
-    "@polkadot/metadata" "3.4.2-14"
-    "@polkadot/rpc-core" "3.4.2-14"
-    "@polkadot/rpc-provider" "3.4.2-14"
-    "@polkadot/types" "3.4.2-14"
-    "@polkadot/types-known" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    "@polkadot/util-crypto" "^5.2.4-6"
-    "@polkadot/x-rxjs" "3.4.2-14"
-    bn.js "^4.11.9"
-    eventemitter3 "^4.0.7"
-
-"@polkadot/apps-config@^0.75.1":
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/apps-config/-/apps-config-0.75.1.tgz#e007c0f0b238f555cab72d3ea03c685b21236c90"
-  integrity sha512-bE8K3jEFn1cglBaSqmE9nV9KKBZ7wiSpgL1n6J/rvaiEd5XSRJX1t/Uq7RkWYru9+f5Q1rMDJ+ujtCt47SRBog==
-  dependencies:
-    "@acala-network/type-definitions" "^0.6.1"
+    "@acala-network/type-definitions" "^0.6.2-7"
     "@babel/runtime" "^7.12.5"
     "@edgeware/node-types" "^3.2.0"
     "@interlay/polkabtc-types" "^0.2.9"
     "@laminar/type-definitions" "^0.2.0-beta.143"
-    "@polkadot/networks" "^5.2.3"
+    "@polkadot/networks" "^5.3.1"
     "@sora-substrate/type-definitions" "^0.3.3"
     "@subsocial/types" "^0.4.28"
     moonbeam-types-bundle "^1.0.5"
 
-"@polkadot/keyring@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-5.2.3.tgz#b555424a553b945893b107d7cf6dd1cf8599465f"
-  integrity sha512-IypWNJkZ+NaaYA/lMNqt1eQu+4Pwmi8KitDWwRaZIqeL8pjHzvoRoUN9qqEU504Ohbbe1Z9OE2CtSK2r41QP9g==
+"@polkadot/keyring@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-5.3.1.tgz#ac523457580acb8fe4946b4250eef368a98e21f6"
+  integrity sha512-wbi1kVxNoxY4hJOcqwHjk+17/aVHGkYzVjASj1QPjNbHVho+KKcjrJVRtUu9ekkblh84sWl9DbcjPwyDDr5F0w==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/util" "5.2.3"
-    "@polkadot/util-crypto" "5.2.3"
+    "@polkadot/util" "5.3.1"
+    "@polkadot/util-crypto" "5.3.1"
 
-"@polkadot/keyring@^5.2.4-6":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-5.2.4-7.tgz#ecdc615f62aa8f686d1b77e0464cdd1b374d7b32"
-  integrity sha512-DkMOKMFsS+8t7SKTixq9sx5csp06sNfDLXT0PWA7D1UAXhzjozkGDVndIYbMPBBJOXYPxsceoSqg4ojKILdmyg==
+"@polkadot/metadata@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.5.1.tgz#b5202b981062db7e742a4107e34a9b20ee2527b3"
+  integrity sha512-pfvV3EvlWmX6zJxsMc3TQlBYFJhmds6PH/gNuxZura4JXSS5ocVPu1JuPq+f31W+D6Yc/tl3+wpVM0cVV0a39A==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/util" "5.2.4-7"
-    "@polkadot/util-crypto" "5.2.4-7"
-
-"@polkadot/metadata@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.4.1.tgz#53144d409e32558995327047e8360beb4df05d3b"
-  integrity sha512-Hk21Fmbty5AqsvzH1dGHdsUlSA0LWGAmzouve2qt9rfB7bwq+rmhuPW09JZwS21rF0XhRSo5Y0MocJL50ZTQ2g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.4.1"
-    "@polkadot/types-known" "3.4.1"
-    "@polkadot/util" "^5.2.3"
-    "@polkadot/util-crypto" "^5.2.3"
+    "@polkadot/types" "3.5.1"
+    "@polkadot/types-known" "3.5.1"
+    "@polkadot/util" "^5.3.1"
+    "@polkadot/util-crypto" "^5.3.1"
     bn.js "^4.11.9"
 
-"@polkadot/metadata@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.4.2-14.tgz#0e241f68d4f7b271a12d345ead171c42979b0025"
-  integrity sha512-NhPrnPwSjR9txQcyL9Feq1DokqhwVBL9dnevpqiBgJYGEWiAjkvcX3mMrtQo3MeyPMgrLjH3AjAF9rRnYmUREQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.4.2-14"
-    "@polkadot/types-known" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    "@polkadot/util-crypto" "^5.2.4-6"
-    bn.js "^4.11.9"
-
-"@polkadot/networks@5.2.3", "@polkadot/networks@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.2.3.tgz#c14de05995636391514220c40f4e0373ffacbaa9"
-  integrity sha512-lDS34KyyIGkxh0Hm8LkZUAB8Rk6BLGd4YeUWy2HyeEj5AvD0t9EC95SMPgMGEfwsmBdF1IWIEV6fL5dnidL94w==
+"@polkadot/networks@5.3.1", "@polkadot/networks@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.3.1.tgz#022d26608361fb2b73d4966a1e4fbb3da551abda"
+  integrity sha512-ilSSPdm7IDKqDzbjRgY7CKwDxCW/2UsOck5TCgDwwZdyRaIsXTQsMDgMqP+jK0rxdEzHSPMvLbnW1uAs7ZWbYA==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/networks@5.2.4-7":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.2.4-7.tgz#fbf82b3982d74aff55db2c5b1359affad92a9edc"
-  integrity sha512-bbEvKJrFNnzeCIPezYrUPAo4sSQYUxyO/0OsXfMSQBvw9gGQpugctKciV6ieoMGH1CAOrEOg6bNZ4EQrD7YFVQ==
+"@polkadot/rpc-core@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-3.5.1.tgz#ada8751efa9458aef29236f8348833cd622180d3"
+  integrity sha512-iVz8hPMU2y0WR0p0fN+v9CYU1wph9sy4DM/PQjm2gAHun2cAFbK4EGOCUdUWZhE6qWvyGgXJrTja2qH/O1oDrg==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@polkadot/metadata" "3.5.1"
+    "@polkadot/rpc-provider" "3.5.1"
+    "@polkadot/types" "3.5.1"
+    "@polkadot/util" "^5.3.1"
+    "@polkadot/x-rxjs" "3.5.1"
 
-"@polkadot/rpc-core@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-3.4.1.tgz#8fcce37bdc8d3ec94e0e3a2cae04182e5b5cdb77"
-  integrity sha512-Wp63rmP6re2FcUnwJ9d97jKPTwsZQnhgecqDP8Sv03Nf+XaUdQ/W0Kb2MzMf+0GhkdK/YZeInp3iypg7B/dLIw==
+"@polkadot/rpc-provider@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.5.1.tgz#b3e2fb2be72266854fdd6921a5f08eca14ff6cb5"
+  integrity sha512-WVPTxVIFv3Lx2fNPHp8uWrUyKixiZDDFffI1nrbZbPeFqzKCmCC56wed0VMrZjmtdFnhQD4M1b4ubV6rHeoACw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "3.4.1"
-    "@polkadot/rpc-provider" "3.4.1"
-    "@polkadot/types" "3.4.1"
-    "@polkadot/util" "^5.2.3"
-    "@polkadot/x-rxjs" "3.4.1"
-
-"@polkadot/rpc-core@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-3.4.2-14.tgz#bc81b7339c7c8985a7c622c4679867e52d138db8"
-  integrity sha512-HDZRmSfgZza/8OcoLYockOYhu7Wbc08vXyjWU0GzkFEu+S/HdRE0lUN0YH36gZniHPOhREJ8GIrpuNexuX2Gsw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "3.4.2-14"
-    "@polkadot/rpc-provider" "3.4.2-14"
-    "@polkadot/types" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    "@polkadot/x-rxjs" "3.4.2-14"
-
-"@polkadot/rpc-provider@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.4.1.tgz#4e2ff56120ed158997c9e2ce8394bde1f32634bf"
-  integrity sha512-8Iy7yBWSQePaFtWAE5Iq4tKR6Flr5epzaKRJwF+7ybnl7WBMiHFMouIGh4/7twB9OswHslF9A2oB2uY17jhD3A==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.4.1"
-    "@polkadot/util" "^5.2.3"
-    "@polkadot/util-crypto" "^5.2.3"
-    "@polkadot/x-fetch" "^5.2.3"
-    "@polkadot/x-ws" "^5.2.3"
+    "@polkadot/types" "3.5.1"
+    "@polkadot/util" "^5.3.1"
+    "@polkadot/util-crypto" "^5.3.1"
+    "@polkadot/x-fetch" "^5.3.1"
+    "@polkadot/x-ws" "^5.3.1"
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/rpc-provider@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.4.2-14.tgz#c6daf3ea06bcb8b017f0c3aa968f730aac3888ca"
-  integrity sha512-qoCbiKWVo7xkysXN/mYHnd1if9m2xSk4v+O0j/7DiWI8Sd1y48bRZ4VEaXx4Mk0LXL0980XPLK+juq6MQaUADg==
+"@polkadot/types-known@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.5.1.tgz#bc32a4ef2f9ed0755ff49e1c480c7201c0eb6053"
+  integrity sha512-km0T1V+aD42A0/NyUy8nE9poEd++5uaNWp7edZg6Gq5XaTWKpHKasHaSXeEOxtrSs0kkXNL1Y8QDX5+9IUAZqA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    "@polkadot/util-crypto" "^5.2.4-6"
-    "@polkadot/x-fetch" "^5.2.4-6"
-    "@polkadot/x-ws" "^5.2.4-6"
-    bn.js "^4.11.9"
-    eventemitter3 "^4.0.7"
-
-"@polkadot/types-known@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.4.1.tgz#36000957f3a781867622cc92d7019403b042822f"
-  integrity sha512-1bE9iatJb912QNyEXJrxV/TMI3vfStpQPCSu+9HZJSkONG/qfLJH9xPHJjYnYOJVDlM8tA1JldTGjaQyuEb+jg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.4.1"
-    "@polkadot/util" "^5.2.3"
+    "@polkadot/types" "3.5.1"
+    "@polkadot/util" "^5.3.1"
     bn.js "^4.11.9"
 
-"@polkadot/types-known@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.4.2-14.tgz#04f001283abd37f935ed6b7c9d46b271f403a52f"
-  integrity sha512-EhrKNaPQjyluga5gkFz/JuEhOZFvHcX1NgrsMi2+diR6U93+I06fyadUooOa0cOS2xpWp0yudYtGFEXGFLHUoQ==
+"@polkadot/types@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.5.1.tgz#d23b9f80beb15ee9be7bb3ab21ed531dbe2a14d9"
+  integrity sha512-oeENgaPNwaNGZSvjO/PN2gyDUiPv4MMoEkwhFkO0spuMsbXZ+5oGRbSkAY09uNlo2Hv2pzfXaUDrQ0j+DwSBbg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    bn.js "^4.11.9"
-
-"@polkadot/types@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.4.1.tgz#75e1df78a0230b55985755f3b29af5750067c193"
-  integrity sha512-GAQxqukU4Ey6LtnyXQiaRaZS4xi8ku3ISLn9/RbRVppdZpjdiv4ehD9Xas3uYiiYkp4OVR9ccZtusK0KCiZKmg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "3.4.1"
-    "@polkadot/util" "^5.2.3"
-    "@polkadot/util-crypto" "^5.2.3"
-    "@polkadot/x-rxjs" "3.4.1"
+    "@polkadot/metadata" "3.5.1"
+    "@polkadot/util" "^5.3.1"
+    "@polkadot/util-crypto" "^5.3.1"
+    "@polkadot/x-rxjs" "3.5.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
 
-"@polkadot/types@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.4.2-14.tgz#de6dea5fb219e3c9d9c2c8e8412559ded7d472cc"
-  integrity sha512-qVEt3SanMlysXtQD9tvpQTtqiP04zELYSU1+LpQF5MiLoYh5k2kSkoQTlpLNcxNg3cIBYocVYDKpMMm2TxKz/g==
+"@polkadot/util-crypto@5.3.1", "@polkadot/util-crypto@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-5.3.1.tgz#46b65b708281664ffd9462cce7e33bb161c2f1c3"
+  integrity sha512-bZRKbgyshpgTxoLDwRPAGJHmxs76N6Wv4Bl13NK+MyTUy5s66M7q7n2CJ2hSgHMDTzanwmge1JMSXpC5ujPieg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "3.4.2-14"
-    "@polkadot/util" "^5.2.4-6"
-    "@polkadot/util-crypto" "^5.2.4-6"
-    "@polkadot/x-rxjs" "3.4.2-14"
-    "@types/bn.js" "^4.11.6"
-    bn.js "^4.11.9"
-
-"@polkadot/util-crypto@5.2.3", "@polkadot/util-crypto@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-5.2.3.tgz#36dd46c6a494da36a6994d92a93f7974d47b1a4f"
-  integrity sha512-gU52s/TDhr48L9QMMCNyb5pRRwmc2TRC8aVpcBGklOY0gOUzAliZP8P8NpLAjQJuPINwYh3aPhQtbB0PVn0ONA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/networks" "5.2.3"
-    "@polkadot/util" "5.2.3"
+    "@polkadot/networks" "5.3.1"
+    "@polkadot/util" "5.3.1"
     "@polkadot/wasm-crypto" "^3.1.1"
-    "@polkadot/x-randomvalues" "5.2.3"
+    "@polkadot/x-randomvalues" "5.3.1"
     base-x "^3.0.8"
     blakejs "^1.1.0"
     bn.js "^4.11.9"
@@ -815,48 +705,14 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util-crypto@5.2.4-7", "@polkadot/util-crypto@^5.2.4-6":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-5.2.4-7.tgz#bcad5938a46f2997d93a924deda09e3b61a37ba2"
-  integrity sha512-HZj/IQHI6r2nHJt2yg+WciJ8s4eBgujg/n7vTqFdBurV9te4u6+2WDba7/OCKuzGvEmtaDd0Lh77XgcGsIw7hA==
+"@polkadot/util@5.3.1", "@polkadot/util@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.3.1.tgz#b2adada572d92ae6fa4600d3ca0598f06b27cd88"
+  integrity sha512-JhXA71kGwlLPj3a7+lGuT3Kgp6Au/UEItnHXLMWdbmlLaWCPhdG5CKrkk/e4yH9VynPDZSyiSOxRgipGiNo8PA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/networks" "5.2.4-7"
-    "@polkadot/util" "5.2.4-7"
-    "@polkadot/wasm-crypto" "^3.1.1"
-    "@polkadot/x-randomvalues" "5.2.4-7"
-    base-x "^3.0.8"
-    blakejs "^1.1.0"
-    bn.js "^4.11.9"
-    create-hash "^1.2.0"
-    elliptic "^6.5.3"
-    hash.js "^1.1.7"
-    js-sha3 "^0.8.0"
-    scryptsy "^2.1.0"
-    tweetnacl "^1.0.3"
-    xxhashjs "^0.2.2"
-
-"@polkadot/util@5.2.3", "@polkadot/util@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.2.3.tgz#843712ca10456c1036b3a3cc01281709e5e58e97"
-  integrity sha512-5DC+iaSxLpwYluE3R1RIGqegxSU6PnmdyoPiAVC5ZNj31C8fE3U7E7lQguoeX4/2dIjaPC6zAbYLSAGLMjfxgA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/x-textdecoder" "5.2.3"
-    "@polkadot/x-textencoder" "5.2.3"
-    "@types/bn.js" "^4.11.6"
-    bn.js "^4.11.9"
-    camelcase "^5.3.1"
-    ip-regex "^4.2.0"
-
-"@polkadot/util@5.2.4-7", "@polkadot/util@^5.2.4-6":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.2.4-7.tgz#d465a27a4118e78312921b769990fb7f73e51b04"
-  integrity sha512-+sciDrmJO0GMA7AaN91ywN/moWv3m5WRs9tWvpmn2SfUsAPq32TdHaV3zaAOE3fb5e2Bbf0DkXled5a1yJW2vQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@polkadot/x-textdecoder" "5.2.4-7"
-    "@polkadot/x-textencoder" "5.2.4-7"
+    "@polkadot/x-textdecoder" "5.3.1"
+    "@polkadot/x-textencoder" "5.3.1"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
     camelcase "^5.3.1"
@@ -885,95 +741,48 @@
     "@polkadot/wasm-crypto-asmjs" "^3.1.1"
     "@polkadot/wasm-crypto-wasm" "^3.1.1"
 
-"@polkadot/x-fetch@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-5.2.3.tgz#ab12c9a941548e9b25f8f12ae98ccb4a6adc937c"
-  integrity sha512-hnIqryERejKKHRk429i1S9cyCuwnO8LkTJV7daEMoSQnQDQp8C1bmXW9WkN1UwwlbjBdYL3w7sSyU1Lp2akgAQ==
+"@polkadot/x-fetch@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-5.3.1.tgz#f446b6eabc49fcb9b65ffc113362e280f1930cd3"
+  integrity sha512-MoHQrazcEEpEZHbnkBdXWI2CGcNczqcJYWzwnCPLqHamLGgJrwgCQSYdqdYASV+PHukN0/odDWbfiHLbVBvYew==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/node-fetch" "^2.5.7"
+    "@types/node-fetch" "^2.5.8"
     node-fetch "^2.6.1"
 
-"@polkadot/x-fetch@^5.2.4-6":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-5.2.4-7.tgz#258dd86c02d502108f7302feb4e652b5611ae089"
-  integrity sha512-J4nw4msPSyvHdLZMHqCKAMrdNSonz8ovlernMfxCVNDAo5t5hWb46QJqVFWAmuk99J/kQrwqBtZfiwfnOAbR2A==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@types/node-fetch" "^2.5.7"
-    node-fetch "^2.6.1"
-
-"@polkadot/x-randomvalues@5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.2.3.tgz#139fbddf8a0dbc2be050a487c9850314afe94bdc"
-  integrity sha512-P8nJ0Q2ePOazazYSb2HHvBFSjHuS+aQFcEzNVayVa4DEZ4seisK6Qrzy1fAqiSvrmz8H4/Tuga9UoHVASwUILw==
+"@polkadot/x-randomvalues@5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.3.1.tgz#6a9c83807ad7c2d83dd003dbc2f2abb3b82925bb"
+  integrity sha512-Hf6vYUKBKFR0dMaeBJ+btb6YOCe606zrH9DYbGiKmoKrIfMth+LRw8J9ml8a0q2DOTTfnhpUV3bSdDSBpqb8hA==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/x-randomvalues@5.2.4-7":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.2.4-7.tgz#5fc34936c55f1067bb983d43d0a5eab4f728d01e"
-  integrity sha512-cIBd0EPZWw/gWJdtnuQZDg/cdb3i9vCX0mGKZoL9vS7fX/IO9ZzMz/u7tIYwLPQiyFVqsjimYpCnDn+cbGWQkA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
-"@polkadot/x-rxjs@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-3.4.1.tgz#3ac08a473b81163c0d1a9f1a0782b1c01c1ee80b"
-  integrity sha512-X1o1S9zcLWj2HamQGeYKK9V10vmqcJlJgq8i+wm+i3mDvVf9lMk1JMuviNCAQeFSPS+XAT6dtjkLmc1Iaiu2AQ==
+"@polkadot/x-rxjs@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-3.5.1.tgz#8383e39c661dd0dffe2620358615a82e7eb5df34"
+  integrity sha512-LW8KPhqQltzmhhC3HMvIDaQfrR7OSj7JFWVYTrN0GAuPX89pQKak6j98oUd2dWiYSZxEXwD0e6MH5yBTqsAtEw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     rxjs "^6.6.3"
 
-"@polkadot/x-rxjs@3.4.2-14":
-  version "3.4.2-14"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-3.4.2-14.tgz#a249bee7080725730abb1f9ec5868e902d482ba8"
-  integrity sha512-iJl7WQn5AHPDchaTli8HuKvDro/LwrAQSwEbiCP40241XFSE5jMIQGheVZuW2v8wmuIfSkTdjcAKRPgavUUzxA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    rxjs "^6.6.3"
-
-"@polkadot/x-textdecoder@5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.2.3.tgz#479a4f56ecab14ec6ddf006f02238a598694a2b4"
-  integrity sha512-fqDSm+kzzRPPhSG3H/tpngf4WtkEhkdESXcOGlr0oychvY2WP2kjBiVBIBJlg5SuAGj2CmBGnk1nYWxO5JW8bQ==
+"@polkadot/x-textdecoder@5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.3.1.tgz#d2ea208f90105138763787ba1b53bd6191f1cfcb"
+  integrity sha512-ACt0mO2b1exfWwzgl711xR6Vlciy7cM8qhaD01AnIv/DxWdHQL2dluwFv3Er5663WM9k2QTf/7WamNOt2GyYmQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/x-textdecoder@5.2.4-7":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.2.4-7.tgz#ec8c6e825cea55bc2f4031099de58f749a73df84"
-  integrity sha512-fETUGsb3qbPtzKYJkdlEKJ94XEHSdcF0SE5MBMACDhqYiMyqk5WCDB89nW8UJSTVc2rW1p3AcgAK+obBpipd3Q==
+"@polkadot/x-textencoder@5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-5.3.1.tgz#8b92fa4d6aeb61f4131c8bf5d97053523b705acd"
+  integrity sha512-I3Sc5fPicJVidk88Lsa7Y8QLWPMHsNIUu5MHrqbjNOEgq+blu8UHC/foUgUo+uWxhJsWgIO+eZXVNAmAwMep4w==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/x-textencoder@5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-5.2.3.tgz#40d2cd2a9bc4adb3304e5ae9e04a27d670b85edc"
-  integrity sha512-TVwbU8A42pCRw15+X3uBMvp2GzQeF9LOFeqwXS5KZ899O+LoDqKpbmqySB1Qs+IncnWqMxO+Z1rQs6JnCpfh9w==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
-"@polkadot/x-textencoder@5.2.4-7":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-5.2.4-7.tgz#73a58198f7bcaffa4acdcd79366d4a2df987c4dd"
-  integrity sha512-hS5W14wxkWb9pOZbXEcgu8vIPBCiUuI74z6RSAxPjYXNoEshQKqDuzh1B3Eo0wz7wfVrlOROniQ+BbzBXFXbpg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
-"@polkadot/x-ws@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.2.3.tgz#288db6106df6f3e6258d9bd6ea19fb0064b38cda"
-  integrity sha512-IA8HyrYIWShi+PeeYQWCp+E6pMDOSPZGza63+6r+CF+XbIFsaUZKBgYWkTt5OVsrhnAM2RtkQjtsiPgwG1P3Mg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@types/websocket" "^1.0.1"
-    websocket "^1.0.33"
-
-"@polkadot/x-ws@^5.2.4-6":
-  version "5.2.4-7"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.2.4-7.tgz#3c60719455ebe8399ee51eb6ace3e50b11b6d757"
-  integrity sha512-hDgtcyWllEXG+Yts8LAWI/ZabMZr4Gk3cuo/NAA9ZGKgMDKUslfnE3fXmz8Y54NU1QosWVBU9aD3TrY9gspcZA==
+"@polkadot/x-ws@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.3.1.tgz#ea9fe3bac5b4f1bd7a6320991fbc209c5215da6e"
+  integrity sha512-7nw0xqXWHJftoLDu7kbkCj1vo3eW0NE/xiqMxo1/Dc+mi1HJALz+PU5LvOmc6kdrQU46agTH4Cz2vFwXjlFKPg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/websocket" "^1.0.1"
@@ -994,9 +803,9 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@sora-substrate/type-definitions@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sora-substrate/type-definitions/-/type-definitions-0.3.3.tgz#8aa7e05d90339805aa689c2caeac0df7c9c459f6"
-  integrity sha512-rOVpjb5dexjM7JEcOxiGXNuMKMtYEuYd5wSZLiG0OkUfVjXfZu1pMfJwPT3bkXwRElyXnooNDhW3XhBrpkvJHQ==
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@sora-substrate/type-definitions/-/type-definitions-0.3.5.tgz#362e2671f80ccd0b5b8f41819a653ad769db0898"
+  integrity sha512-PJrxBR297RryHi0y9pFsXZE5EvzJpERtZ2NoQyazhEXKovK3GhS/MNN3tScD5SsjSE0MVpAdvTzE0Ad5b8+2kg==
   dependencies:
     "@open-web3/orml-type-definitions" "^0.6.0-beta.26"
 
@@ -1144,10 +953,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/mime@*":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
-  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
 "@types/minimist@^1.2.0":
   version "1.2.1"
@@ -1161,7 +970,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-fetch@^2.5.7":
+"@types/node-fetch@^2.5.8":
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
   integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
@@ -1195,11 +1004,11 @@
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/serve-static@*":
-  version "1.13.8"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz#851129d434433c7082148574ffec263d58309c46"
-  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
+  version "1.13.9"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.9.tgz#aacf28a85a05ee29a11fb7c3ead935ac56f33e4e"
+  integrity sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==
   dependencies:
-    "@types/mime" "*"
+    "@types/mime" "^1"
     "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
@@ -2917,9 +2726,9 @@ fast-diff@^1.1.2:
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
-  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -5158,9 +4967,9 @@ parse-json@^4.0.0:
     json-parse-better-errors "^1.0.1"
 
 parse-json@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"
-  integrity sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     error-ex "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,10 +313,10 @@
   resolved "https://registry.yarnpkg.com/@edgeware/node-types/-/node-types-3.2.0.tgz#fdc6d049b2d361ef8b80ef61fed5b6a447a3571b"
   integrity sha512-uhjncXI+B89nCq1dtFWOuPq9/dmuQZziMMCV0i6rzetPyN/ibdn0lCNMl5rPpPP4WKDNT+hAgxhKipEaRlbiJw==
 
-"@eslint/eslintrc@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
-  integrity sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==
+"@eslint/eslintrc@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
+  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -325,14 +325,14 @@
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
 "@interlay/polkabtc-types@^0.2.9":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@interlay/polkabtc-types/-/polkabtc-types-0.2.12.tgz#8b6a189345ef188fe49380813a873d40ef841e08"
-  integrity sha512-Rj1Rt3HH6G4xEF4yl4FQQPwk1f1TGWcYhKq/5zDRy/JrE1tIXNNnJtjs5nJzdAxm9OZ/qFSIg5KUYyWgcAGr0g==
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@interlay/polkabtc-types/-/polkabtc-types-0.2.15.tgz#8feb13097ac10dc46227de7c80b637984bba7d1b"
+  integrity sha512-ec537TvD8THo+8sir1yC+rHQSSrc9DHFM7582vGdECgSksxWDNFgpiGhw2scytKhJV9KvUZbmjqFhcqVlDXftQ==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -555,9 +555,9 @@
   integrity sha512-6asf2W/sluGQ6LNiGSdCg/Xop54mq/Q2FcV2Z9cBxys6QC4qXfo4JwUL6kJsRh/vcIIbUxoyGgKUrU/6Xdm7wA==
 
 "@open-web3/orml-type-definitions@^0.8.2-4":
-  version "0.8.2-5"
-  resolved "https://registry.yarnpkg.com/@open-web3/orml-type-definitions/-/orml-type-definitions-0.8.2-5.tgz#f65b000affdb207a71f35adc9a7d10a8141a6eb7"
-  integrity sha512-o/o7ucy4RkuQ5oZgGMBc7t7UuaTK/+rG6QHE7+ZPCRG6cnYzg6ZZ9pApOTmzG0e47k0GUZDg0m+IYzltgwJRMQ==
+  version "0.8.2-6"
+  resolved "https://registry.yarnpkg.com/@open-web3/orml-type-definitions/-/orml-type-definitions-0.8.2-6.tgz#ee1df60a55f9239217948248d402ea76e1c7974b"
+  integrity sha512-44GH7qvNKvASOHHkRXWMcEUze58xR5+nkWuAAlMhSEUmQWeX+mlXdORfexGtC3abKvK5QNyCNmyrDcT+DEYb3g==
 
 "@polkadot/api-derive@3.4.1":
   version "3.4.1"
@@ -573,7 +573,21 @@
     "@polkadot/x-rxjs" "3.4.1"
     bn.js "^4.11.9"
 
-"@polkadot/api@3.4.1", "@polkadot/api@^3.2.3", "@polkadot/api@^3.4.1":
+"@polkadot/api-derive@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-3.4.2-14.tgz#ca13760d05042094f285d6d92dbc9150c84c3d73"
+  integrity sha512-KgN81i/F6b8awvbvaNnwemjKmAiqs+VeF7KV07f7BUhfhZI13UCWPAq4YosaDQBJJdML/TiLJM0JhJUUthxX7g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/api" "3.4.2-14"
+    "@polkadot/rpc-core" "3.4.2-14"
+    "@polkadot/types" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
+    "@polkadot/util-crypto" "^5.2.4-6"
+    "@polkadot/x-rxjs" "3.4.2-14"
+    bn.js "^4.11.9"
+
+"@polkadot/api@3.4.1", "@polkadot/api@^3.2.3":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.4.1.tgz#9f1a2846dd80f184169d87127b8f724aff54e727"
   integrity sha512-LmlSaOF6QomTAKW96J5MhPgOV8XkH6PClsi5x802G4CKXYYtr65D3CyWsNykpLHFd/h/TTUb+8Cpk3zvSWDg7A==
@@ -589,6 +603,25 @@
     "@polkadot/util" "^5.2.3"
     "@polkadot/util-crypto" "^5.2.3"
     "@polkadot/x-rxjs" "3.4.1"
+    bn.js "^4.11.9"
+    eventemitter3 "^4.0.7"
+
+"@polkadot/api@3.4.2-14", "@polkadot/api@^3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.4.2-14.tgz#21c274b6140f109c39568bce3ceb293e7e8473fb"
+  integrity sha512-m1JopdXcJHj+I9khsvVr7N7lkHEjbOCLuMGiXz4hqrRrWqPJF49ZnAC6NZx4gM0eMLqWsSlVrG6Mmp3rX1xlhw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/api-derive" "3.4.2-14"
+    "@polkadot/keyring" "^5.2.4-6"
+    "@polkadot/metadata" "3.4.2-14"
+    "@polkadot/rpc-core" "3.4.2-14"
+    "@polkadot/rpc-provider" "3.4.2-14"
+    "@polkadot/types" "3.4.2-14"
+    "@polkadot/types-known" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
+    "@polkadot/util-crypto" "^5.2.4-6"
+    "@polkadot/x-rxjs" "3.4.2-14"
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
@@ -616,6 +649,15 @@
     "@polkadot/util" "5.2.3"
     "@polkadot/util-crypto" "5.2.3"
 
+"@polkadot/keyring@^5.2.4-6":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-5.2.4-7.tgz#ecdc615f62aa8f686d1b77e0464cdd1b374d7b32"
+  integrity sha512-DkMOKMFsS+8t7SKTixq9sx5csp06sNfDLXT0PWA7D1UAXhzjozkGDVndIYbMPBBJOXYPxsceoSqg4ojKILdmyg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/util" "5.2.4-7"
+    "@polkadot/util-crypto" "5.2.4-7"
+
 "@polkadot/metadata@3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.4.1.tgz#53144d409e32558995327047e8360beb4df05d3b"
@@ -628,10 +670,29 @@
     "@polkadot/util-crypto" "^5.2.3"
     bn.js "^4.11.9"
 
+"@polkadot/metadata@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.4.2-14.tgz#0e241f68d4f7b271a12d345ead171c42979b0025"
+  integrity sha512-NhPrnPwSjR9txQcyL9Feq1DokqhwVBL9dnevpqiBgJYGEWiAjkvcX3mMrtQo3MeyPMgrLjH3AjAF9rRnYmUREQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/types" "3.4.2-14"
+    "@polkadot/types-known" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
+    "@polkadot/util-crypto" "^5.2.4-6"
+    bn.js "^4.11.9"
+
 "@polkadot/networks@5.2.3", "@polkadot/networks@^5.2.3":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.2.3.tgz#c14de05995636391514220c40f4e0373ffacbaa9"
   integrity sha512-lDS34KyyIGkxh0Hm8LkZUAB8Rk6BLGd4YeUWy2HyeEj5AvD0t9EC95SMPgMGEfwsmBdF1IWIEV6fL5dnidL94w==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@polkadot/networks@5.2.4-7":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.2.4-7.tgz#fbf82b3982d74aff55db2c5b1359affad92a9edc"
+  integrity sha512-bbEvKJrFNnzeCIPezYrUPAo4sSQYUxyO/0OsXfMSQBvw9gGQpugctKciV6ieoMGH1CAOrEOg6bNZ4EQrD7YFVQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -647,6 +708,18 @@
     "@polkadot/util" "^5.2.3"
     "@polkadot/x-rxjs" "3.4.1"
 
+"@polkadot/rpc-core@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-3.4.2-14.tgz#bc81b7339c7c8985a7c622c4679867e52d138db8"
+  integrity sha512-HDZRmSfgZza/8OcoLYockOYhu7Wbc08vXyjWU0GzkFEu+S/HdRE0lUN0YH36gZniHPOhREJ8GIrpuNexuX2Gsw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/metadata" "3.4.2-14"
+    "@polkadot/rpc-provider" "3.4.2-14"
+    "@polkadot/types" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
+    "@polkadot/x-rxjs" "3.4.2-14"
+
 "@polkadot/rpc-provider@3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.4.1.tgz#4e2ff56120ed158997c9e2ce8394bde1f32634bf"
@@ -661,6 +734,20 @@
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
+"@polkadot/rpc-provider@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.4.2-14.tgz#c6daf3ea06bcb8b017f0c3aa968f730aac3888ca"
+  integrity sha512-qoCbiKWVo7xkysXN/mYHnd1if9m2xSk4v+O0j/7DiWI8Sd1y48bRZ4VEaXx4Mk0LXL0980XPLK+juq6MQaUADg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/types" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
+    "@polkadot/util-crypto" "^5.2.4-6"
+    "@polkadot/x-fetch" "^5.2.4-6"
+    "@polkadot/x-ws" "^5.2.4-6"
+    bn.js "^4.11.9"
+    eventemitter3 "^4.0.7"
+
 "@polkadot/types-known@3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.4.1.tgz#36000957f3a781867622cc92d7019403b042822f"
@@ -669,6 +756,16 @@
     "@babel/runtime" "^7.12.5"
     "@polkadot/types" "3.4.1"
     "@polkadot/util" "^5.2.3"
+    bn.js "^4.11.9"
+
+"@polkadot/types-known@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.4.2-14.tgz#04f001283abd37f935ed6b7c9d46b271f403a52f"
+  integrity sha512-EhrKNaPQjyluga5gkFz/JuEhOZFvHcX1NgrsMi2+diR6U93+I06fyadUooOa0cOS2xpWp0yudYtGFEXGFLHUoQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/types" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
     bn.js "^4.11.9"
 
 "@polkadot/types@3.4.1":
@@ -681,6 +778,19 @@
     "@polkadot/util" "^5.2.3"
     "@polkadot/util-crypto" "^5.2.3"
     "@polkadot/x-rxjs" "3.4.1"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^4.11.9"
+
+"@polkadot/types@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.4.2-14.tgz#de6dea5fb219e3c9d9c2c8e8412559ded7d472cc"
+  integrity sha512-qVEt3SanMlysXtQD9tvpQTtqiP04zELYSU1+LpQF5MiLoYh5k2kSkoQTlpLNcxNg3cIBYocVYDKpMMm2TxKz/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/metadata" "3.4.2-14"
+    "@polkadot/util" "^5.2.4-6"
+    "@polkadot/util-crypto" "^5.2.4-6"
+    "@polkadot/x-rxjs" "3.4.2-14"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
 
@@ -705,6 +815,27 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
+"@polkadot/util-crypto@5.2.4-7", "@polkadot/util-crypto@^5.2.4-6":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-5.2.4-7.tgz#bcad5938a46f2997d93a924deda09e3b61a37ba2"
+  integrity sha512-HZj/IQHI6r2nHJt2yg+WciJ8s4eBgujg/n7vTqFdBurV9te4u6+2WDba7/OCKuzGvEmtaDd0Lh77XgcGsIw7hA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/networks" "5.2.4-7"
+    "@polkadot/util" "5.2.4-7"
+    "@polkadot/wasm-crypto" "^3.1.1"
+    "@polkadot/x-randomvalues" "5.2.4-7"
+    base-x "^3.0.8"
+    blakejs "^1.1.0"
+    bn.js "^4.11.9"
+    create-hash "^1.2.0"
+    elliptic "^6.5.3"
+    hash.js "^1.1.7"
+    js-sha3 "^0.8.0"
+    scryptsy "^2.1.0"
+    tweetnacl "^1.0.3"
+    xxhashjs "^0.2.2"
+
 "@polkadot/util@5.2.3", "@polkadot/util@^5.2.3":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.2.3.tgz#843712ca10456c1036b3a3cc01281709e5e58e97"
@@ -713,6 +844,19 @@
     "@babel/runtime" "^7.12.5"
     "@polkadot/x-textdecoder" "5.2.3"
     "@polkadot/x-textencoder" "5.2.3"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^4.11.9"
+    camelcase "^5.3.1"
+    ip-regex "^4.2.0"
+
+"@polkadot/util@5.2.4-7", "@polkadot/util@^5.2.4-6":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.2.4-7.tgz#d465a27a4118e78312921b769990fb7f73e51b04"
+  integrity sha512-+sciDrmJO0GMA7AaN91ywN/moWv3m5WRs9tWvpmn2SfUsAPq32TdHaV3zaAOE3fb5e2Bbf0DkXled5a1yJW2vQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/x-textdecoder" "5.2.4-7"
+    "@polkadot/x-textencoder" "5.2.4-7"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
     camelcase "^5.3.1"
@@ -750,10 +894,26 @@
     "@types/node-fetch" "^2.5.7"
     node-fetch "^2.6.1"
 
+"@polkadot/x-fetch@^5.2.4-6":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-5.2.4-7.tgz#258dd86c02d502108f7302feb4e652b5611ae089"
+  integrity sha512-J4nw4msPSyvHdLZMHqCKAMrdNSonz8ovlernMfxCVNDAo5t5hWb46QJqVFWAmuk99J/kQrwqBtZfiwfnOAbR2A==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/node-fetch" "^2.5.7"
+    node-fetch "^2.6.1"
+
 "@polkadot/x-randomvalues@5.2.3":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.2.3.tgz#139fbddf8a0dbc2be050a487c9850314afe94bdc"
   integrity sha512-P8nJ0Q2ePOazazYSb2HHvBFSjHuS+aQFcEzNVayVa4DEZ4seisK6Qrzy1fAqiSvrmz8H4/Tuga9UoHVASwUILw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@polkadot/x-randomvalues@5.2.4-7":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.2.4-7.tgz#5fc34936c55f1067bb983d43d0a5eab4f728d01e"
+  integrity sha512-cIBd0EPZWw/gWJdtnuQZDg/cdb3i9vCX0mGKZoL9vS7fX/IO9ZzMz/u7tIYwLPQiyFVqsjimYpCnDn+cbGWQkA==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -765,10 +925,25 @@
     "@babel/runtime" "^7.12.5"
     rxjs "^6.6.3"
 
+"@polkadot/x-rxjs@3.4.2-14":
+  version "3.4.2-14"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-3.4.2-14.tgz#a249bee7080725730abb1f9ec5868e902d482ba8"
+  integrity sha512-iJl7WQn5AHPDchaTli8HuKvDro/LwrAQSwEbiCP40241XFSE5jMIQGheVZuW2v8wmuIfSkTdjcAKRPgavUUzxA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    rxjs "^6.6.3"
+
 "@polkadot/x-textdecoder@5.2.3":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.2.3.tgz#479a4f56ecab14ec6ddf006f02238a598694a2b4"
   integrity sha512-fqDSm+kzzRPPhSG3H/tpngf4WtkEhkdESXcOGlr0oychvY2WP2kjBiVBIBJlg5SuAGj2CmBGnk1nYWxO5JW8bQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@polkadot/x-textdecoder@5.2.4-7":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.2.4-7.tgz#ec8c6e825cea55bc2f4031099de58f749a73df84"
+  integrity sha512-fETUGsb3qbPtzKYJkdlEKJ94XEHSdcF0SE5MBMACDhqYiMyqk5WCDB89nW8UJSTVc2rW1p3AcgAK+obBpipd3Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -779,10 +954,26 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@polkadot/x-textencoder@5.2.4-7":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-5.2.4-7.tgz#73a58198f7bcaffa4acdcd79366d4a2df987c4dd"
+  integrity sha512-hS5W14wxkWb9pOZbXEcgu8vIPBCiUuI74z6RSAxPjYXNoEshQKqDuzh1B3Eo0wz7wfVrlOROniQ+BbzBXFXbpg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@polkadot/x-ws@^5.2.3":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.2.3.tgz#288db6106df6f3e6258d9bd6ea19fb0064b38cda"
   integrity sha512-IA8HyrYIWShi+PeeYQWCp+E6pMDOSPZGza63+6r+CF+XbIFsaUZKBgYWkTt5OVsrhnAM2RtkQjtsiPgwG1P3Mg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/websocket" "^1.0.1"
+    websocket "^1.0.33"
+
+"@polkadot/x-ws@^5.2.4-6":
+  version "5.2.4-7"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.2.4-7.tgz#3c60719455ebe8399ee51eb6ace3e50b11b6d757"
+  integrity sha512-hDgtcyWllEXG+Yts8LAWI/ZabMZr4Gk3cuo/NAA9ZGKgMDKUslfnE3fXmz8Y54NU1QosWVBU9aD3TrY9gspcZA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/websocket" "^1.0.1"
@@ -2449,12 +2640,12 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.17.0:
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.17.0.tgz#4ccda5bf12572ad3bf760e6f195886f50569adb0"
-  integrity sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.18.0.tgz#7fdcd2f3715a41fe6295a16234bd69aed2c75e67"
+  integrity sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.2"
+    "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -2478,7 +2669,7 @@ eslint@^7.17.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"


### PR DESCRIPTION
Closes #392 
Reverts #390

**N.B.** this has build issues due to `tsc` complaining of conflicting types. I _think_ this is because we are using a beta of polkadot-js/api and that makes lining up the versioning of packages harder. Once polkadot-js/api has its non-beta release monday we should be able to just update this branch, double check it on the polkadot `/blocks/3337808`.