### PR TITLE
fix: refactor typeFactory, cleanup mockApi

### DIFF
--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -37,9 +37,6 @@ import { events789629 } from './data/events789629Hex';
 import { localListenAddressesHex } from './data/localListenAddresses';
 import { validators789629Hex } from './data/validators789629Hex';
 
-const rococoApi = createApiWithAugmentations(rococoMetadataV228);
-const rococoTypeFactory = new TypeFactory(rococoApi);
-
 const eventsAt = (_hash: Hash) =>
 	Promise.resolve().then(() =>
 		polkadotRegistry.createType('Vec<EventRecord>', events789629)
@@ -296,6 +293,8 @@ const referendumInfoOfAt = () =>
  * The below types and constants use the rococo registry in order to properly
  * test the ParasService with accurate metadata
  */
+const rococoApi = createApiWithAugmentations(rococoMetadataV228);
+const rococoTypeFactory = new TypeFactory(rococoApi);
 
 /**
  * Used for parachain crowdloans

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -17,6 +17,7 @@ import {
 import { Codec } from '@polkadot/types/types';
 import BN from 'bn.js';
 
+import { rococoMetadataV228 } from '../../..//test-helpers/metadata/rococoMetadata';
 import { polkadotMetadata } from '../../../test-helpers/metadata/metadata';
 import {
 	polkadotRegistry,
@@ -36,8 +37,8 @@ import { events789629 } from './data/events789629Hex';
 import { localListenAddressesHex } from './data/localListenAddresses';
 import { validators789629Hex } from './data/validators789629Hex';
 
-const api = createApiWithAugmentations();
-const typeFactory = new TypeFactory(api);
+const rococoApi = createApiWithAugmentations(rococoMetadataV228);
+const rococoTypeFactory = new TypeFactory(rococoApi);
 
 const eventsAt = (_hash: Hash) =>
 	Promise.resolve().then(() =>
@@ -295,6 +296,10 @@ const referendumInfoOfAt = () =>
  * The below types and constants use the rococo registry in order to properly
  * test the ParasService with accurate metadata
  */
+
+/**
+ * Used for parachain crowdloans
+ */
 const funds = {
 	depositor: rococoRegistry.createType(
 		'AccountId',
@@ -324,8 +329,16 @@ const paraLifecycleObjectTwo = {
 	parathread: true,
 	parachain: false,
 };
-const paraId1 = typeFactory.storageKey(199);
-const paraId2 = typeFactory.storageKey(200);
+const crowdloanParaId1 = rococoTypeFactory.storageKey(
+	199,
+	'ParaId',
+	rococoApi.query.crowdloan.funds
+);
+const crowdloanParaId2 = rococoTypeFactory.storageKey(
+	200,
+	'ParaId',
+	rococoApi.query.crowdloan.funds
+);
 const paraLifecycleOne = rococoRegistry.createType(
 	'ParaLifecycle',
 	paraLifecycleObjectOne
@@ -350,8 +363,8 @@ const fundsEntries = () =>
 		const optionFundInfo = rococoRegistry.createType('Option<FundInfo>', funds);
 
 		const entries = [
-			[paraId1, optionFundInfo],
-			[paraId2, optionFundInfo],
+			[crowdloanParaId1, optionFundInfo],
+			[crowdloanParaId2, optionFundInfo],
 		];
 
 		return entries;
@@ -364,14 +377,28 @@ const fundsAt = () =>
 
 const fundsKeys = () =>
 	Promise.resolve().then(() => {
-		return [paraId1, paraId2];
+		return [crowdloanParaId1, crowdloanParaId2];
 	});
+
+/**
+ * Used for parachain paras
+ */
+const paraLifeCycleParaId1 = rococoTypeFactory.storageKey(
+	199,
+	'ParaId',
+	rococoApi.query.paras.paraLifecycles
+);
+const paraLifeCycleParaId2 = rococoTypeFactory.storageKey(
+	200,
+	'ParaId',
+	rococoApi.query.paras.paraLifecycles
+);
 
 const parasLifecyclesEntriesAt = () =>
 	Promise.resolve().then(() => {
 		return [
-			[paraId1, paraLifecycleOne],
-			[paraId2, paraLifecycleTwo],
+			[paraLifeCycleParaId1, paraLifecycleOne],
+			[paraLifeCycleParaId2, paraLifecycleTwo],
 		];
 	});
 
@@ -389,23 +416,36 @@ const upcomingParasGenesisAt = () =>
 
 const parasLifecyclesAt = () =>
 	Promise.resolve().then(() => {
-		return typeFactory.optionOf(paraLifecycleOne);
+		return rococoTypeFactory.optionOf(paraLifecycleOne);
 	});
 
 /**
  * Used for parachain leases
  */
-const leasesTupleOne = typeFactory.tupleOf(
+const leasesParaId1 = rococoTypeFactory.storageKey(
+	199,
+	'ParaId',
+	rococoApi.query.slots.leases
+);
+const leasesParaId2 = rococoTypeFactory.storageKey(
+	200,
+	'ParaId',
+	rococoApi.query.slots.leases
+);
+const leasesTupleOne = rococoTypeFactory.tupleOf(
 	[accountIdOne, balanceOfOne],
 	['AccountId', 'BalanceOf']
 );
-const leasesTupleTwo = typeFactory.tupleOf(
+const leasesTupleTwo = rococoTypeFactory.tupleOf(
 	[accountIdTwo, balanceOfTwo],
 	['AccountId', 'BalanceOf']
 );
-const parasOptionsOne = typeFactory.optionOf(leasesTupleOne);
-const parasOptionsTwo = typeFactory.optionOf(leasesTupleTwo);
-const vectorLeases = typeFactory.vecOf([parasOptionsOne, parasOptionsTwo]);
+const parasOptionsOne = rococoTypeFactory.optionOf(leasesTupleOne);
+const parasOptionsTwo = rococoTypeFactory.optionOf(leasesTupleTwo);
+const vectorLeases = rococoTypeFactory.vecOf([
+	parasOptionsOne,
+	parasOptionsTwo,
+]);
 export const emptyVectorLeases = rococoRegistry.createType('Vec<Raw>', []);
 
 export const slotsLeasesAt = (): Promise<Vec<Option<Tuple>>> =>
@@ -416,8 +456,8 @@ export const slotsLeasesAt = (): Promise<Vec<Option<Tuple>>> =>
 const slotsLeasesEntriesAt = () =>
 	Promise.resolve().then(() => {
 		return [
-			[paraId1, vectorLeases],
-			[paraId2, vectorLeases],
+			[leasesParaId1, vectorLeases],
+			[leasesParaId2, vectorLeases],
 		];
 	});
 
@@ -428,8 +468,11 @@ export const auctionsInfoAt = (): Promise<Option<Vec<BlockNumber>>> =>
 	Promise.resolve().then(() => {
 		const beingEnd = rococoRegistry.createType('BlockNumber', 1000);
 		const leasePeriodIndex = rococoRegistry.createType('BlockNumber', 39);
-		const vectorAuctions = typeFactory.vecOf([beingEnd, leasePeriodIndex]);
-		const optionAuctions = typeFactory.optionOf(vectorAuctions);
+		const vectorAuctions = rococoTypeFactory.vecOf([
+			beingEnd,
+			leasePeriodIndex,
+		]);
+		const optionAuctions = rococoTypeFactory.optionOf(vectorAuctions);
 
 		return optionAuctions;
 	});
@@ -448,16 +491,16 @@ const auctionsWinningsAt = () =>
 	Promise.resolve().then(() => {
 		const paraId1 = rococoRegistry.createType('ParaId', 199);
 		const paraId2 = rococoRegistry.createType('ParaId', 200);
-		const tupleOne = typeFactory.tupleOf(
+		const tupleOne = rococoTypeFactory.tupleOf(
 			[accountIdOne, paraId1, balanceOfOne],
 			['AccountId', 'ParaId', 'BalanceOf']
 		);
-		const tupleTwo = typeFactory.tupleOf(
+		const tupleTwo = rococoTypeFactory.tupleOf(
 			[accountIdTwo, paraId2, balanceOfTwo],
 			['AccountId', 'ParaId', 'BalanceOf']
 		);
-		const parasOptionsOne = typeFactory.optionOf(tupleOne);
-		const parasOptionsTwo = typeFactory.optionOf(tupleTwo);
+		const parasOptionsOne = rococoTypeFactory.optionOf(tupleOne);
+		const parasOptionsTwo = rococoTypeFactory.optionOf(tupleTwo);
 
 		// No bids for the remaining slot ranges
 		const mockWinningOptions = new Array(8).fill(
@@ -465,12 +508,12 @@ const auctionsWinningsAt = () =>
 		) as Option<Tuple>[];
 
 		// Total of 10 winning object, 2 `Some(..)`, 8 `None`
-		const vectorWinnings = typeFactory.vecOf([
+		const vectorWinnings = rococoTypeFactory.vecOf([
 			parasOptionsOne,
 			parasOptionsTwo,
 			...mockWinningOptions,
 		]);
-		const optionWinnings = typeFactory.optionOf(vectorWinnings);
+		const optionWinnings = rococoTypeFactory.optionOf(vectorWinnings);
 
 		return optionWinnings;
 	});

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -21,7 +21,7 @@ type GenericStorageEntryFunction = (
 
 /**
  * Creates an augmented api with a specific chains metadata. This allows
- * for flexible testing.
+ * for flexible type creation, which can be useful for testing.
  *
  * @param metaData Metadata to be associated with the api augmentation
  */

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -38,7 +38,7 @@ export function createApiWithAugmentations(
 		registry,
 	});
 
-	api.injectMetadata(metadata, true);
+	api.injectMetadata(expandedMetadata, true);
 
 	return api;
 }
@@ -60,12 +60,9 @@ export class TypeFactory {
 	}
 
 	/**
-	 * @param index
-	 * The id to assign the key to.
-	 * @param indexType
-	 * The InterfaceType that will be used to create the index into its new appropriate index type
-	 * @param storageEntry
-	 * Used primarily on QueryableStorageEntry (ie: api.query) within the polkadot api library.
+	 * @param index The id to assign the key to.
+	 * @param indexType The InterfaceType that will be used to create the index into its new appropriate index type
+	 * @param storageEntry Used primarily on QueryableStorageEntry (ie: api.query) within the polkadot api library.
 	 * Contains necessary key value pairs to retrieve specific information from a query
 	 * such as `at`, `entriesAt`, `entries` etc..
 	 *
@@ -73,26 +70,26 @@ export class TypeFactory {
 	 * 1. apiPromise.query.crowdloans.funds
 	 * 2. apiPromise.query.slots.leases
 	 */
-	storageKey = (
+	storageKey(
 		index: number,
 		indexType: keyof InterfaceTypes,
 		storageEntry: StorageEntryBase<'promise', GenericStorageEntryFunction>
-	): StorageKey => {
+	): StorageKey {
 		const id = this.#registry.createType(indexType, index);
 		const key = new StorageKey(this.#registry, storageEntry.key(id));
 
 		return key.setMeta(storageEntry.creator.meta);
-	};
+	}
 
-	optionOf = <T extends Codec>(value: T): Option<T> => {
+	optionOf<T extends Codec>(value: T): Option<T> {
 		return new Option<T>(
 			this.#registry,
 			value.constructor as Constructor<T>,
 			value
 		);
-	};
+	}
 
-	vecOf = <T extends Codec>(items: T[]): Vec<T> => {
+	vecOf<T extends Codec>(items: T[]): Vec<T> {
 		const vector = new Vec<T>(
 			this.#registry,
 			items[0].constructor as Constructor<T>
@@ -101,12 +98,12 @@ export class TypeFactory {
 		vector.push(...items);
 
 		return vector;
-	};
+	}
 
-	tupleOf = <T extends Codec>(
+	tupleOf<T extends Codec>(
 		value: T[],
 		types: (Constructor | keyof InterfaceTypes)[]
-	): Tuple => {
+	): Tuple {
 		return new Tuple(this.#registry, types, value);
-	};
+	}
 }

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -44,8 +44,9 @@ export function createApiWithAugmentations(
 }
 
 /**
- * This Factory facilitates a use for creating types when the registries `createType` method
- * does not suffice.
+ * Factory for creating polkadot-js `Codec` types. Useful for creating
+ * complex types that `createType` cannot accommodate (i.e. creating complex
+ * mock data for testing).
  *
  * Ex: <Vec<Option<Tuple<[AccountId, BalanceOf]>>>>
  */

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -29,7 +29,7 @@ export function createApiWithAugmentations(
 	metadata?: string | Uint8Array
 ): ApiPromise {
 	const registry = new TypeRegistry();
-	const metadata = new Metadata(registry, metaData);
+	const expandedMetadata = new Metadata(registry, metadata);
 
 	registry.setMetadata(metadata);
 

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -12,7 +12,7 @@ import {
 import { Observable } from '@polkadot/x-rxjs';
 
 /**
- * Necessary Type to fulfill StorageEntryBase regarding storage keys
+ * Type to fulfill StorageEntryBase regarding storage keys
  */
 type GenericStorageEntryFunction = (
 	arg1?: CodecArg,

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -70,8 +70,8 @@ export class TypeFactory {
 	 * such as `at`, `entriesAt`, `entries` etc..
 	 *
 	 * Some Parameter Examples:
-	 * 1. this.api.query.crowdloans.funds
-	 * 2. this.api.query.slots.leases
+	 * 1. apiPromise.query.crowdloans.funds
+	 * 2. apiPromise.query.slots.leases
 	 */
 	storageKey = (
 		index: number,

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -23,7 +23,7 @@ type GenericStorageEntryFunction = (
  * Creates an augmented api with a specific chains metadata. This allows
  * for flexible type creation, which can be useful for testing.
  *
- * @param metaData Metadata to be associated with the api augmentation
+ * @param metadata Metadata to be associated with the api augmentation
  */
 export function createApiWithAugmentations(
 	metaData?: string | Uint8Array

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -20,7 +20,7 @@ type GenericStorageEntryFunction = (
 ) => Observable<Codec>;
 
 /**
- * Used to create an augmented api for a specific chains metadata. This allows
+ * Creates an augmented api with a specific chains metadata. This allows
  * for flexible testing.
  *
  * @param metaData Metadata to be associated with the api augmentation

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -26,7 +26,7 @@ type GenericStorageEntryFunction = (
  * @param metaData Metadata to be associated with the api augmentation
  */
 export function createApiWithAugmentations(
-	metaData: string | Uint8Array | undefined
+	metaData?: string | Uint8Array
 ): ApiPromise {
 	const registry = new TypeRegistry();
 	const metadata = new Metadata(registry, metaData);

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -31,7 +31,7 @@ export function createApiWithAugmentations(
 	const registry = new TypeRegistry();
 	const expandedMetadata = new Metadata(registry, metadata);
 
-	registry.setMetadata(metadata);
+	registry.setMetadata(expandedMetadata);
 
 	const api = new ApiPromise({
 		provider: new WsProvider('ws://', false),

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -59,9 +59,8 @@ export class TypeFactory {
 	}
 
 	/**
-	 *
 	 * @param index
-	 * The id to assign the key as.
+	 * The id to assign the key to.
 	 * @param indexType
 	 * The InterfaceType that will be used to create the index into its new appropriate index type
 	 * @param storageEntry

--- a/src/test-helpers/typeFactory.ts
+++ b/src/test-helpers/typeFactory.ts
@@ -26,7 +26,7 @@ type GenericStorageEntryFunction = (
  * @param metadata Metadata to be associated with the api augmentation
  */
 export function createApiWithAugmentations(
-	metaData?: string | Uint8Array
+	metadata?: string | Uint8Array
 ): ApiPromise {
 	const registry = new TypeRegistry();
 	const metadata = new Metadata(registry, metaData);


### PR DESCRIPTION
### Added

* Allow `TypeFactory.storageKey` to dynamically create storage keys for any `StorageEntryBase`.

* Change `createApiWithAugmentations` dynamically create api's for testing.

* Cleanup mockApi to have clearer naming for each set of paraId constants. Also specify where rococo is being used as an api and registry typefactory