### PR TITLE
fix!: Update polkadot-js/api and account for chainProperties updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "test": "jest --silent"
   },
   "dependencies": {
-    "@polkadot/api": "^3.5.1",
-    "@polkadot/apps-config": "^0.76.1",
-    "@polkadot/util-crypto": "^5.3.1",
+    "@polkadot/api": "^3.6.4",
+    "@polkadot/apps-config": "^0.77.1",
+    "@polkadot/util-crypto": "^5.4.4",
     "@substrate/calc": "^0.1.3",
     "confmgr": "^1.0.6",
     "express": "^4.17.1",
@@ -53,8 +53,8 @@
     "@types/jest": "^26.0.20",
     "@types/morgan": "^1.9.2",
     "@types/triple-beam": "^1.3.2",
-    "@typescript-eslint/eslint-plugin": "4.14.0",
-    "@typescript-eslint/parser": "4.14.0",
+    "@typescript-eslint/eslint-plugin": "4.14.1",
+    "@typescript-eslint/parser": "4.14.1",
     "eslint": "^7.17.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^3.3.1",

--- a/src/controllers/accounts/AccountsBalanceInfoController.ts
+++ b/src/controllers/accounts/AccountsBalanceInfoController.ts
@@ -68,7 +68,8 @@ export default class AccountsBalanceController extends AbstractController<Accoun
 		const tokenArg =
 			typeof token === 'string'
 				? token.toUpperCase()
-				: this.api.registry.chainTokens[0];
+				: // We assume the first token is the native token
+				  this.api.registry.chainTokens[0].toUpperCase();
 
 		const hash = await this.getHashFromAt(at);
 

--- a/src/controllers/accounts/AccountsBalanceInfoController.ts
+++ b/src/controllers/accounts/AccountsBalanceInfoController.ts
@@ -68,7 +68,7 @@ export default class AccountsBalanceController extends AbstractController<Accoun
 		const tokenArg =
 			typeof token === 'string'
 				? token.toUpperCase()
-				: this.api.registry.chainToken;
+				: this.api.registry.chainTokens[0];
 
 		const hash = await this.getHashFromAt(at);
 

--- a/src/services/accounts/AccountsBalanceInfoService.spec.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.spec.ts
@@ -1,7 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { AccountInfo, Address, Hash } from '@polkadot/types/interfaces';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
@@ -25,37 +24,90 @@ describe('AccountsBalanceInfoService', () => {
 			).toStrictEqual(accountsBalanceInfo789629);
 		});
 
-		it('does not change the casing of non-native tokens', async () => {
-			// `temp` should just be `undefined` but to future proof this it is safer
-			// to reassign this back to what ever it was at the start of the test (see
-			// last line of this test)
-			const temp = mockApi.query.tokens;
+		describe('token recognization', () => {
+			let tempQueryTokens: any,
+				tempQueryBalance: any,
+				mockTokensLocksAt: jest.Mock<any>,
+				mockTokenAccountAt: jest.Mock<any>,
+				mockBalancesLocksAt: jest.Mock<any>;
+			beforeAll(() => {
+				// Import: these temp values should never be reassinged. These are used
+				// so we can assign these back to there orignal values after this sub-section
+				// of tests run.
+				tempQueryTokens = mockApi.query.tokens;
+				tempQueryBalance = mockApi.query.balances;
 
-			const tokensAccountAt = async (
-				hash: Hash,
-				address: Address
-			): Promise<any> =>
-				(((await mockApi.query.system.account.at(
-					hash,
-					address
-				)) as unknown) as AccountInfo).data;
-			mockApi.query.tokens = {
-				locks: { at: mockApi.query.balances.locks.at },
-				accounts: { at: tokensAccountAt },
-			} as any;
+				const tokensAccountAt = async (
+					hash: Hash,
+					address: Address
+				): Promise<any> =>
+					(((await mockApi.query.system.account.at(
+						hash,
+						address
+					)) as unknown) as AccountInfo).data;
+				// Wrap our functions in a jest mock so we can collect data on how they where called
+				mockTokensLocksAt = jest.fn(mockApi.query.balances.locks.at);
+				mockTokenAccountAt = jest.fn(tokensAccountAt);
+				mockApi.query.tokens = {
+					locks: { at: mockTokensLocksAt },
+					accounts: { at: mockTokenAccountAt },
+				} as any;
 
-			expect(
-				(sanitizeNumbers(
-					await accountsBalanceInfoService.fetchAccountBalanceInfo(
-						blockHash789629,
-						testAddress,
-						'ausd'
-					)
-				) as any).tokenSymbol
-			).toEqual('ausd');
+				mockBalancesLocksAt = jest.fn(mockApi.query.balances.locks.at);
+				mockApi.query.balances = {
+					locks: { at: mockBalancesLocksAt },
+				} as any;
+			});
 
-			// Cleanup
-			mockApi.query.tokens = temp;
+			afterEach(() => {
+				// Clear data about how the mocks where called after each `it` test.
+				mockTokensLocksAt.mockClear();
+				mockTokenAccountAt.mockClear();
+				mockBalancesLocksAt.mockClear();
+			});
+
+			afterAll(() => {
+
+				mockApi.query.tokens = tempQueryTokens;
+				mockApi.query.balances = tempQueryBalance;
+			});
+
+			it('only has `DOT` (all uppercase) for the mockApi registry', () => {
+				expect(mockApi.registry.chainTokens).toStrictEqual(['DOT']);
+				expect(mockApi.registry.chainDecimals).toStrictEqual([12]);
+			});
+
+			it('querrys tokens pallet storage with a non-native token', async () => {
+				expect(
+					(sanitizeNumbers(
+						await accountsBalanceInfoService.fetchAccountBalanceInfo(
+							blockHash789629,
+							testAddress,
+							'fOoToKeN'
+						)
+					) as any).tokenSymbol
+				).toEqual('fOoToKeN');
+
+				expect(mockTokensLocksAt).toBeCalled();
+				expect(mockTokenAccountAt).toBeCalled();
+				expect(mockBalancesLocksAt).not.toBeCalled();
+			});
+
+			it('does not query tokens pallet storage with the native token', async () => {
+				expect(
+					(sanitizeNumbers(
+						await accountsBalanceInfoService.fetchAccountBalanceInfo(
+							blockHash789629,
+							testAddress,
+							'doT'
+						)
+					) as any).tokenSymbol
+				).toEqual('doT');
+
+				expect(mockTokensLocksAt).not.toBeCalled();
+				expect(mockTokenAccountAt).not.toBeCalled();
+				expect(mockBalancesLocksAt).toBeCalled();
+			});
 		});
 	});
 });

