### PR TITLE
 feat: include lease set for each winning bid in auctions/current

### DIFF
--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -23,6 +23,7 @@ import {
 	ILeaseInfo,
 	ILeasesCurrent,
 	IParas,
+	ISlotSet,
 	LeaseFormatted,
 	ParaType,
 } from '../../types/responses';
@@ -72,8 +73,6 @@ export class ParasService extends AbstractService {
 		return {
 			at,
 			fundInfo,
-			// TOOD would it make snese to merge the below derived info into `fundInfo`
-			// or put them under another key like `fundInfoDerive`?
 			leasePeriods,
 		};
 	}
@@ -131,12 +130,15 @@ export class ParasService extends AbstractService {
 	 * @param paraId ID of para to get lease info of
 	 */
 	async leaseInfo(hash: BlockHash, paraId: number): Promise<ILeaseInfo> {
-		const [leases, { number }, paraLifeCycle] = await Promise.all([
+		const [leases, { number }, paraLifeCycleOpt] = await Promise.all([
 			this.api.query.slots.leases.at<
 				Vec<Option<ITuple<[AccountId, BalanceOf]>>>
 			>(hash, paraId),
 			this.api.rpc.chain.getHeader(hash),
-			this.api.query.paras.paraLifecycles.at<ParaLifecycle>(hash, paraId),
+			this.api.query.paras.paraLifecycles.at<Option<ParaLifecycle>>(
+				hash,
+				paraId
+			),
 		]);
 		const blockNumber = number.unwrap();
 
@@ -169,19 +171,21 @@ export class ParasService extends AbstractService {
 		}
 
 		let onboardingAs: ParaType | undefined;
-		if (paraLifeCycle.isOnboarding) {
-			const paraGenesisArgs = await this.api.query.paras.paraGenesisArgs.at<ParaGenesisArgs>(
-				hash,
-				paraId
-			);
-			onboardingAs = paraGenesisArgs.parachain.isTrue
-				? 'parachain'
-				: 'parathread';
+		if (paraLifeCycleOpt.isSome && paraLifeCycleOpt.unwrap().isOnboarding) {
+			const paraGenesisArgs = await this.api.query.paras.upcomingParasGenesis.at<
+				Option<ParaGenesisArgs>
+			>(hash, paraId);
+
+			if (paraGenesisArgs.isSome) {
+				onboardingAs = paraGenesisArgs.unwrap().parachain.isTrue
+					? 'parachain'
+					: 'parathread';
+			}
 		}
 
 		return {
 			at,
-			paraLifeCycle,
+			paraLifeCycle: paraLifeCycleOpt,
 			onboardingAs,
 			leases: leasesFormatted,
 		};
@@ -212,11 +216,34 @@ export class ParasService extends AbstractService {
 		if (auctionInfoOpt.isSome) {
 			[leasePeriodIndex, beginEnd] = auctionInfoOpt.unwrap();
 			const endingOffset = this.endingOffset(blockNumber, beginEnd);
-			if (endingOffset) {
-				winning = await this.api.query.auctions.winning.at<Option<WinningData>>(
-					hash,
-					endingOffset
-				);
+			const winningOpt = endingOffset
+				? await this.api.query.auctions.winning.at<Option<WinningData>>(
+						hash,
+						endingOffset
+				  )
+				: await this.api.query.auctions.winning.at<Option<WinningData>>(
+						hash,
+						// when we are not in the ending phase of the auction all winning bids stored at 0
+						0
+				  );
+
+			if (winningOpt.isSome) {
+				const ranges = ParasService.enumerateLeaseSets(leasePeriodIndex);
+
+				// zip the winning bids together with their slot range
+				winning = winningOpt.unwrap().map((bid, idx) => {
+					const leaseSet = ranges[idx];
+
+					let result;
+					if (bid.isSome) {
+						const [accountId, paraId, amount] = bid.unwrap();
+						result = { bid: { accountId, paraId, amount }, leaseSet };
+					} else {
+						result = { bid: null, leaseSet };
+					}
+
+					return result;
+				});
 			} else {
 				winning = null;
 			}
@@ -354,9 +381,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
-	 * The offset into the ending samples of the auction.
-	 *
-	 * Mimics `Auctioneer::is_ending` impl in polkadot's `runtime::common::auctions`.
+	 * The offset into the ending samples of the auction. When we are not in the
+	 * ending phase of the auction we can use 0 as the offset, but we do not return
+	 * that here in order to closely mimic `Auctioneer::is_ending` impl in
+	 * polkadot's `runtime::common::auctions`.
 	 *
 	 * @param now current block number
 	 * @param startEnd block number of the start of the auctions ending period
@@ -374,7 +402,32 @@ export class ParasService extends AbstractService {
 			return null;
 		}
 
-		const sampleLength = this.api.consts.auctions.sampleLength as AbstractInt;
+		// Once https://github.com/paritytech/polkadot/pull/2848 is merged no longer
+		// need a fallback of 1
+		const sampleLength =
+			(this.api.consts.auctions.sampleLength as AbstractInt) || new BN(1);
 		return afterEarlyEnd.div(sampleLength);
+	}
+
+	/**
+	 * Enumerate in order all the lease sets (SlotRange expressed as a set of
+	 * lease periods) that an `auctions::winning` array covers.
+	 *
+	 * @param leasePeriodIndex
+	 */
+	private static enumerateLeaseSets(leasePeriodIndex: BN): ISlotSet[] {
+		const leasePeriodIndexNumber = leasePeriodIndex.toNumber();
+		const ranges: ISlotSet[] = [];
+		for (let start = 0; start < 4; start += 1) {
+			for (let end = start; end < 4; end += 1) {
+				const slotRange = [];
+				for (let i = start; i <= end; i += 1) {
+					slotRange.push(i + leasePeriodIndexNumber);
+				}
+				ranges.push(slotRange as ISlotSet);
+			}
+		}
+
+		return ranges;
 	}
 }

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -22,8 +22,8 @@ import {
 	IFund,
 	ILeaseInfo,
 	ILeasesCurrent,
+	ILeaseSet,
 	IParas,
-	ISlotSet,
 	LeaseFormatted,
 	ParaType,
 } from '../../types/responses';
@@ -415,16 +415,16 @@ export class ParasService extends AbstractService {
 	 *
 	 * @param leasePeriodIndex
 	 */
-	private static enumerateLeaseSets(leasePeriodIndex: BN): ISlotSet[] {
+	private static enumerateLeaseSets(leasePeriodIndex: BN): ILeaseSet[] {
 		const leasePeriodIndexNumber = leasePeriodIndex.toNumber();
-		const ranges: ISlotSet[] = [];
+		const ranges: ILeaseSet[] = [];
 		for (let start = 0; start < 4; start += 1) {
 			for (let end = start; end < 4; end += 1) {
 				const slotRange = [];
 				for (let i = start; i <= end; i += 1) {
 					slotRange.push(i + leasePeriodIndexNumber);
 				}
-				ranges.push(slotRange as ISlotSet);
+				ranges.push(slotRange as ILeaseSet);
 			}
 		}
 

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -223,7 +223,7 @@ export class ParasService extends AbstractService {
 				  )
 				: await this.api.query.auctions.winning.at<Option<WinningData>>(
 						hash,
-						// when we are not in the ending phase of the auction all winning bids stored at 0
+						// when we are not in the ending phase of the auction winning bids are stored at 0
 						0
 				  );
 

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -6,7 +6,6 @@ import {
 	FundInfo,
 	ParaId,
 	ParaLifecycle,
-	WinningData,
 } from '@polkadot/types/interfaces';
 import BN from 'bn.js';
 
@@ -69,7 +68,7 @@ export interface ILeaseInfo {
 	/**
 	 * Lifecycle of the para (i.e Onboarding, Parathread, Offboarding etc)
 	 */
-	paraLifeCycle: ParaLifecycle;
+	paraLifeCycle: Option<ParaLifecycle>;
 	/**
 	 * If the para is in the onboarding phase, this will say if it is onboarding as
 	 * a `parachain` or a `parathread`.
@@ -79,6 +78,26 @@ export interface ILeaseInfo {
 	 * List of current and upcoming leases this para has.
 	 */
 	leases: IOption<LeaseFormatted[]>;
+}
+
+/**
+ * `auctions::WinningData` expressed as an object.
+ */
+export interface IWinningData {
+	accountId: AccountId;
+	paraId: ParaId;
+	amount: BalanceOf;
+}
+
+export type ISlotSet =
+	| [number]
+	| [number, number]
+	| [number, number, number]
+	| [number, number, number, number];
+
+export interface IWinningDataWithSlotRange {
+	bid: IOption<IWinningData>;
+	leaseSet: ISlotSet;
 }
 
 export interface IAuctionsCurrent {
@@ -110,7 +129,7 @@ export interface IAuctionsCurrent {
 	 * Winning bids at this current block height. Is only not `null` during the
 	 * `Ending` phase.
 	 */
-	winning: IOption<Option<WinningData>>;
+	winning: IOption<IWinningDataWithSlotRange[]>;
 }
 
 export interface ILeasesCurrent {

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -89,15 +89,21 @@ export interface IWinningData {
 	amount: BalanceOf;
 }
 
-export type ISlotSet =
+/**
+ * Union of different length lease sets.
+ */
+export type ILeaseSet =
 	| [number]
 	| [number, number]
 	| [number, number, number]
 	| [number, number, number, number];
 
-export interface IWinningDataWithSlotRange {
+/**
+ * Bid and correspond set of leases.
+ */
+export interface IWinningDataWithLeaseSet {
 	bid: IOption<IWinningData>;
-	leaseSet: ISlotSet;
+	leaseSet: ILeaseSet;
 }
 
 export interface IAuctionsCurrent {
@@ -129,7 +135,7 @@ export interface IAuctionsCurrent {
 	 * Winning bids at this current block height. Is only not `null` during the
 	 * `Ending` phase.
 	 */
-	winning: IOption<IWinningDataWithSlotRange[]>;
+	winning: IOption<IWinningDataWithLeaseSet[]>;
 }
 
 export interface ILeasesCurrent {


### PR DESCRIPTION
changes
- correct type annotations on some queries
- use 0 as the offset for when we are not in the ending phase of an auction
- hardcode a fallback for `this.api.consts.auctions.sampleLength` because it is not yet in the metadata
- data in `winning` array is now structured with properties describing each tuple member. We also add in the `leaseSet`, which is the lease periods the bid is for