### PR TITLE
fix: update eraElectionStatus for runtime upgrade v30

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1309,7 +1309,7 @@ components:
         status:
           type: object
           description: >-
-            [Deprecated](Works for runtimes before v30).   
+            [Deprecated](Works for polkadot runtimes before v0.8.30).   
             
             Era election status: either `Close: null` or `Open: <BlockNumber>`.
             A status of `Close` indicates that the submission window for solutions

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1309,6 +1309,8 @@ components:
         status:
           type: object
           description: >-
+            [Deprecated](Works for runtimes before v30).   
+            
             Era election status: either `Close: null` or `Open: <BlockNumber>`.
             A status of `Close` indicates that the submission window for solutions
             from off-chain Phragmen is not open. A status of `Open` indicates that the

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -115,7 +115,7 @@ export class PalletsStakingProgressService extends AbstractService {
 			electionStatus: {
 				status: eraElectionStatus
 					? eraElectionStatus.toJSON()
-					: 'Not Applicable for this runtime',
+					: 'Deprecated! See docs',
 				toggleEstimate: toggle?.toString(10) ?? null,
 			},
 			idealValidatorCount: validatorCount.toString(10),

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -33,7 +33,7 @@ export class PalletsStakingProgressService extends AbstractService {
 		/**
 		 * Polkadot runtimes v0.8.30 and above do not support eraElectionStatus, so we check
 		 * to see if eraElectionStatus is mounted to the api, and if were running on a
-		 * runtime less than v30 it will return a successful result. If it doesn't
+		 * runtime less than v0.8.30 it will return a successful result. If it doesn't
 		 * we do nothing and let `eraElectionStatus` stay undefined.
 		 */
 		if (api.query.staking.eraElectionStatus) {

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -97,10 +97,7 @@ export class PalletsStakingProgressService extends AbstractService {
 		if (electionLookAhead.eq(new BN(0))) {
 			// no offchain solutions accepted
 			toggle = null;
-		} else if (
-			eraElectionStatus &&
-			(eraElectionStatus as { isClose?: boolean }).isClose
-		) {
+		} else if ((eraElectionStatus as { isClose?: boolean })?.isClose) {
 			// election window is yet to open
 			toggle = nextCurrentEra.sub(electionLookAhead);
 		} else {

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -30,15 +30,14 @@ export class PalletsStakingProgressService extends AbstractService {
 		]);
 
 		let eraElectionStatus;
-		try {
+		/**
+		 * Runtime v30 and above do not support eraElectionStatus, so we check
+		 * to see if eraElectionStatus is mounted to the api, and if were running on a
+		 * runtime less than v30 it will return a successful result. If it doesn't
+		 * we do nothing and let `eraElectionStatus` stay undefined.
+		 */
+		if (api.query.staking.eraElectionStatus) {
 			eraElectionStatus = await api.query.staking.eraElectionStatus.at(hash);
-		} catch {
-			/**
-			 * Runtime v30 and above do not support eraElectionStatus, so use
-			 * a `try` to retrieve the eraElectionStatus, and if were running on a
-			 * runtime less than v30 it will return a successful result. If it doesn't
-			 * we do nothing and let the undefined `eraElectionStatus` dictate the below logic.
-			 */
 		}
 
 		const {

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -31,7 +31,7 @@ export class PalletsStakingProgressService extends AbstractService {
 
 		let eraElectionStatus;
 		/**
-		 * Runtime v30 and above do not support eraElectionStatus, so we check
+		 * Polkadot runtimes v0.8.30 and above do not support eraElectionStatus, so we check
 		 * to see if eraElectionStatus is mounted to the api, and if were running on a
 		 * runtime less than v30 it will return a successful result. If it doesn't
 		 * we do nothing and let `eraElectionStatus` stay undefined.

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -111,12 +111,12 @@ export class PalletsStakingProgressService extends AbstractService {
 		return {
 			...baseResponse,
 			nextActiveEraEstimate: nextActiveEra.toString(10),
-			electionStatus: {
-				status: eraElectionStatus
-					? eraElectionStatus.toJSON()
-					: 'Deprecated! See docs',
-				toggleEstimate: toggle?.toString(10) ?? null,
-			},
+			electionStatus: eraElectionStatus
+				? {
+						status: eraElectionStatus.toJSON(),
+						toggleEstimate: toggle?.toString(10) ?? null,
+				  }
+				: 'Deprecated, see docs',
 			idealValidatorCount: validatorCount.toString(10),
 			validatorSet: validators.map((accountId) => accountId.toString()),
 		};

--- a/src/types/responses/PalletStakingProgress.ts
+++ b/src/types/responses/PalletStakingProgress.ts
@@ -10,9 +10,11 @@ export interface IPalletStakingProgress {
 	nextActiveEraEstimate?: AnyJson;
 	nextSessionEstimate: string | null;
 	unappliedSlashes: AnyJson[] | null;
-	electionStatus?: {
-		status: AnyJson;
-		toggleEstimate: string | null;
-	};
+	electionStatus?:
+		| {
+				status: AnyJson;
+				toggleEstimate: string | null;
+		  }
+		| string;
 	validatorSet?: string[] | null;
 }


### PR DESCRIPTION
This PR resolves issue [#468](https://github.com/paritytech/substrate-api-sidecar/issues/468).

Updated `eraElectionStatus` to work for parachains, but also to work with the upcoming runtime upgrade. 

With the upcoming runtime Upgrade v30, `eraElectionStatus` will no longer be supported and therefore deprecated. 

