### PR TITLE
feat: Log version before creating ws connection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { WsProvider } from '@polkadot/rpc-provider';
 import { OverrideBundleType, RegistryTypes } from '@polkadot/types/types';
 import { json } from 'express';
 
+import packageJSON from '../package.json';
 import App from './App';
 import { getControllersForSpec } from './chains-config';
 import { consoleOverride } from './logging/consoleOverride';
@@ -35,6 +36,8 @@ const { config } = SidecarConfig;
 async function main() {
 	// Overide console.{log, error, warn, etc}
 	consoleOverride(logger);
+
+	logger.info(`Version: ${packageJSON.version}`);
 
 	const { TYPES_BUNDLE, TYPES_SPEC, TYPES_CHAIN, TYPES } = config.SUBSTRATE;
 	// Instantiate a web socket connection to the node and load types


### PR DESCRIPTION
This PR simply adds a log message of the version of api-sidecar prior to creating the `ApiPromise` and starting up the websocket connection.

If the `ApiPromise` fails to connect (due to type issues, node not running etc.) the logging prompts following will never show up. Thus, logging the version prior to the most common failure point for new users is prudent for helping debug ([example](https://github.com/paritytech/substrate-api-sidecar/issues/479#issuecomment-802928219)).

Below is an example of the startup logging when the api fails to connect because there is no websocket port at the specified address.

<img width="943" alt="Screen Shot 2021-03-19 at 9 04 38 AM" src="https://user-images.githubusercontent.com/32168567/111809395-2d354280-8892-11eb-860d-01b2a28dc99a.png">
