### PR TITLE
docs: update docs for /blocks/head and /blocks/{blockId}. 

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1117,7 +1117,7 @@ components:
           type: string
           description: The block's hash.
           format: hex
-        height:
+        number:
           type: string
           description: The block's height.
           format: unsignedInteger


### PR DESCRIPTION
Change "height" to "number" for the docs in reference to these routes:

`/blocks/{blockId}`
`/blocks/head`

Resolves [#457](https://github.com/paritytech/substrate-api-sidecar/issues/457)