### PR TITLE
docs: /paras{/leases/current, /auctions/current}

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -759,7 +759,7 @@ paths:
       parameters:
       - name: at
         in: query
-        description: Block at which to retrieve runtime version information at.
+        description: Block at which to retrieve info at.
         required: false
         schema:
           type: string
@@ -784,7 +784,7 @@ paths:
       parameters:
       - name: at
         in: query
-        description: Block at which to retrieve runtime version information at.
+        description: Block at which to retrieve info at.
         required: false
         schema:
           type: string
@@ -820,7 +820,7 @@ paths:
       parameters:
       - name: at
         in: query
-        description: Block at which to retrieve runtime version information at.
+        description: Block at which to retrieve info at.
         required: false
         schema:
           type: string
@@ -833,6 +833,102 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasAuctionsCurrent'
+  /experimental/paras/crowdloans:
+    get:
+      tags:
+      - paras
+      summary: |
+        [Experimental subject to breaking change] List all available crowdloans.
+      description: |
+        Returns a list of all the `paraId`s that have a crowdloan. Can optionally
+        specify to include the `fundInfo`.
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve info at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: fundInfo
+        in: query
+        description: Wehther or not to include the `fundInfo` of each crowdlaon
+        required: false
+        schema:
+          type: boolean
+          default: false
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParasCrowdloans'
+                
+  /experimental/paras/{paraId}/crowdloan-info:
+    get:
+      tags:
+      - paras
+      summary: |
+        [Experimental subject to breaking change] Get crowdloan information for a
+        `paraId`
+      description: |
+        Returns `fundInfo` and the set of `leasePeriods` a crowdloan covers.
+      parameters:
+      - name: paraId
+        in: path
+        description: paraId to query crowdloan information of.
+        required: true
+        schema:
+          type: number
+      - name: at
+        in: query
+        description: Block at which to retrieve info at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParasCrowdloanInfo'
+  /experimental/paras/{paraId}/lease-info:
+    get:
+      tags:
+      - paras
+      summary: |
+        [Experimental subject to breaking change] Get current and future lease
+        info + lifecycle stage for a given `paraId.
+      description: |
+        Returns a list of leases that belong to the `paraId` as well as the
+        `paraId`'s current lifecycle stage.
+      parameters:
+      - name: paraId
+        in: path
+        description: paraId to query crowdloan information of.
+        required: true
+        schema:
+          type: number
+      - name: at
+        in: query
+        description: Block at which to retrieve info at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParasLeaseInfo'
 components:
   schemas:
     BalanceLock:
@@ -1745,6 +1841,28 @@ components:
           items:
             $ref: '#/components/schemas/PalletStorageItemMetadata'
           description: Array containing metadata for each storage entry of the pallet.
+    ParaLifeCycle:
+      type: string
+      enum:
+      - onboarding
+      - parathread
+      - parachain
+      - upgradingParathread
+      - downgradingParachain
+      - offboardingParathread
+      - offboardingParachain
+      description: |
+        The possible states of a para, to take into account delayed lifecycle
+        changes.
+    OnboardingAs:
+      type: string
+      enum:
+      - parachain
+      - parathread
+      description: |
+        This property only shows up when `paraLifeCycle=onboarding`. It
+        describes if a particular para is onboarding as a `parachain` or a
+        `parathread`.
     Para:
       type: object
       properties:
@@ -1752,26 +1870,9 @@ components:
           type: string
           format: unsignedInteger
         paraLifeCycle:
-          type: string
-          enum:
-          - onboarding
-          - parathread
-          - parachain
-          - upgradingParathread
-          - downgradingParachain
-          - offboardingParathread
-          - offboardingParachain
-          description: |
-            The possible states of a para, to take into account delayed lifecycle
-            changes.
+          $ref: '#/components/schemas/ParaLifeCycle'
         onboardingAs:
-          type: string
-          enum:
-          - parachain
-          - parathread
-          description: |
-            This property only shows up when `paraLifeCycle=onboarding`. It
-            describes if a particular para is onboarding as a `parachain` or a `parathread`.
+          $ref: '#/components/schemas/OnboardingAs'
     Paras:
       type: object
       properties:
@@ -1865,6 +1966,95 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WinningData'
+    FundInfo:
+      type: object
+      properties:
+        depositor:
+          type: string
+        verifier:
+          type: string
+        deposit: 
+          type: string
+          format: unsignedInteger
+        raised:
+          type: string
+          format: unsignedInteger
+        end:
+          type: string
+          format: unsignedInteger
+        cap:
+          type: string
+          format: unsignedInteger
+        lastConstribution:
+          type: string
+          enum:
+          - preEnding
+          - ending
+        firstSlot:
+          type: string
+          format: unsignedInteger
+        lastSlot:
+          type: string
+          format: unsignedInteger
+        trieIndex:
+          type: string
+          format: unsignedInteger
+    ParasCrowdloans:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        funds:
+          type: array
+          items:
+            type: object
+            properties:
+              paraId:
+                type: string
+                format: unsignedInteger
+              fundInfo:
+                $ref: '#/components/schemas/FundInfo'
+          description: |
+            List of paras that have crowdloans. Note `fundInfo` is only included when query
+            param `fundInfo=true`.
+    ParasCrowdloanInfo:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        fundInfo:
+          $ref: '#/components/schemas/FundInfo'
+        leasePeriods:
+          type: array
+          items:
+            type: string
+            format: unsignedInteger
+          description: Lease periods the crowdloan covers.
+    ParasLeaseInfo:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        paraLifeCycle:
+          $ref: '#/components/schemas/ParaLifeCycle'
+        onboardingAs:
+          $ref: '#/components/schemas/OnboardingAs'
+        leases:
+          type: array
+          items:
+            type: object
+            properties:
+              leasePeriodIndex: 
+                type: string
+                format: unsignedInteger
+              account:
+                type: string
+              deposit:
+                type: string
+                format: unsignedInteger
+          description: |
+            List of lease periods for which the `paraId` holds a lease along with 
+            the deposit held and the associated `accountId`.
   requestBodies:
     Transaction:
       content:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -815,8 +815,8 @@ paths:
         [Experimental subject to breaking change] Get the status of the current
         auction.
       description: |
-        Returns an overview of the current of the current auction. There is only
-        one auction at a time. If there is no auction most fields will be `null`.
+        Returns an overview of the current of auction. There is only one auction
+        at a time. If there is no auction most fields will be `null`.
       parameters:
       - name: at
         in: query
@@ -853,7 +853,7 @@ paths:
           format: unsignedInteger or $hex
       - name: fundInfo
         in: query
-        description: Wehther or not to include the `fundInfo` of each crowdlaon
+        description: Whether or not to include the `fundInfo` of each crowdloan.
         required: false
         schema:
           type: boolean
@@ -865,7 +865,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasCrowdloans'
-                
   /experimental/paras/{paraId}/crowdloan-info:
     get:
       tags:
@@ -878,7 +877,7 @@ paths:
       parameters:
       - name: paraId
         in: path
-        description: paraId to query crowdloan information of.
+        description: paraId to query the crowdloan information of.
         required: true
         schema:
           type: number
@@ -903,14 +902,14 @@ paths:
       - paras
       summary: |
         [Experimental subject to breaking change] Get current and future lease
-        info + lifecycle stage for a given `paraId.
+        info as well as the lifecycle stage for a given `paraId`.
       description: |
         Returns a list of leases that belong to the `paraId` as well as the
         `paraId`'s current lifecycle stage.
       parameters:
       - name: paraId
         in: path
