### PR TITLE
docs: update release and publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ use squash merge and 2/ that the title of the PR follows the Conventional Commit
 
 4. Update the version in the package.json (this is very important for releasing on NPM).
 
-5. Update the changelog by looking at the past commits since the last release. Follow the format of previous releases. 
+5. Update `CHANGELOG.md` by looking at merged PRs since the last release. Follow the format of previous releases. 
 
   * Make sure to note if it has a high upgrade priority.
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Need help or want to contribute ideas or code? Head over to our [CONTRIBUTING](C
 All the commits in this repo follow the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/#summary). When merging a PR, make sure 1/ to
 use squash merge and 2/ that the title of the PR follows the Conventional Commits spec.
 
-### Preparation
+### Step 1 - Preparation
 
 1. Checkout a branch `name-v5-0-1`. When deciding what version will be released it is important to look over 1) PRs since the last release and 2) release notes for any updated polkadot-js dependencies as they may affect type definitions.
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ $ yarn npm publish
 
 ```bash
 git tag v5.0.1
-git push origin --tags
+git push origin v5.0.1
 ```
 
 2. Go to tags on github, inside of the repo, and click the three dots to the far right and select the option to create a release. 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ $ yarn npm publish
 1. Make sure the tag reflects your corresponding version, and run:
 
 ```bash
-git tag v5.0.1
+git tag -s v5.0.1
 git push origin v5.0.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -268,12 +268,14 @@ curl -s http://0.0.0.0:8080/blocks/head | jq
 
 Need help or want to contribute ideas or code? Head over to our [CONTRIBUTING](CONTRIBUTING.md) doc for more information.
 
-## Note for maintainers (Commits && Releases && Publishing)
+## Note for maintainers
+
+* Commits && Releases && Publishing
 
 All the commits in this repo follow the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/#summary). When merging a PR, make sure 1/ to
 use squash merge and 2/ that the title of the PR follows the Conventional Commits spec.
 
-### Preperation
+### Preparation
 
 1. Checkout a branch `name-v5-0-1`. When deciding what version will be released it is important to look over the past commits since the last release and the updated dependencies release notes in step 2 to see if this will be a major, minor, or patch release. If you have any questions feel free to ask the maintainers.
 

--- a/README.md
+++ b/README.md
@@ -268,32 +268,65 @@ curl -s http://0.0.0.0:8080/blocks/head | jq
 
 Need help or want to contribute ideas or code? Head over to our [CONTRIBUTING](CONTRIBUTING.md) doc for more information.
 
-## Note for maintainers
+## Note for maintainers (Commits && Releases && Publishing)
 
 All the commits in this repo follow the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/#summary). When merging a PR, make sure 1/ to
 use squash merge and 2/ that the title of the PR follows the Conventional Commits spec.
 
-The history of commits will be used to generate the `CHANGELOG`. To do so, run `yarn deploy` on the master
-branch. This command will look at all the commits since the latest tag, bump the package version according
-to semver rules, and generate a new `CHANGELOG`.
+### Preperation
 
-If you don't want to follow semver or need to do a dry run, consult the [`standard-version` CLI usage](https://github.com/conventional-changelog/standard-version#cli-usag)
-docs. Flags for `standard-version` can be passed to `yarn deploy`.
+1. Checkout a branch `name-v5-0-1`. When deciding what version will be released it is important to look over the past commits since the last release and the updated dependencies release notes in step 2 to see if this will be a major, minor, or patch release. If you have any questions feel free to ask the maintainers.
 
-`yarn deploy`, which only does local operations and doesn't push anything, will output more or
-less the following lines:
+2. Ensure we have the latest polkadot-js dependencies
 
-``` bash
-$ yarn deploy
-yarn run v1.21.1
-$ yarn build && standard-version -r minor
-$ rimraf lib/ && tsc
-✔ bumping version in package.json from 0.18.1 to 0.18.2
-✔ outputting changes to CHANGELOG.md
-✔ committing package.json and CHANGELOG.md
-✔ tagging release v0.18.2
-ℹ Run `git push --follow-tags origin master && npm publish` to publish
+  * @polkadot/api [release notes](https://github.com/polkadot-js/api/releases)
+  * @polkadot/apps-config [release notes](https://github.com/polkadot-js/apps/releases)
+  * @polkadot/util-crypto [release notes](https://github.com/polkadot-js/common/releases)
+
+  Note: Every monday the polkadot-js ecosystem will usually come out with a new release. It's important that we keep up, and read the release notes for any breaking changes, or high priority updates.
+
+3. After updating the dependencies, the next step is making sure the release will work against all noted runtimes for Polkadot, Kusama, and Westend. This can be handled via the [sidecar-runtime-test](https://github.com/TarikGul/sidecar-runtime-test) helper library. Instructions for how to run it are in the repos README.md. Before moving forward ensure all tests pass, and if it warns of any missing types feel free to make an issue [here](https://github.com/paritytech/substrate-api-sidecar/issues). 
+
+4. Update the version in the package.json (this is very important for releasing on NPM).
+
+5. Update the changelog by looking at the past commits since the last release. Follow the format of previous releases. 
+
+  * Make sure to note if it has a high upgrade priority.
+
+6. Commit with ex: `chore(release): 5.0.1`, then push your release up, make a PR, get review approval, then merge. 
+
+  * NOTE: Before pushing up as a sanity check run the 3 following commands and ensure they all run with zero errors.
+  ```bash
+  $ yarn test
+  $ yarn build
+  $ yarn lint
+  ```
+
+### Release && Pubishing to NPM and Github
+
+** NPM **
+
+NOTE: You must be a member of the @substrate NPM org and must belong to the developers team within the org. (Please make sure you have 2FA enabled.) 
+
+1. Now that master has the commit for the release, pull down master. Run `yarn build` to ensure the target JS build is there for the NPM release. 
+
+2. Run the following commands. (Please ensure you have 2FA enabled)
+
+```bash
+$ yarn npm login
+...
+$ yarn npm publish
 ```
 
-To publish the new package, just follow the instructions: `git push --follow-tags origin master && npm publish.`
-You must have access to the @substrate organization on npm to publish.
+** Github **
+
+1. Make sure the tag reflects your corresponding version, and run:
+
+```bash
+git tag v5.0.1
+git push origin --tags
+```
+
+2. Go to tags on github, inside of the repo, and click the three dots to the far right and select the option to create a release. 
+
+3. Generally you can copy the changelog information and set the release notes to that. You can also observe past releases as a reference.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ use squash merge and 2/ that the title of the PR follows the Conventional Commit
 
 5. Update `CHANGELOG.md` by looking at merged PRs since the last release. Follow the format of previous releases. 
 
-  * Make sure to note if it has a high upgrade priority.
+  * Make sure to note if it is a high upgrade priority (e.g. it has type definitions for an upcoming runtime upgrade to a Parity maintained network).
 
 6. Commit with ex: `chore(release): 5.0.1`, then push your release up, make a PR, get review approval, then merge. 
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ use squash merge and 2/ that the title of the PR follows the Conventional Commit
 
 6. Commit with ex: `chore(release): 5.0.1`, then push your release up, make a PR, get review approval, then merge. 
 
-  * NOTE: Before pushing up as a sanity check run the 3 following commands and ensure they all run with zero errors.
+  * NOTE: Before pushing up as a sanity check run the 3 following commands and ensure they all run with zero errors. There is one exception with `yarn test` where you will see an `InternalServerError`, that is alright. As long as all the test suites pass. 
   ```bash
   $ yarn test
   $ yarn build

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ use squash merge and 2/ that the title of the PR follows the Conventional Commit
 
 ### Preparation
 
-1. Checkout a branch `name-v5-0-1`. When deciding what version will be released it is important to look over the past commits since the last release and the updated dependencies release notes in step 2 to see if this will be a major, minor, or patch release. If you have any questions feel free to ask the maintainers.
+1. Checkout a branch `name-v5-0-1`. When deciding what version will be released it is important to look over 1) PRs since the last release and 2) release notes for any updated polkadot-js dependencies as they may affect type definitions.
 
 2. Ensure we have the latest polkadot-js dependencies
 


### PR DESCRIPTION
This PR aims to update the documentation around releasing a new release of sidecar.

closes: [#527](https://github.com/paritytech/substrate-api-sidecar/issues/527) 