### PR TITLE
fix: Bump polkadot-js/api to get parachain types: Document user contract regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "substrate-exec-jest --silent"
   },
   "dependencies": {
-    "@polkadot/api": "^4.8.1",
+    "@polkadot/api": "^4.9.2",
     "@polkadot/apps-config": "^0.90.1",
     "@polkadot/util-crypto": "^6.3.1",
     "@substrate/calc": "^0.2.0",
@@ -54,7 +54,7 @@
     "@types/morgan": "^1.9.2",
     "@types/triple-beam": "^1.3.2",
     "rimraf": "^3.0.2",
-    "standard-version": "^9.2.0",
+    "standard-version": "^9.3.0",
     "tsc-watch": "^4.2.9",
     "typescript": "4.2.4"
   },

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -75,15 +75,13 @@ describe('BlocksService', () => {
 			).toMatchObject(blocks789629Response);
 		});
 
-		it('does not throw when an extrinsic is undefined', async () => {
+		it('throws when an extrinsic is undefined', async () => {
 			// Create a block with undefined as the first extrinisic and the last extrinsic removed
 			const mockBlock789629BadExt = polkadotRegistry.createType(
 				'Block',
 				block789629
 			);
 
-			mockBlock789629BadExt.extrinsics.pop();
-			mockBlock789629BadExt.extrinsics.pop();
 			mockBlock789629BadExt.extrinsics.pop();
 
 			mockBlock789629BadExt.extrinsics.unshift(

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -75,13 +75,15 @@ describe('BlocksService', () => {
 			).toMatchObject(blocks789629Response);
 		});
 
-		it('throws when an extrinsic is undefined', async () => {
+		it('does not throw when an extrinsic is undefined', async () => {
 			// Create a block with undefined as the first extrinisic and the last extrinsic removed
 			const mockBlock789629BadExt = polkadotRegistry.createType(
 				'Block',
 				block789629
 			);
 
+			mockBlock789629BadExt.extrinsics.pop();
+			mockBlock789629BadExt.extrinsics.pop();
 			mockBlock789629BadExt.extrinsics.pop();
 
 			mockBlock789629BadExt.extrinsics.unshift(
@@ -90,14 +92,14 @@ describe('BlocksService', () => {
 
 			// fetchBlock Options
 			const options = {
-				eventDocs: false,
+				eventDocs: true,
 				extrinsicDocs: false,
 				checkFinalized: false,
 				queryFinalizedHead: false,
 				omitFinalizedTag: false,
 			};
 
-			mockApi.rpc.chain.getBlock = (() =>
+			mockApi.derive.chain.getBlock = (() =>
 				Promise.resolve().then(() => {
 					return {
 						block: mockBlock789629BadExt,
@@ -112,7 +114,7 @@ describe('BlocksService', () => {
 				)
 			);
 
-			mockApi.rpc.chain.getBlock = (getBlock as unknown) as GetBlock;
+			mockApi.derive.chain.getBlock = (getBlock as unknown) as GetBlock;
 		});
 
 		it('Returns the finalized tag as undefined when omitFinalizedTag equals true', async () => {

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -26,7 +26,6 @@ import { ExtBaseWeightValue, PerClassValue } from '../../types/chains-config';
 import { IExtrinsic } from '../../types/responses/';
 import {
 	blockHash789629,
-	getBlock,
 	mockApi,
 	mockBlock789629,
 	mockForkedBlock789629,
@@ -90,13 +89,13 @@ describe('BlocksService', () => {
 
 			// fetchBlock Options
 			const options = {
-				eventDocs: true,
+				eventDocs: false,
 				extrinsicDocs: false,
 				checkFinalized: false,
 				queryFinalizedHead: false,
 				omitFinalizedTag: false,
 			};
-
+			const tempGetBlock = mockApi.derive.chain.getBlock;
 			mockApi.derive.chain.getBlock = (() =>
 				Promise.resolve().then(() => {
 					return {
@@ -112,7 +111,7 @@ describe('BlocksService', () => {
 				)
 			);
 
-			mockApi.derive.chain.getBlock = (getBlock as unknown) as GetBlock;
+			mockApi.derive.chain.getBlock = (tempGetBlock as unknown) as GetBlock;
 		});
 
 		it('Returns the finalized tag as undefined when omitFinalizedTag equals true', async () => {

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -323,7 +323,7 @@ export class BlocksService extends AbstractService {
 		block: Block,
 		events: Vec<EventRecord> | string,
 		extrinsicDocs: boolean
-	) {g
+	) {
 		const defaultSuccess = typeof events === 'string' ? events : false;
 		// Note, if events is a string then there was an issue getting them from the node.
 		// In this case we try and create the calls with the registry on `block`

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -323,12 +323,12 @@ export class BlocksService extends AbstractService {
 		block: Block,
 		events: Vec<EventRecord> | string,
 		extrinsicDocs: boolean
-	) {
+	) {g
 		const defaultSuccess = typeof events === 'string' ? events : false;
 		// Note, if events is a string then there was an issue getting them from the node.
 		// In this case we try and create the calls with the registry on `block`
-		// The block from `api.derive.chain.getBlock` this regisry is just the most
-		// recent registry. We know e
+		// The block from `api.derive.chain.getBlock` has the most recent registry,
+		// which coudl cause issues with historical querries.
 		// On the other hand, we know `events` will have the correctly dated query
 		// since it is a storage query..
 		const registry =

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -326,11 +326,11 @@ export class BlocksService extends AbstractService {
 	) {
 		const defaultSuccess = typeof events === 'string' ? events : false;
 		// Note, if events is a string then there was an issue getting them from the node.
-		// In this case we try and create the calls with the registry on `block`
+		// In this case we try and create the calls with the registry on `block`.
 		// The block from `api.derive.chain.getBlock` has the most recent registry,
-		// which coudl cause issues with historical querries.
+		// which could cause issues with historical querries.
 		// On the other hand, we know `events` will have the correctly dated query
-		// since it is a storage query..
+		// since it is a storage query.
 		const registry =
 			typeof events === 'string' ? block.registry : events.registry;
 

--- a/src/services/test-helpers/responses/blocks/blocks789629.json
+++ b/src/services/test-helpers/responses/blocks/blocks789629.json
@@ -10,7 +10,7 @@
             "type": "PreRuntime",
             "index": "6",
             "value": [
-                "BABE",
+                "0x45424142",
                 "0x036d000000f4f4d80f00000000ec9bd8e2d0368c97f3d888837f7283bbe08266869eb613159db547905026c2502a70f168b9ffcc233344005d11ebecd166769200d270a2eaa642118a00acb708a0487a440b0caf3dd5c91ab173e80ddfe5735ef8b938ea87a6105a1161612707"
             ]
         },
@@ -18,7 +18,7 @@
             "type": "Seal",
             "index": "5",
             "value": [
-                "BABE",
+                "0x45424142",
                 "0xae78514e1de84a7d32e55b9b652f9d408ab1f7b4bfdbf6b2fad9cad94a91b86b0161cabf08f5ae1d3a1aa4993e2d96d56c94b03cee0898ccb8385a546084f88b"
             ]
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,40 +829,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/api-derive@npm:4.8.1"
+"@polkadot/api-derive@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/api-derive@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/api": 4.8.1
-    "@polkadot/rpc-core": 4.8.1
-    "@polkadot/types": 4.8.1
+    "@polkadot/api": 4.9.2
+    "@polkadot/rpc-core": 4.9.2
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 479188a0a16bdafa5fd50d581022f43629359c7cf5f8fdeec27868dc7bcd2e35103b773ff068c980c18653dfe0f60fe9907577ca0a324ca6e343fc9f1b2df628
+  checksum: b8c1b4f66348535b5d88ae239602ee04eee401855a628c3202bfa07b70d9c71742bf7724c76d88fbc51c9c380fd521e8a96366bcd44c752355a5841f0fc263a8
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:4.8.1, @polkadot/api@npm:^4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/api@npm:4.8.1"
+"@polkadot/api@npm:4.9.2, @polkadot/api@npm:^4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/api@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/api-derive": 4.8.1
+    "@polkadot/api-derive": 4.9.2
     "@polkadot/keyring": ^6.3.1
-    "@polkadot/metadata": 4.8.1
-    "@polkadot/rpc-core": 4.8.1
-    "@polkadot/rpc-provider": 4.8.1
-    "@polkadot/types": 4.8.1
-    "@polkadot/types-known": 4.8.1
+    "@polkadot/metadata": 4.9.2
+    "@polkadot/rpc-core": 4.9.2
+    "@polkadot/rpc-provider": 4.9.2
+    "@polkadot/types": 4.9.2
+    "@polkadot/types-known": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     bn.js: ^4.11.9
     eventemitter3: ^4.0.7
-  checksum: 01dc838e76bc69d38aa13b192595e8095af405f7e4106cace0ad1cdbb77d76569571177b682b0240cb6480f2f8e02c6503d28b2da61bb2e3346a53f951ba25c2
+  checksum: a95686fe008dcf9f5de69ab433b585fb7ece40fd64bae56555873da829704ee0f24bc96d81b7c653402dbf4dbad772f82db4498ca772e1b80ee765ae8c5307dd
   languageName: node
   linkType: hard
 
@@ -932,17 +932,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/metadata@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/metadata@npm:4.8.1"
+"@polkadot/metadata@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/metadata@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/types": 4.8.1
-    "@polkadot/types-known": 4.8.1
+    "@polkadot/types": 4.9.2
+    "@polkadot/types-known": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 9516361b7a27872ed936cf19560165903823b7efb81accb46a114202583fec66458d87e2e4fcc5ce4e0db9c389575ff10aa821009c3f500eb6ff0a978b164722
+  checksum: efb59a743a536ea5f14e37da6024aab6617016b0521e43ab9c570728d06ad6f33fa13780740715750e401cad389ca55ed378ec6a1c37102b4ee7128284180088
   languageName: node
   linkType: hard
 
@@ -955,26 +955,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/rpc-core@npm:4.8.1"
+"@polkadot/rpc-core@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/rpc-core@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/metadata": 4.8.1
-    "@polkadot/rpc-provider": 4.8.1
-    "@polkadot/types": 4.8.1
+    "@polkadot/metadata": 4.9.2
+    "@polkadot/rpc-provider": 4.9.2
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
-  checksum: 9298e1c81323680c1a384465a1ac204d2f5e3718a4a43e175244aba363cc3df006f2be8d469e96469a2386c45099c50a3b0238cc6e7a998432137de423c20cf9
+  checksum: e2246bd701fc86d2df29aafc7051a404b33fda4732da697789e727ebaf97859605707b23770430fce84b639a4c8716772b7618f00c935067d268f2aa5d4db7fb
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/rpc-provider@npm:4.8.1"
+"@polkadot/rpc-provider@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/rpc-provider@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/types": 4.8.1
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-fetch": ^6.3.1
@@ -982,7 +982,7 @@ __metadata:
     "@polkadot/x-ws": ^6.3.1
     bn.js: ^4.11.9
     eventemitter3: ^4.0.7
-  checksum: 65ec370e246ca26b72c9b88b7bbf66824bb467e63394e73e881b38216d7300ad3c81a6b939bf8323f86cafceb2b2fe2ebd8fa37ae915a0b51fab000651f7dedf
+  checksum: d2b96ffe6361f69848d76e16a603b8551110dbb71dfe7e8233cad1386d34b5d25434cd9075b4fe9834de662b7d9ebc2f5b543c7438d179392fef523b899961c4
   languageName: node
   linkType: hard
 
@@ -1012,16 +1012,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/types-known@npm:4.8.1"
+"@polkadot/types-known@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/types-known@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
     "@polkadot/networks": ^6.3.1
-    "@polkadot/types": 4.8.1
+    "@polkadot/types": 4.9.2
     "@polkadot/util": ^6.3.1
     bn.js: ^4.11.9
-  checksum: 4c775b473370c8a0368c7098f75e1c87bd024287290bac332c4b97f5c2cf13eb7d62b07c7f90136c4468ae20141d0884ab3084191ddc81b66f330b259b798628
+  checksum: 50e88d5f5c994c3bee45f72186cf4a037310da3d7b3e87a2d0694bfe64c298a8fc247f235ffb4fbe242bda51286eaa3ac0f0aff4c4c17be0fc1fc1f900eac8cf
   languageName: node
   linkType: hard
 
@@ -1055,18 +1055,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:4.8.1":
-  version: 4.8.1
-  resolution: "@polkadot/types@npm:4.8.1"
+"@polkadot/types@npm:4.9.2":
+  version: 4.9.2
+  resolution: "@polkadot/types@npm:4.9.2"
   dependencies:
     "@babel/runtime": ^7.14.0
-    "@polkadot/metadata": 4.8.1
+    "@polkadot/metadata": 4.9.2
     "@polkadot/util": ^6.3.1
     "@polkadot/util-crypto": ^6.3.1
     "@polkadot/x-rxjs": ^6.3.1
     "@types/bn.js": ^4.11.6
     bn.js: ^4.11.9
-  checksum: 0215f6915053fb666de3f214c3bc8db561c346d8fa458348f1d0b93344053d6d4da7df05687de6f3ed0ce9e01a242b993c178933f1f52695b71b9603367c4b79
+  checksum: c37ce7b2343e3db7846a0d3e88b87bd4306a780e9bf2ae82e8a399fa21624acd6697a129ae8e02284a428fade8592951c6f90bdf26ff338e79a69e46dde72770
   languageName: node
   linkType: hard
 
@@ -1350,7 +1350,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^4.8.1
+    "@polkadot/api": ^4.9.2
     "@polkadot/apps-config": ^0.90.1
     "@polkadot/util-crypto": ^6.3.1
     "@substrate/calc": ^0.2.0
@@ -1365,7 +1365,7 @@ __metadata:
     express-winston: ^4.1.0
     http-errors: ^1.8.0
     rimraf: ^3.0.2
-    standard-version: ^9.2.0
+    standard-version: ^9.3.0
     tsc-watch: ^4.2.9
     typescript: 4.2.4
     winston: ^3.3.3
@@ -8663,9 +8663,9 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"standard-version@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "standard-version@npm:9.2.0"
+"standard-version@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "standard-version@npm:9.3.0"
   dependencies:
     chalk: ^2.4.2
     conventional-changelog: 3.1.24
@@ -8684,7 +8684,7 @@ fsevents@^2.1.2:
     yargs: ^16.0.0
   bin:
     standard-version: bin/cli.js
-  checksum: 978dd1c7a342fab75d8fdfc8cd790573a94ab7df6777363aa91622599ba0729fa33a1e1e51de1a239a107a3d51cdf6ef7c1dad22c378c0d2e7c1e7be1ff2e862
+  checksum: e56d3e550622d5a636a311ee432d2bb9697a9d4610a57e779d3f47a20bae4393547a1bd1de34151b01b7408b32976e88daa08cb4c4a29a61379ceeb77a248633
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### NOTE 
~~need to hold off on merging until I figure out how to get a valid type registry. The one of the derive block is not working~~ Using the registry from `Vec<EventRecord>` now, which seems to work.

### Changes

- Bump polkadot-js/api => 4.9.2
- Document changes to serialization of `ConsensusEngineId` (see specs)
- Use `derive.chain.getBlock` to get both authorId and block. We remove the query to `session.validators` and the `authorId` extraction function because it looks like something about the new `ConsensusEngineId` serialization broke that.

We should also check to see if there is any significant performance regression from the new derive.