-        description: paraId to query crowdloan information of.
+        description: paraId to query the crowdloan information of.
         required: true
         schema:
           type: number
@@ -1491,8 +1490,8 @@ components:
         status:
           type: object
           description: >-
-            [Deprecated](Works for polkadot runtimes before v0.8.30).   
-            
+            [Deprecated](Works for polkadot runtimes before v0.8.30).
+
             Era election status: either `Close: null` or `Open: <BlockNumber>`.
             A status of `Close` indicates that the submission window for solutions
             from off-chain Phragmen is not open. A status of `Open` indicates that the
@@ -1921,7 +1920,7 @@ components:
             type: string
             format: unsignedInteger
       description: |
-        A currently win bid and the set of lease periods the bid is for. The
+        A currently winning bid and the set of lease periods the bid is for. The
         `amount` of the bid is per lease period. The `bid` property will be `null`
         if no bid has been made for the corresponding `SlotRange`.
     ParasAuctionsCurrent:
@@ -1945,13 +1944,13 @@ components:
           - opening
           - ending
           description: |
-            Wether the auction is in the `opening` or `ending` phase. The 
-            `ending` phase is where the eventual winners are retroactively 
+            Whether the auction is in the `opening` or `ending` phase. The
+            `ending` phase is where the eventual winners are retroactively
             picked from. `null` if no ongoing auction.
         auctionIndex:
           type: string
           format: unsignedInteger