--- a/src/services/accounts/AccountsBalanceInfoService.spec.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.spec.ts
@@ -31,9 +31,8 @@ describe('AccountsBalanceInfoService', () => {
 				mockTokenAccountAt: jest.Mock<any>,
 				mockBalancesLocksAt: jest.Mock<any>;
 			beforeAll(() => {
-				// Import: these temp values should never be reassinged. These are used
-				// so we can assign these back to there orignal values after this sub-section
-				// of tests run.
+				// Important: these temp values should never be reassinged. They are used so we can assign
+				// the mockApi properties back to there orignal values after this sub-section of tests run.
 				tempQueryTokens = mockApi.query.tokens;
 				tempQueryBalance = mockApi.query.balances;
 
@@ -45,7 +44,7 @@ describe('AccountsBalanceInfoService', () => {
 						hash,
 						address
 					)) as unknown) as AccountInfo).data;
-				// Wrap our functions in a jest mock so we can collect data on how they where called
+				// Wrap our functions in a jest mock so we can collect data on how they are called
 				mockTokensLocksAt = jest.fn(mockApi.query.balances.locks.at);
 				mockTokenAccountAt = jest.fn(tokensAccountAt);
 				mockApi.query.tokens = {
@@ -67,12 +66,11 @@ describe('AccountsBalanceInfoService', () => {
 			});
 
 			afterAll(() => {
-
 				mockApi.query.tokens = tempQueryTokens;
 				mockApi.query.balances = tempQueryBalance;
 			});
 
-			it('only has `DOT` (all uppercase) for the mockApi registry', () => {
+			it('only has `["DOT"]` (all uppercase chars) for the mockApi registry', () => {
 				expect(mockApi.registry.chainTokens).toStrictEqual(['DOT']);
 				expect(mockApi.registry.chainDecimals).toStrictEqual([12]);
 			});

--- a/src/services/accounts/AccountsBalanceInfoService.spec.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.spec.ts
@@ -1,3 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { AccountInfo, Address, Hash } from '@polkadot/types/interfaces';
+
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { blockHash789629, mockApi, testAddress } from '../test-helpers/mock';
 import * as accountsBalanceInfo789629 from '../test-helpers/responses/accounts/balanceInfo789629.json';
@@ -17,6 +23,39 @@ describe('AccountsBalanceInfoService', () => {
 					)
 				)
 			).toStrictEqual(accountsBalanceInfo789629);
+		});
+
+		it('does not change the casing of non-native tokens', async () => {
+			// `temp` should just be `undefined` but to future proof this it is safer
+			// to reassign this back to what ever it was at the start of the test (see
+			// last line of this test)
+			const temp = mockApi.query.tokens;
+
+			const tokensAccountAt = async (
+				hash: Hash,
+				address: Address
+			): Promise<any> =>
+				(((await mockApi.query.system.account.at(
+					hash,
+					address
+				)) as unknown) as AccountInfo).data;
+			mockApi.query.tokens = {
+				locks: { at: mockApi.query.balances.locks.at },
+				accounts: { at: tokensAccountAt },
+			} as any;
+
+			expect(
+				(sanitizeNumbers(
+					await accountsBalanceInfoService.fetchAccountBalanceInfo(
+						blockHash789629,
+						testAddress,
+						'ausd'
+					)
+				) as any).tokenSymbol
+			).toEqual('ausd');
+
+			// Cleanup
+			mockApi.query.tokens = temp;
 		});
 	});
 });

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -26,7 +26,8 @@ export class AccountsBalanceInfoService extends AbstractService {
 		const { api } = this;
 
 		let locks, header, accountInfo, accountData;
-		if (token === api.registry.chainToken) {
+		// We assume the first token is the native token
+		if (token === api.registry.chainTokens[0]) {
 			[header, locks, accountInfo] = await Promise.all([
 				api.rpc.chain.getHeader(hash),
 				api.query.balances.locks.at(hash, address),

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -27,7 +27,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 
 		let locks, header, accountInfo, accountData;
 		// We assume the first token is the native token
-		if (token === api.registry.chainTokens[0]) {
+		if (token === api.registry.chainTokens[0].toUpperCase()) {
 			[header, locks, accountInfo] = await Promise.all([
 				api.rpc.chain.getHeader(hash),
 				api.query.balances.locks.at(hash, address),

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -27,7 +27,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 
 		let locks, header, accountInfo, accountData;
 		// We assume the first token is the native token
-		if (token === api.registry.chainTokens[0].toUpperCase()) {
+		if (token.toUpperCase() === api.registry.chainTokens[0].toUpperCase()) {
 			[header, locks, accountInfo] = await Promise.all([
 				api.rpc.chain.getHeader(hash),
 				api.query.balances.locks.at(hash, address),

--- a/src/services/test-helpers/mock/index.ts
+++ b/src/services/test-helpers/mock/index.ts
@@ -1,16 +1,4 @@
-import { Hash } from '@polkadot/types/interfaces';
-import { Codec, CodecArg } from '@polkadot/types/types';
-
 export * from './addresses';
 export * from './mockApi';
 export * from './mockBlock789629';
 export * from './transactions';
-
-/**
- * Convience type for type casting mockApi storage querys.
- */
-export type PolkadotStorageQuery = <T extends unknown = Codec>(
-	hash: string | Hash | Uint8Array,
-	arg1?: CodecArg,
-	arg2?: CodecArg
-) => Promise<T>;

--- a/src/services/test-helpers/mock/index.ts
+++ b/src/services/test-helpers/mock/index.ts
@@ -1,4 +1,16 @@
+import { Hash } from '@polkadot/types/interfaces';
+import { Codec, CodecArg } from '@polkadot/types/types';
+
 export * from './addresses';
 export * from './mockApi';
 export * from './mockBlock789629';
 export * from './transactions';
+
+/**
+ * Convience type for type casting mockApi storage querys.
+ */
+export type PolkadotStorageQuery = <T extends unknown = Codec>(
+	hash: string | Hash | Uint8Array,
+	arg1?: CodecArg,
+	arg2?: CodecArg
+) => Promise<T>;

--- a/src/services/test-helpers/responses/runtime/spec.json
+++ b/src/services/test-helpers/responses/runtime/spec.json
@@ -13,7 +13,7 @@
   },
   "properties": {
     "ss58Format": "0",
-    "tokenDecimals": "12",
-    "tokenSymbol": "DOT"
+    "tokenDecimals": ["12"],
+    "tokenSymbol": ["DOT"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,9 +309,9 @@
     kuler "^2.0.0"
 
 "@edgeware/node-types@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@edgeware/node-types/-/node-types-3.2.0.tgz#fdc6d049b2d361ef8b80ef61fed5b6a447a3571b"
-  integrity sha512-uhjncXI+B89nCq1dtFWOuPq9/dmuQZziMMCV0i6rzetPyN/ibdn0lCNMl5rPpPP4WKDNT+hAgxhKipEaRlbiJw==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@edgeware/node-types/-/node-types-3.3.0.tgz#ac651114a5a815d6a7192d9242623527bd65b2ab"
+  integrity sha512-JK0bVxmuqDiolErPFFHINJiFW5Z5+mk44esJZDgvI1CsSGF/MTHS/oq0Hv/SlJfGSQV/Xk1et0bSeQETF6LBpQ==
 
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
@@ -329,10 +329,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@interlay/polkabtc-types@^0.2.9":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@interlay/polkabtc-types/-/polkabtc-types-0.2.15.tgz#8feb13097ac10dc46227de7c80b637984bba7d1b"
-  integrity sha512-ec537TvD8THo+8sir1yC+rHQSSrc9DHFM7582vGdECgSksxWDNFgpiGhw2scytKhJV9KvUZbmjqFhcqVlDXftQ==
+"@interlay/polkabtc-types@^0.3.1":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@interlay/polkabtc-types/-/polkabtc-types-0.3.4.tgz#256d1c75e62775469c0a7a05f3a847d8f84d53ed"
+  integrity sha512-WMvDwhdYo+Q835EnZYhdunNUkfjBa8+WfkPqU09059XEVbXQWiy19X5EFU10gOtLu1wtK26EC8Y8LljTfMYrJw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -559,141 +559,142 @@
   resolved "https://registry.yarnpkg.com/@open-web3/orml-type-definitions/-/orml-type-definitions-0.8.2-6.tgz#ee1df60a55f9239217948248d402ea76e1c7974b"
   integrity sha512-44GH7qvNKvASOHHkRXWMcEUze58xR5+nkWuAAlMhSEUmQWeX+mlXdORfexGtC3abKvK5QNyCNmyrDcT+DEYb3g==
 
-"@polkadot/api-derive@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-3.5.1.tgz#8c939caf6662ca6c37f271ae79f9c3c97fc54751"
-  integrity sha512-hZlWc05+td1SikFdKH0v9sTd5lz0s5LF+JHJNA35m07zG3MISEByxGhEbGDtBtCe5k4e8CL9JNgw4GcdGVOKiA==
+"@polkadot/api-derive@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-3.6.4.tgz#806f1cc61ec474bb53374088c1f510c4ba07da86"
+  integrity sha512-AOdJnQxqNnjKay4F788xHYJqpsSjJV8n+zSLfXY8Fm9nMj2wPZ2y/C6k4zpZDQN1kHetYHpzVt77cVONJladvg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/api" "3.5.1"
-    "@polkadot/rpc-core" "3.5.1"
-    "@polkadot/types" "3.5.1"
-    "@polkadot/util" "^5.3.1"
-    "@polkadot/util-crypto" "^5.3.1"
-    "@polkadot/x-rxjs" "3.5.1"
+    "@polkadot/api" "3.6.4"
+    "@polkadot/rpc-core" "3.6.4"
+    "@polkadot/types" "3.6.4"
+    "@polkadot/util" "^5.4.4"
+    "@polkadot/util-crypto" "^5.4.4"
+    "@polkadot/x-rxjs" "^5.4.4"
     bn.js "^4.11.9"
 
-"@polkadot/api@3.5.1", "@polkadot/api@^3.2.3", "@polkadot/api@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.5.1.tgz#a03c754107d413520037da13de85a1d1eb409a20"
-  integrity sha512-prnWXjzMBZczpIhnF4dgamWAUOn5V4Fhv/D85QyEcrloiLgC5JBhXgdhDwHcESh+fkw8+gFptkuIMu3emWVaHg==
+"@polkadot/api@3.6.4", "@polkadot/api@^3.2.3", "@polkadot/api@^3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.6.4.tgz#a7b02eb0f4c2a98b087003edc1c2f7ed4bea077a"
+  integrity sha512-jsbBoL99OtBazGyufab9zkC1ORYdvrqzs5tHhLkhUl9zNrDBHyLVawyYNPXAyejtwLl3RMAWMMpnarDjlmjwPQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/api-derive" "3.5.1"
-    "@polkadot/keyring" "^5.3.1"
-    "@polkadot/metadata" "3.5.1"
-    "@polkadot/rpc-core" "3.5.1"
-    "@polkadot/rpc-provider" "3.5.1"
-    "@polkadot/types" "3.5.1"
-    "@polkadot/types-known" "3.5.1"
-    "@polkadot/util" "^5.3.1"
-    "@polkadot/util-crypto" "^5.3.1"
-    "@polkadot/x-rxjs" "3.5.1"
+    "@polkadot/api-derive" "3.6.4"
+    "@polkadot/keyring" "^5.4.4"
+    "@polkadot/metadata" "3.6.4"
+    "@polkadot/rpc-core" "3.6.4"
+    "@polkadot/rpc-provider" "3.6.4"
+    "@polkadot/types" "3.6.4"
+    "@polkadot/types-known" "3.6.4"
+    "@polkadot/util" "^5.4.4"
+    "@polkadot/util-crypto" "^5.4.4"
+    "@polkadot/x-rxjs" "^5.4.4"
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/apps-config@^0.76.1":
-  version "0.76.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/apps-config/-/apps-config-0.76.1.tgz#d09305dbf626868278d52c150cdc3bde2433332b"
-  integrity sha512-+IGxMYLiYLAmFhP4vZe7QCkevBOHlnJkVM4lDo0mZcr7syi/FoHmmRBirly715k2iX87V1DelqacwvFU+r7y7Q==
+"@polkadot/apps-config@^0.77.1":
+  version "0.77.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/apps-config/-/apps-config-0.77.1.tgz#50e98e627a6b58692bf1abd6c9200d17a962e65c"
+  integrity sha512-CVaZF7pQjq0OfCzP+7lGdF8evRLGHWNz/DrMdCcXAPSoFZymNxIu+F7gJk8MzBNAO/9pBjRNgWZWlz+yp7inQQ==
   dependencies:
     "@acala-network/type-definitions" "^0.6.2-7"
     "@babel/runtime" "^7.12.5"
     "@edgeware/node-types" "^3.2.0"
-    "@interlay/polkabtc-types" "^0.2.9"
+    "@interlay/polkabtc-types" "^0.3.1"
     "@laminar/type-definitions" "^0.2.0-beta.143"
-    "@polkadot/networks" "^5.3.1"
-    "@sora-substrate/type-definitions" "^0.3.3"
+    "@polkadot/networks" "^5.4.4"
+    "@sora-substrate/type-definitions" "^0.3.5"
     "@subsocial/types" "^0.4.28"
-    moonbeam-types-bundle "^1.0.5"
+    moonbeam-types-bundle "^1.0.6"
 
-"@polkadot/keyring@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-5.3.1.tgz#ac523457580acb8fe4946b4250eef368a98e21f6"
-  integrity sha512-wbi1kVxNoxY4hJOcqwHjk+17/aVHGkYzVjASj1QPjNbHVho+KKcjrJVRtUu9ekkblh84sWl9DbcjPwyDDr5F0w==
+"@polkadot/keyring@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-5.4.4.tgz#422596dba927c7a546ff7bd97dd92f5885efeaeb"
+  integrity sha512-ozruLiecfjAwUDeoAg6wMWVTRtSVRRUVg7JSiDHjxw/0V6kmtWepe839krZSnYOGkGUUg946Gd3iu4wEq+8f6g==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/util" "5.3.1"
-    "@polkadot/util-crypto" "5.3.1"
+    "@polkadot/util" "5.4.4"
+    "@polkadot/util-crypto" "5.4.4"
 
-"@polkadot/metadata@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.5.1.tgz#b5202b981062db7e742a4107e34a9b20ee2527b3"
-  integrity sha512-pfvV3EvlWmX6zJxsMc3TQlBYFJhmds6PH/gNuxZura4JXSS5ocVPu1JuPq+f31W+D6Yc/tl3+wpVM0cVV0a39A==
+"@polkadot/metadata@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-3.6.4.tgz#033dad14d962c14b61cbcbfe5db7ef9700a4e771"
+  integrity sha512-EPxpiRnaqUvySLyasAXRJk7lb7YS0xvRuLHDaMIuoPpjtr1TqXxvhH4q/VjzjHpXTtriAVPczNydD+NtKYXDiQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.5.1"
-    "@polkadot/types-known" "3.5.1"
-    "@polkadot/util" "^5.3.1"
-    "@polkadot/util-crypto" "^5.3.1"
+    "@polkadot/types" "3.6.4"
+    "@polkadot/types-known" "3.6.4"
+    "@polkadot/util" "^5.4.4"
+    "@polkadot/util-crypto" "^5.4.4"
     bn.js "^4.11.9"
 
-"@polkadot/networks@5.3.1", "@polkadot/networks@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.3.1.tgz#022d26608361fb2b73d4966a1e4fbb3da551abda"
-  integrity sha512-ilSSPdm7IDKqDzbjRgY7CKwDxCW/2UsOck5TCgDwwZdyRaIsXTQsMDgMqP+jK0rxdEzHSPMvLbnW1uAs7ZWbYA==
+"@polkadot/networks@5.4.4", "@polkadot/networks@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-5.4.4.tgz#e1160d2c544a5e3489ea4711cf81a2293ed3130f"
+  integrity sha512-D0e7I77X4wkIJ/G9kkjz8pLauekGdGkKjYLj3W5wZEZKMcFDQy+wYdH3LKf0n+Ni77DZ7SIuqJVKfAk+wXPWVA==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/rpc-core@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-3.5.1.tgz#ada8751efa9458aef29236f8348833cd622180d3"
-  integrity sha512-iVz8hPMU2y0WR0p0fN+v9CYU1wph9sy4DM/PQjm2gAHun2cAFbK4EGOCUdUWZhE6qWvyGgXJrTja2qH/O1oDrg==
+"@polkadot/rpc-core@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-3.6.4.tgz#d436e0d1d65d3cbd9b1e437f1827e3cf8a26089b"
+  integrity sha512-TzsmERRELrqB6mbf23GxLVObDhxInTrdSWkmle4a3qKXgAPfuGlEhxpqiaMMQZjo4LVHCeXStUc18VCHVY17ag==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "3.5.1"
-    "@polkadot/rpc-provider" "3.5.1"
-    "@polkadot/types" "3.5.1"
-    "@polkadot/util" "^5.3.1"
-    "@polkadot/x-rxjs" "3.5.1"
+    "@polkadot/metadata" "3.6.4"
+    "@polkadot/rpc-provider" "3.6.4"
+    "@polkadot/types" "3.6.4"
+    "@polkadot/util" "^5.4.4"
+    "@polkadot/x-rxjs" "^5.4.4"
 
-"@polkadot/rpc-provider@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.5.1.tgz#b3e2fb2be72266854fdd6921a5f08eca14ff6cb5"
-  integrity sha512-WVPTxVIFv3Lx2fNPHp8uWrUyKixiZDDFffI1nrbZbPeFqzKCmCC56wed0VMrZjmtdFnhQD4M1b4ubV6rHeoACw==
+"@polkadot/rpc-provider@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-3.6.4.tgz#433572380264ed92c6cd06636057aea3967f659b"
+  integrity sha512-yWEgHdlO/lxqrkDXxq2kY87tuPg2xyR0OPw3LM+ZE8/UMubR/KWjAtk3/KI0iLimPMtKcCL4L3z/mazYN6A19Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.5.1"
-    "@polkadot/util" "^5.3.1"
-    "@polkadot/util-crypto" "^5.3.1"
-    "@polkadot/x-fetch" "^5.3.1"
-    "@polkadot/x-ws" "^5.3.1"
+    "@polkadot/types" "3.6.4"
+    "@polkadot/util" "^5.4.4"
+    "@polkadot/util-crypto" "^5.4.4"
+    "@polkadot/x-fetch" "^5.4.4"
+    "@polkadot/x-global" "^5.4.4"
+    "@polkadot/x-ws" "^5.4.4"
     bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/types-known@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.5.1.tgz#bc32a4ef2f9ed0755ff49e1c480c7201c0eb6053"
-  integrity sha512-km0T1V+aD42A0/NyUy8nE9poEd++5uaNWp7edZg6Gq5XaTWKpHKasHaSXeEOxtrSs0kkXNL1Y8QDX5+9IUAZqA==
+"@polkadot/types-known@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-3.6.4.tgz#765c212a7b8a9e4fa1538041911a0aa30302c5e4"
+  integrity sha512-wK2VN95h8isyHzkf9PD3/8udlj1pw54tOoSQYv9LPJ94EBLM0iAUYvz7dQX4MGy3H6kcJvwT21639Bt7aqWhzQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "3.5.1"
-    "@polkadot/util" "^5.3.1"
+    "@polkadot/types" "3.6.4"
+    "@polkadot/util" "^5.4.4"
     bn.js "^4.11.9"
 
-"@polkadot/types@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.5.1.tgz#d23b9f80beb15ee9be7bb3ab21ed531dbe2a14d9"
-  integrity sha512-oeENgaPNwaNGZSvjO/PN2gyDUiPv4MMoEkwhFkO0spuMsbXZ+5oGRbSkAY09uNlo2Hv2pzfXaUDrQ0j+DwSBbg==
+"@polkadot/types@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.6.4.tgz#cdecfc317dd510b58854fe7c2f08e675f7c160b2"
+  integrity sha512-cfI5m08wk/1Cexxm0Qv+TELQPp1GQoWefuKBDMH2g8f4dbMD2lTelsmsAeRWvEoiS9Gd69PGjD0EwSIdjzj5ow==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "3.5.1"
-    "@polkadot/util" "^5.3.1"
-    "@polkadot/util-crypto" "^5.3.1"
-    "@polkadot/x-rxjs" "3.5.1"
+    "@polkadot/metadata" "3.6.4"
+    "@polkadot/util" "^5.4.4"
+    "@polkadot/util-crypto" "^5.4.4"
+    "@polkadot/x-rxjs" "^5.4.4"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
 
-"@polkadot/util-crypto@5.3.1", "@polkadot/util-crypto@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-5.3.1.tgz#46b65b708281664ffd9462cce7e33bb161c2f1c3"
-  integrity sha512-bZRKbgyshpgTxoLDwRPAGJHmxs76N6Wv4Bl13NK+MyTUy5s66M7q7n2CJ2hSgHMDTzanwmge1JMSXpC5ujPieg==
+"@polkadot/util-crypto@5.4.4", "@polkadot/util-crypto@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-5.4.4.tgz#c77fc9f5636d32b3fd9d593e80c71ce1345194aa"
+  integrity sha512-xSCY1oTNc77hblUN39aUEPdduH6Cu729gdUIIXiDP+azCnxnAp4n7qwr5Djs1STbQnQBen9PP0swit/7PFewLA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/networks" "5.3.1"
-    "@polkadot/util" "5.3.1"
-    "@polkadot/wasm-crypto" "^3.1.1"
-    "@polkadot/x-randomvalues" "5.3.1"
+    "@polkadot/networks" "5.4.4"
+    "@polkadot/util" "5.4.4"
+    "@polkadot/wasm-crypto" "^3.2.2"
+    "@polkadot/x-randomvalues" "5.4.4"
     base-x "^3.0.8"
     blakejs "^1.1.0"
     bn.js "^4.11.9"
@@ -705,86 +706,100 @@
     tweetnacl "^1.0.3"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@5.3.1", "@polkadot/util@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.3.1.tgz#b2adada572d92ae6fa4600d3ca0598f06b27cd88"
-  integrity sha512-JhXA71kGwlLPj3a7+lGuT3Kgp6Au/UEItnHXLMWdbmlLaWCPhdG5CKrkk/e4yH9VynPDZSyiSOxRgipGiNo8PA==
+"@polkadot/util@5.4.4", "@polkadot/util@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-5.4.4.tgz#6a17bec31b841ee40fd2330da67824a8644b0005"
+  integrity sha512-DEsipEJL2HP817zeRKxYwoWJ9br+/ydbOtR6z9UZUG1MoyGAnkl8XtEmcgrXejP+hK9AycCZ5kX0ZwaccoqeYQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/x-textdecoder" "5.3.1"
-    "@polkadot/x-textencoder" "5.3.1"
+    "@polkadot/x-textdecoder" "5.4.4"
+    "@polkadot/x-textencoder" "5.4.4"
     "@types/bn.js" "^4.11.6"
     bn.js "^4.11.9"
     camelcase "^5.3.1"
-    ip-regex "^4.2.0"
+    ip-regex "^4.3.0"
 
-"@polkadot/wasm-crypto-asmjs@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-3.1.1.tgz#391e1be6f7d65552b09c2e2486d108c379e46dc6"
-  integrity sha512-7Lt4B/6dwUhb5OAuSes0qMd83TpkngvEpiXTt2ccf/t2OvAXY9msfeJ9as3dI2jvjA9edD//jiejJ0BHJgpuXw==
+"@polkadot/wasm-crypto-asmjs@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-3.2.2.tgz#b18af677764d6943cba3c225ba28e9626760704c"
+  integrity sha512-OD6Ejzq0II+VuMLbs7nvGILO9b7PbK8F74uglDXQIaAl2YXuSEWbpE4S3RY7mRp+1Xg0igeNBhgMdRRUg5vDVg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/wasm-crypto-wasm@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-3.1.1.tgz#94638daa7642e6a9681cb854757d98401913f087"
-  integrity sha512-KaP1Ojf889ZeXHGPmyFTj0Qxr/jQ4yfpaGiEOCvYKXRYsDsbZKfxcb96PFil/x0yoZswWG3TX2S3hebnAzkmBg==
+"@polkadot/wasm-crypto-wasm@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-3.2.2.tgz#44f8713d1db19efe13ea4c598f13a8495b24b49f"
+  integrity sha512-kU0m5X68NA8g7OKu0f0C+M1TmTy+hBEmGZ+7jbGBdDqkogc01sUR6qNtmPiT9g9Qsi1bhCoYVaVqtetpiD+CUw==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/wasm-crypto@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-3.1.1.tgz#e9ec63204f508541dfda72f0b6b98be40e27de50"
-  integrity sha512-uApLRojJY9Q7Arji6w9/eOYEu8Pg8dm+zt+640QLzC4KVVCpbdMmrcFAXCZXeOIJwsKveZsNehGUCcG77ypVPg==
+"@polkadot/wasm-crypto@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-3.2.2.tgz#732d36f2dcd4c327696d078ad2efc64b70ca8586"
+  integrity sha512-dffdBQvFHbP0WLvpCf2fJ5mEWavXj75ykuFR16WIduhTRnI7fVYqYRaiJioUHWvPR34ik/VKlATWG7WPYiF5ZQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/wasm-crypto-asmjs" "^3.1.1"
-    "@polkadot/wasm-crypto-wasm" "^3.1.1"
+    "@polkadot/wasm-crypto-asmjs" "^3.2.2"
+    "@polkadot/wasm-crypto-wasm" "^3.2.2"
 
-"@polkadot/x-fetch@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-5.3.1.tgz#f446b6eabc49fcb9b65ffc113362e280f1930cd3"
-  integrity sha512-MoHQrazcEEpEZHbnkBdXWI2CGcNczqcJYWzwnCPLqHamLGgJrwgCQSYdqdYASV+PHukN0/odDWbfiHLbVBvYew==
+"@polkadot/x-fetch@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-5.4.4.tgz#ce2f9468349396a3e2804cb969745b537507c198"
+  integrity sha512-eIYoMKAYcmWsMpe5CveyErwkDp3IH8vwsNGureC7sd1Aon7Pr4bfB4o+Geb26ylVMBhbvmrGXBeB1A8D9lB4Sg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/x-global" "5.4.4"
+    "@types/node-fetch" "^2.5.8"
+    node-fetch "^2.6.1"
+
+"@polkadot/x-global@5.4.4", "@polkadot/x-global@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-5.4.4.tgz#1e6a7a5eb6db154740e419ad1eb1e379012cda70"
+  integrity sha512-4GM4YdzrNMUqF4TnaLWL6TiSsIb9wcSW8uJm7KrXXFRhAuYhOlU3sYyCpUzvAZhOb4BkDA1HPCkCE7ubWe9LbA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/node-fetch" "^2.5.8"
     node-fetch "^2.6.1"
 
-"@polkadot/x-randomvalues@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.3.1.tgz#6a9c83807ad7c2d83dd003dbc2f2abb3b82925bb"
-  integrity sha512-Hf6vYUKBKFR0dMaeBJ+btb6YOCe606zrH9DYbGiKmoKrIfMth+LRw8J9ml8a0q2DOTTfnhpUV3bSdDSBpqb8hA==
+"@polkadot/x-randomvalues@5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-5.4.4.tgz#960010ae1ce772b72680b7f38c71f174cb50cd6a"
+  integrity sha512-wJWUALRCCvwqGoPj8pvHJcvyrrgAudlvY58PNCMeXevXBbLpyz5uoYs1k/bAt4IW5tCsa1biqI+3BQIayLuXGg==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@polkadot/x-global" "5.4.4"
 
-"@polkadot/x-rxjs@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-3.5.1.tgz#8383e39c661dd0dffe2620358615a82e7eb5df34"
-  integrity sha512-LW8KPhqQltzmhhC3HMvIDaQfrR7OSj7JFWVYTrN0GAuPX89pQKak6j98oUd2dWiYSZxEXwD0e6MH5yBTqsAtEw==
+"@polkadot/x-rxjs@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-5.4.4.tgz#b75171bc1bdfac5bca82a0d85000fe8f0f75c23d"
+  integrity sha512-Sal4/2hQwmeqWEAEkAFLfjggxMaorbMiF+CFZQaxCcMNbxxEm/2+Cdr+13ffXLZgGpjOmWtRF1Z8WD6ZnUwGzQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     rxjs "^6.6.3"
 
-"@polkadot/x-textdecoder@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.3.1.tgz#d2ea208f90105138763787ba1b53bd6191f1cfcb"
-  integrity sha512-ACt0mO2b1exfWwzgl711xR6Vlciy7cM8qhaD01AnIv/DxWdHQL2dluwFv3Er5663WM9k2QTf/7WamNOt2GyYmQ==
+"@polkadot/x-textdecoder@5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-5.4.4.tgz#acb4982c6176bf91aa0f1e4d5aa59a8b7e48a668"
+  integrity sha512-QecoEM+Yj9pMgf7Mg5D//kVeIjcSrSdUH2zC4FsKAH2ky1Jfvhiup6SH4upwFQpuipKeobMPgB/l2ZuQ8PJUbQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@polkadot/x-global" "5.4.4"
 
-"@polkadot/x-textencoder@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-5.3.1.tgz#8b92fa4d6aeb61f4131c8bf5d97053523b705acd"
-  integrity sha512-I3Sc5fPicJVidk88Lsa7Y8QLWPMHsNIUu5MHrqbjNOEgq+blu8UHC/foUgUo+uWxhJsWgIO+eZXVNAmAwMep4w==
+"@polkadot/x-textencoder@5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-5.4.4.tgz#52295ce0aa29f579a42600e3762a39b032416d8b"
+  integrity sha512-pjXBxijzLPS3GIUkielYTFxjqsI20R6nIIM9eVQErBN4wtuGsxSz3Tc2NeW5y/uKDQzac40W5canAT0gkFmduA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@polkadot/x-global" "5.4.4"
 
-"@polkadot/x-ws@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.3.1.tgz#ea9fe3bac5b4f1bd7a6320991fbc209c5215da6e"
-  integrity sha512-7nw0xqXWHJftoLDu7kbkCj1vo3eW0NE/xiqMxo1/Dc+mi1HJALz+PU5LvOmc6kdrQU46agTH4Cz2vFwXjlFKPg==
+"@polkadot/x-ws@^5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-5.4.4.tgz#af5f366cc5bdf0248be6c4b6b0f60aac54e13a44"
+  integrity sha512-5uklIUDGN3K2djaMtf52BRzXfcPf6AexIVT7h+SlO1PXhcI0pk0sczA+ovJZQ0FvQKcp9OfUyxdb6lMOFMFkrA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+    "@polkadot/x-global" "5.4.4"
     "@types/websocket" "^1.0.1"
     websocket "^1.0.33"
 
@@ -802,10 +817,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sora-substrate/type-definitions@^0.3.3":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@sora-substrate/type-definitions/-/type-definitions-0.3.5.tgz#362e2671f80ccd0b5b8f41819a653ad769db0898"
-  integrity sha512-PJrxBR297RryHi0y9pFsXZE5EvzJpERtZ2NoQyazhEXKovK3GhS/MNN3tScD5SsjSE0MVpAdvTzE0Ad5b8+2kg==
+"@sora-substrate/type-definitions@^0.3.5":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@sora-substrate/type-definitions/-/type-definitions-0.3.7.tgz#2c49d944a2bde59c97d464f3b0a38d3287760f71"
+  integrity sha512-mk68BVNoRf+fHd3qJrkhViohb78dkCGyktbE4NahywTn1SUcq61ANEGnD0W6k54rKewMeDciC4+SuWdsXnvM4w==
   dependencies:
     "@open-web3/orml-type-definitions" "^0.6.0-beta.26"
 
@@ -1047,13 +1062,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.0.tgz#92db8e7c357ed7d69632d6843ca70b71be3a721d"
-  integrity sha512-IJ5e2W7uFNfg4qh9eHkHRUCbgZ8VKtGwD07kannJvM5t/GU8P8+24NX8gi3Hf5jST5oWPY8kyV1s/WtfiZ4+Ww==
+"@typescript-eslint/eslint-plugin@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.1.tgz#22dd301ce228aaab3416b14ead10b1db3e7d3180"
+  integrity sha512-5JriGbYhtqMS1kRcZTQxndz1lKMwwEXKbwZbkUZNnp6MJX0+OVXnG0kOlBZP4LUAxEyzu3cs+EXd/97MJXsGfw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.14.0"
-    "@typescript-eslint/scope-manager" "4.14.0"
+    "@typescript-eslint/experimental-utils" "4.14.1"
+    "@typescript-eslint/scope-manager" "4.14.1"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.15"
@@ -1061,48 +1076,48 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.0.tgz#5aa7b006736634f588a69ee343ca959cd09988df"
-  integrity sha512-6i6eAoiPlXMKRbXzvoQD5Yn9L7k9ezzGRvzC/x1V3650rUk3c3AOjQyGYyF9BDxQQDK2ElmKOZRD0CbtdkMzQQ==
+"@typescript-eslint/experimental-utils@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.1.tgz#a5c945cb24dabb96747180e1cfc8487f8066f471"
+  integrity sha512-2CuHWOJwvpw0LofbyG5gvYjEyoJeSvVH2PnfUQSn0KQr4v8Dql2pr43ohmx4fdPQ/eVoTSFjTi/bsGEXl/zUUQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.14.0"
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/typescript-estree" "4.14.0"
+    "@typescript-eslint/scope-manager" "4.14.1"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/typescript-estree" "4.14.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.0.tgz#62d4cd2079d5c06683e9bfb200c758f292c4dee7"
-  integrity sha512-sUDeuCjBU+ZF3Lzw0hphTyScmDDJ5QVkyE21pRoBo8iDl7WBtVFS+WDN3blY1CH3SBt7EmYCw6wfmJjF0l/uYg==
+"@typescript-eslint/parser@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.1.tgz#3bd6c24710cd557d8446625284bcc9c6d52817c6"
+  integrity sha512-mL3+gU18g9JPsHZuKMZ8Z0Ss9YP1S5xYZ7n68Z98GnPq02pYNQuRXL85b9GYhl6jpdvUc45Km7hAl71vybjUmw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.14.0"
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/typescript-estree" "4.14.0"
+    "@typescript-eslint/scope-manager" "4.14.1"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/typescript-estree" "4.14.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.0.tgz#55a4743095d684e1f7b7180c4bac2a0a3727f517"
-  integrity sha512-/J+LlRMdbPh4RdL4hfP1eCwHN5bAhFAGOTsvE6SxsrM/47XQiPSgF5MDgLyp/i9kbZV9Lx80DW0OpPkzL+uf8Q==
+"@typescript-eslint/scope-manager@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.1.tgz#8444534254c6f370e9aa974f035ced7fe713ce02"
+  integrity sha512-F4bjJcSqXqHnC9JGUlnqSa3fC2YH5zTtmACS1Hk+WX/nFB0guuynVK5ev35D4XZbdKjulXBAQMyRr216kmxghw==
   dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/visitor-keys" "4.14.0"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/visitor-keys" "4.14.1"
 
-"@typescript-eslint/types@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.0.tgz#d8a8202d9b58831d6fd9cee2ba12f8a5a5dd44b6"
-  integrity sha512-VsQE4VvpldHrTFuVPY1ZnHn/Txw6cZGjL48e+iBxTi2ksa9DmebKjAeFmTVAYoSkTk7gjA7UqJ7pIsyifTsI4A==
+"@typescript-eslint/types@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.1.tgz#b3d2eb91dafd0fd8b3fce7c61512ac66bd0364aa"
+  integrity sha512-SkhzHdI/AllAgQSxXM89XwS1Tkic7csPdndUuTKabEwRcEfR8uQ/iPA3Dgio1rqsV3jtqZhY0QQni8rLswJM2w==
 
-"@typescript-eslint/typescript-estree@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.0.tgz#4bcd67486e9acafc3d0c982b23a9ab8ac8911ed7"
-  integrity sha512-wRjZ5qLao+bvS2F7pX4qi2oLcOONIB+ru8RGBieDptq/SudYwshveORwCVU4/yMAd4GK7Fsf8Uq1tjV838erag==
+"@typescript-eslint/typescript-estree@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.1.tgz#20d3b8c8e3cdc8f764bdd5e5b0606dd83da6075b"
+  integrity sha512-M8+7MbzKC1PvJIA8kR2sSBnex8bsR5auatLCnVlNTJczmJgqRn8M+sAlQfkEq7M4IY3WmaNJ+LJjPVRrREVSHQ==
   dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/visitor-keys" "4.14.0"
+    "@typescript-eslint/types" "4.14.1"
+    "@typescript-eslint/visitor-keys" "4.14.1"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1110,12 +1125,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.0.tgz#b1090d9d2955b044b2ea2904a22496849acbdf54"
-  integrity sha512-MeHHzUyRI50DuiPgV9+LxcM52FCJFYjJiWHtXlbyC27b80mfOwKeiKI+MHOTEpcpfmoPFm/vvQS88bYIx6PZTA==
+"@typescript-eslint/visitor-keys@4.14.1":
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.1.tgz#e93c2ff27f47ee477a929b970ca89d60a117da91"
+  integrity sha512-TAblbDXOI7bd0C/9PE1G+AFo7R5uc+ty1ArDoxmrC1ah61Hn6shURKy7gLdRb1qKJmjHkqu5Oq+e4Kt0jwf1IA==
   dependencies:
-    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/types" "4.14.1"
     eslint-visitor-keys "^2.0.0"
 
 JSONStream@^1.0.4:
@@ -3378,10 +3393,10 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip-regex@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.2.0.tgz#a03f5eb661d9a154e3973a03de8b23dd0ad6892e"
-  integrity sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==
+ip-regex@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -4579,10 +4594,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moonbeam-types-bundle@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/moonbeam-types-bundle/-/moonbeam-types-bundle-1.0.5.tgz#7620f003af92e121bc96a6dad1ed7c22540b5933"
-  integrity sha512-DpNsjtdWUtWKecI2Oo/ovuGbWzyGOCBLyeXi5UYvYslHQ1iJchNtYG2QINF9iuQucC8ZFLoSg6bbteKOnfLnWg==
+moonbeam-types-bundle@^1.0.6:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/moonbeam-types-bundle/-/moonbeam-types-bundle-1.0.9.tgz#90fb29fdacf6997ca269117b0ef116c64ebe5549"
+  integrity sha512-z/vLHxCCSeGPi4ueGThD7EM4eRv1Zvbv8YP4qqSgyycf74GQflrImOB9SchkZxvMmS0RbxK97ePVCL2ojw+h+g==
   dependencies:
     "@polkadot/api" "^3.2.3"
     typescript "^4.1.3"
@@ -6260,9 +6275,9 @@ tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tsutils@^3.17.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.19.1.tgz#d8566e0c51c82f32f9c25a4d367cd62409a547a9"
-  integrity sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.20.0.tgz#ea03ea45462e146b53d70ce0893de453ff24f698"
+  integrity sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==
   dependencies:
     tslib "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@acala-network/type-definitions@^0.6.2-7":
-  version "0.6.2-7"
-  resolved "https://registry.yarnpkg.com/@acala-network/type-definitions/-/type-definitions-0.6.2-7.tgz#4a335d831f74999db2ed19d3bd5a1bb3a1b1833c"
-  integrity sha512-01HZuh3qaA1hkj3cmzeg9WJgno8f+a5An3qFwRdJVJyCRtvRqqH5XyB04/oNDfzgQdHPdE6R3LkpTZvGOH8pOA==
+  version "0.6.2-8"
+  resolved "https://registry.yarnpkg.com/@acala-network/type-definitions/-/type-definitions-0.6.2-8.tgz#1ea62096e732946d5e7881d7b90fe2b8d48b0901"
+  integrity sha512-x2dYgpLkpm6Rr2A7FT+A3yckh7movhLYxZJnqbeHvgvkqCVbAPLvwa8e0R9KogYaJREn4/aUYkVSAG7tBgBZIg==
   dependencies:
     "@open-web3/orml-type-definitions" "^0.8.2-6"
 
@@ -309,9 +309,9 @@
     kuler "^2.0.0"
 
 "@edgeware/node-types@^3.2.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@edgeware/node-types/-/node-types-3.3.0.tgz#ac651114a5a815d6a7192d9242623527bd65b2ab"
-  integrity sha512-JK0bVxmuqDiolErPFFHINJiFW5Z5+mk44esJZDgvI1CsSGF/MTHS/oq0Hv/SlJfGSQV/Xk1et0bSeQETF6LBpQ==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@edgeware/node-types/-/node-types-3.3.1.tgz#e98e3ebf63319c497020c1b14105f148d927eaae"
+  integrity sha512-vD8kChXW4qapj5qmeAl7f1P1dOVPwC2FxLJZODxH+ifYjl//mfknaaZ4ApjHTtxT7UrF/MJJ6XtnlkyMaTPEOg==
 
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
@@ -573,7 +573,7 @@
     "@polkadot/x-rxjs" "^5.4.4"
     bn.js "^4.11.9"
 
-"@polkadot/api@3.6.4", "@polkadot/api@^3.2.3", "@polkadot/api@^3.6.4":
+"@polkadot/api@3.6.4", "@polkadot/api@^3.6.4":
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-3.6.4.tgz#a7b02eb0f4c2a98b087003edc1c2f7ed4bea077a"
   integrity sha512-jsbBoL99OtBazGyufab9zkC1ORYdvrqzs5tHhLkhUl9zNrDBHyLVawyYNPXAyejtwLl3RMAWMMpnarDjlmjwPQ==
@@ -672,7 +672,7 @@
     "@polkadot/util" "^5.4.4"
     bn.js "^4.11.9"
 
-"@polkadot/types@3.6.4":
+"@polkadot/types@3.6.4", "@polkadot/types@^3.6.4":
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-3.6.4.tgz#cdecfc317dd510b58854fe7c2f08e675f7c160b2"
   integrity sha512-cfI5m08wk/1Cexxm0Qv+TELQPp1GQoWefuKBDMH2g8f4dbMD2lTelsmsAeRWvEoiS9Gd69PGjD0EwSIdjzj5ow==
@@ -3032,12 +3032,12 @@ git-raw-commits@2.0.0:
     through2 "^2.0.0"
 
 git-raw-commits@^2.0.8:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.9.tgz#5cbc707a615cb77b71e687f8a1ee54af46208b22"
-  integrity sha512-hSpNpxprVno7IOd4PZ93RQ+gNdzPAIrW0x8av6JQDJGV4k1mR9fE01dl8sEqi2P7aKmmwiGUn1BCPuf16Ae0Qw==
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.10.tgz#e2255ed9563b1c9c3ea6bd05806410290297bbc1"
+  integrity sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==
   dependencies:
     dargs "^7.0.0"
-    lodash.template "^4.0.2"
+    lodash "^4.17.15"
     meow "^8.0.0"
     split2 "^3.0.0"
     through2 "^4.0.0"
@@ -4595,11 +4595,12 @@ modify-values@^1.0.0:
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
 moonbeam-types-bundle@^1.0.6:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/moonbeam-types-bundle/-/moonbeam-types-bundle-1.0.9.tgz#90fb29fdacf6997ca269117b0ef116c64ebe5549"
-  integrity sha512-z/vLHxCCSeGPi4ueGThD7EM4eRv1Zvbv8YP4qqSgyycf74GQflrImOB9SchkZxvMmS0RbxK97ePVCL2ojw+h+g==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/moonbeam-types-bundle/-/moonbeam-types-bundle-1.1.4.tgz#deec437148d9f9fb39c496ca2d1d46dee2dcf79e"
+  integrity sha512-6dNik2dlhLv8ji8INIKgIw37T36MYjYATT1X/WfFyv20cTwlZJVe5xVWiWhKze884T4Dlr9JVYhvIqRjOkiScQ==
   dependencies:
-    "@polkadot/api" "^3.2.3"
+    "@polkadot/api" "^3.6.4"
+    "@polkadot/types" "^3.6.4"
     typescript "^4.1.3"
 
 ms@2.0.0:


### PR DESCRIPTION
BREAKING CHANGE

- Document regression (breaking change) in `runtime/spec` response. `tokenSymbol` and `tokenDecimals` now return an `Arrary<string>` instead of a `string`. See the diff for `src/services/test-helpers/responses/runtime/spec.json` to view a concrete example of the change.
- Bumps dependencies, including polkadot-js
- Accounts for updates to `chainProperties.chainTokens`. Formerly, `chainProperties.chainToken` was just a `string`; now it is a `Array<string>`, so it can be extensible for chains that support multiple tokens. In this PR we make the assumption that the token at index 0 will be the native token. We consider a token native because its balance is stored in `system::Accounts`; opposed to a non-native token which has its balance accessible via the ORML `tokens` pallets.