-          description: | 
+          description: |
             Auction number. If there is no current auction this will be the number
             of the previous auction.
         leasePeriods:
@@ -1973,7 +1972,7 @@ components:
           type: string
         verifier:
           type: string
-        deposit: 
+        deposit:
           type: string
           format: unsignedInteger
         raised:
@@ -2015,8 +2014,8 @@ components:
               fundInfo:
                 $ref: '#/components/schemas/FundInfo'
           description: |
-            List of paras that have crowdloans. Note `fundInfo` is only included when query
-            param `fundInfo=true`.
+            List of paras that have crowdloans. Note `fundInfo` is only included
+            when query param `fundInfo=true`.
     ParasCrowdloanInfo:
       type: object
       properties:
@@ -2044,7 +2043,7 @@ components:
           items:
             type: object
             properties:
-              leasePeriodIndex: 
+              leasePeriodIndex:
                 type: string
                 format: unsignedInteger
               account:
@@ -2053,7 +2052,7 @@ components:
                 type: string
                 format: unsignedInteger
           description: |
-            List of lease periods for which the `paraId` holds a lease along with 
+            List of lease periods for which the `paraId` holds a lease along with
             the deposit held and the associated `accountId`.
   requestBodies:
     Transaction:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -799,6 +799,7 @@ paths:
         required: false
         schema:
           type: boolean
+          default: true
       responses:
         "200":
           description: successful operation
@@ -806,6 +807,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasLeasesCurrent'
+  /experimental/paras/auctions/current:
+    get:
+      tags:
+      - paras
+      summary: |
+        [Experimental subject to breaking change] Get the status of the current
+        auction.
+      description: |
+        Returns an overview of the current of the current auction. There is only
+        one auction at a time. If there is no auction most fields will be `null`.
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve runtime version information at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParasAuctionsCurrent'
 components:
   schemas:
     BalanceLock:
@@ -1757,6 +1784,8 @@ components:
     ParasLeasesCurrent:
       type: object
       properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
         leasePeriodIndex:
           type: string
           format: unsignedInteger
@@ -1771,6 +1800,54 @@ components:
             type: string
             format: unsignedInteger
           description: List of `paraId`s that currently hold a lease.
+    ParasAuctionsCurrent:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        beginEnd:
+          type: string
+          format: unisgnedInteger or $null
+          description: |
+            Fist block of the auction ending phase. `null` if no ongoing auction.
+        finishEnd:
+          type: string
+          format: unisgnedInteger or $null
+          description: |
+            Last block of the auction ending phase. `null` if no ongoing auction.
+        phase:
+          type: string
+          enum:
+          - opening
+          - ending
+          description: |
+            Wether the auction is in the `opening` or `ending` phase. The 
+            `ending` phase is where the eventual winners are retroactively 
+            picked from. `null` if no ongoing auction.
+        auctionIndex:
+          type: string
+          format: unsignedInteger
+          description: | 
+            Auction number. If there is no current auction this will be the number
+            of the previous auction.
+        leasePeriods:
+          type: array
+          items:
+            type: string
+            format: unsignedInteger
+          description: |
+            Lease period indexes that may be bid on in this auction. `null` if no
+            ongoing auction.
+        winning:
+          type: array
+          items:
+            type: string
+          description: |
+            Array of tuples where each tuple includes `AccountId`, `ParaId`
+            `Balance`. The `Balance` is the bid per lease index made by
+            `AccountId` on behalf of `ParaId`. The index of each tuple represents
+            the `SlotRange` the bid is for. Please read polkadot docs for more
+            details. `null` if no ongoing auction or not in the `ending` phase.
   requestBodies:
     Transaction:
       content:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1800,6 +1800,29 @@ components:
             type: string
             format: unsignedInteger
           description: List of `paraId`s that currently hold a lease.
+    WinningData:
+      type: object
+      properties:
+        bid:
+          type: object
+          properties:
+            accountId:
+              type: string
+            paraId:
+              type: string
+              format: unsignedInteger
+            amount:
+              type: string
+              format: unsignedInteger
+        leaseSet:
+          type: array
+          items:
+            type: string
+            format: unsignedInteger
+      description: |
+        A currently win bid and the set of lease periods the bid is for. The
+        `amount` of the bid is per lease period. The `bid` property will be `null`
+        if no bid has been made for the corresponding `SlotRange`.
     ParasAuctionsCurrent:
       type: object
       properties:
@@ -1841,13 +1864,7 @@ components:
         winning:
           type: array
           items:
-            type: string
-          description: |
-            Array of tuples where each tuple includes `AccountId`, `ParaId`
-            `Balance`. The `Balance` is the bid per lease index made by
-            `AccountId` on behalf of `ParaId`. The index of each tuple represents
-            the `SlotRange` the bid is for. Please read polkadot docs for more
-            details. `null` if no ongoing auction or not in the `ending` phase.
+            $ref: '#/components/schemas/WinningData'
   requestBodies:
     Transaction:
       content:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1932,12 +1932,14 @@ components:
           type: string
           format: unisgnedInteger or $null
           description: |
-            Fist block of the auction ending phase. `null` if no ongoing auction.
+            Fist block of the auction ending phase. `null` if there is no ongoing
+            auction.
         finishEnd:
           type: string
           format: unisgnedInteger or $null
           description: |
-            Last block of the auction ending phase. `null` if no ongoing auction.
+            Last block of the auction ending phase. `null` if there is no ongoing
+            auction.
         phase:
           type: string
           enum:
@@ -1946,7 +1948,7 @@ components:
           description: |
             Whether the auction is in the `opening` or `ending` phase. The
             `ending` phase is where the eventual winners are retroactively
-            picked from. `null` if no ongoing auction.
+            picked from. `null` if there is no ongoing auction.
         auctionIndex:
           type: string
           format: unsignedInteger
@@ -1959,8 +1961,8 @@ components:
             type: string
             format: unsignedInteger
           description: |
-            Lease period indexes that may be bid on in this auction. `null` if no
-            ongoing auction.
+            Lease period indexes that may be bid on in this auction. `null` if
+            there is no ongoing auction.
         winning:
           type: array
           items:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -18,6 +18,7 @@ tags:
   description: pallets employed in the runtime
 - name: runtime
 - name: transaction
+- name: paras
 paths:
   /accounts/{accountId}/balance-info:
     get:
@@ -747,6 +748,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /experimental/paras:
+    get:
+      tags:
+      - paras
+      summary: |
+        [Experimental subject to breaking change] List all registered para
+        (parathreads & parachains).
+      description: Returns registered parachains and parathreads with lifecycle info.
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve runtime version information at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Paras'
+  /experimental/paras/leases/current:
+    get:
+      tags:
+      - paras
+      summary: |
+        [Experimental subject to breaking change] Get general information about
+        the current lease period.
+      description: |
+        Returns an overview of the current lease period, including lease holders.
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve runtime version information at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: currentLeaseHolders
+        in: query
+        description: |
+          Wether or not to include the `currentLeaseHolders` property. Inclusion
+          of the property will likely result in a larger payload and increased 
+          response time.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParasLeasesCurrent'
 components:
   schemas:
     BalanceLock:
@@ -1659,6 +1718,59 @@ components:
           items:
             $ref: '#/components/schemas/PalletStorageItemMetadata'
           description: Array containing metadata for each storage entry of the pallet.
+    Para:
+      type: object
+      properties:
+        paraId:
+          type: string
+          format: unsignedInteger
+        paraLifeCycle:
+          type: string
+          enum:
+          - onboarding
+          - parathread
+          - parachain
+          - upgradingParathread
+          - downgradingParachain
+          - offboardingParathread
+          - offboardingParachain
+          description: |
+            The possible states of a para, to take into account delayed lifecycle
+            changes.
+        onboardingAs:
+          type: string
+          enum:
+          - parachain
+          - parathread
+          description: |
+            This property only shows up when `paraLifeCycle=onboarding`. It
+            describes if a particular para is onboarding as a `parachain` or a `parathread`.
+    Paras:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        paras:
+          type: array
+          items:
+            $ref: '#/components/schemas/Para'
+    ParasLeasesCurrent:
+      type: object
+      properties:
+        leasePeriodIndex:
+          type: string
+          format: unsignedInteger
+          description: Current lease period index.
+        endOfLeasePeriod:
+          type: string
+          format: unsignedInteger
+          description: Last block (number) of the current lease period.
+        currentLeaseHolders:
+          type: array
+          items:
+            type: string
+            format: unsignedInteger
+          description: List of `paraId`s that currently hold a lease.
   requestBodies:
     Transaction:
       content:

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -33,7 +33,6 @@ export class ParasService extends AbstractService {
 	/**
 	 * Get crowdloan information for a `paraId`.
 	 *
-         *  `/:paraId/crowdloan-info` Service function to retrieve crowdloan information for a specific paraId.
 	 * @param hash `BlockHash` to make call at
 	 * @param paraId ID of para to get crowdloan info for
 	 */

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -222,7 +222,7 @@ export class ParasService extends AbstractService {
 			}
 
 			finishEnd = beginEnd.add(endingPeriod);
-			phase = beginEnd.gt(blockNumber) ? 'preEnding' : 'ending';
+			phase = beginEnd.gt(blockNumber) ? 'opening' : 'ending';
 		} else {
 			leasePeriodIndex = null;
 			beginEnd = null;

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -249,7 +249,7 @@ export class ParasService extends AbstractService {
 			}
 
 			finishEnd = beginEnd.add(endingPeriod);
-			phase = beginEnd.gt(blockNumber) ? 'opening' : 'ending';
+			phase = beginEnd.gt(blockNumber) ? 'starting' : 'ending';
 		} else {
 			leasePeriodIndex = null;
 			beginEnd = null;

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -13,7 +13,7 @@ import BN from 'bn.js';
 import { IOption } from '../util';
 import { IAt } from './';
 
-export type AuctionPhase = 'preEnding' | 'ending';
+export type AuctionPhase = 'opening' | 'ending';
 
 export type ParaType = 'parachain' | 'parathread';
 
@@ -92,7 +92,7 @@ export interface IAuctionsCurrent {
 	 */
 	finishEnd: IOption<BN>;
 	/**
-	 * Phase of auction. One of `PreEnding` or `Ending`. The `Ending` phase is where
+	 * Phase of auction. One of `opening` or `ending`. The `ending` phase is where
 	 * an eventual winner is chosen retroactively by randomly choosing a block number
 	 * in the `Ending` phase and using the `winning` bids.
 	 */

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import { IOption } from '../util';
 import { IAt } from './';
 
-export type AuctionPhase = 'opening' | 'ending';
+export type AuctionPhase = 'starting' | 'ending';
 
 export type ParaType = 'parachain' | 'parathread';
 


### PR DESCRIPTION
adds docs for
- `/paras`
- `/paras/leases/current`
- `/paras/auctions/current`
- `/paras/crowdloans`
- `/paras/{paraId}/crowdloan-info`
- `/paras/{paraId}/lease-info`

changes 
- Auction phases are now modeled as `AuctionPhase::Starting` instead of (`AuctionPhase::PreEnding`) and `AuctionPhase::Ending`. 

future prs
- tests