### PR TITLE
build: Improve release build & process instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,14 +268,15 @@ curl -s http://0.0.0.0:8080/blocks/head | jq
 
 Need help or want to contribute ideas or code? Head over to our [CONTRIBUTING](CONTRIBUTING.md) doc for more information.
 
-## Note for maintainers
+## Notes for maintainers
 
-* Commits && Releases && Publishing
+### Commits
 
-All the commits in this repo follow the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/#summary). When merging a PR, make sure 1/ to
-use squash merge and 2/ that the title of the PR follows the Conventional Commits spec.
+All the commits in this repo follow the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/#summary). When merging a PR, make sure 1) to use squash merge and 2) that the title of the PR follows the Conventional Commits spec.
 
-### Step 1 - Preparation
+### Releases
+
+#### Preparation
 
 1. Checkout a branch `name-v5-0-1`. When deciding what version will be released it is important to look over 1) PRs since the last release and 2) release notes for any updated polkadot-js dependencies as they may affect type definitions.
 
@@ -285,50 +286,48 @@ use squash merge and 2/ that the title of the PR follows the Conventional Commit
   * @polkadot/apps-config [release notes](https://github.com/polkadot-js/apps/releases)
   * @polkadot/util-crypto [release notes](https://github.com/polkadot-js/common/releases)
 
-  Note: Every monday the polkadot-js ecosystem will usually come out with a new release. It's important that we keep up, and read the release notes for any breaking changes, or high priority updates. You can use the following command `yarn upgrade-interactive` to find and update all available releases. Feel free to update other packages that are available for upgrade if reasonable. 
+  Note: Every monday the polkadot-js ecosystem will usually come out with a new release. It's important that we keep up, and read the release notes for any breaking changes, or high priority updates. You can use the following command `yarn upgrade-interactive` to find and update all available releases. Feel free to update other packages that are available for upgrade if reasonable. To upgrade just `@polkadot` scoped deps use `yarn up "@polkadot/*"`.
 
-3. After updating the dependencies, the next step is making sure the release will work against all noted runtimes for Polkadot, Kusama, and Westend. This can be handled via the [sidecar-runtime-test](https://github.com/TarikGul/sidecar-runtime-test) helper library. Instructions for how to run it are in the repos README.md. Before moving forward ensure all tests pass, and if it warns of any missing types feel free to make an issue [here](https://github.com/paritytech/substrate-api-sidecar/issues). 
+3. After updating the dependencies, the next step is making sure the release will work against all noted runtimes for Polkadot, Kusama, and Westend. This can be handled via the [sidecar-runtime-test](https://github.com/TarikGul/sidecar-runtime-test) helper library. Instructions for how to run it are in the repos README.md. Before moving forward ensure all tests pass, and if it warns of any missing types feel free to make an issue [here](https://github.com/paritytech/substrate-api-sidecar/issues).
 
 4. Update the version in the package.json (this is very important for releasing on NPM).
 
-5. Update `CHANGELOG.md` by looking at merged PRs since the last release. Follow the format of previous releases. 
+5. Update `CHANGELOG.md` by looking at merged PRs since the last release. Follow the format of previous releases.Only record dep updates if they reflect type definition updates as those affect the users API.
 
   * Make sure to note if it is a high upgrade priority (e.g. it has type definitions for an upcoming runtime upgrade to a Parity maintained network).
 
-6. Commit with ex: `chore(release): 5.0.1`, then push your release up, make a PR, get review approval, then merge. 
+6. Commit with ex: `chore(release): 5.0.1`, then push your release up, make a PR, get review approval, then merge.
 
-  * NOTE: Before pushing up as a sanity check run the 3 following commands and ensure they all run with zero errors. There is one exception with `yarn test` where you will see an `InternalServerError`, that is alright. As long as all the test suites pass. 
+  * NOTE: Before pushing up as a sanity check run the 3 following commands and ensure they all run with zero errors. There is one exception with `yarn test` where you will see errors logged, that is alright as long as all the test suites pass.
+
   ```bash
-  $ yarn test
-  $ yarn build
-  $ yarn lint
+  yarn build
+  yarn lint
+  yarn test
   ```
 
-### Release && Pubishing to NPM and Github
-
-** NPM **
-
-NOTE: You must be a member of the @substrate NPM org and must belong to the developers team within the org. (Please make sure you have 2FA enabled.) 
-
-1. Now that master has the commit for the release, pull down master. Run `yarn build` to ensure the target JS build is there for the NPM release. 
-
-2. Run the following commands. (Please ensure you have 2FA enabled)
-
-```bash
-$ yarn npm login
-...
-$ yarn npm publish
-```
-
-** Github **
+#### Release on GitHub
 
 1. Make sure the tag reflects your corresponding version, and run:
 
 ```bash
-git tag -s v5.0.1
+git tag v5.0.1
 git push origin v5.0.1
 ```
 
 2. Go to tags on github, inside of the repo, and click the three dots to the far right and select the option to create a release. 
 
 3. Generally you can copy the changelog information and set the release notes to that. You can also observe past releases as a reference.
+
+#### Publish to NPM
+
+NOTE: You must be a member of the @substrate NPM org and must belong to the developers team within the org. (Please make sure you have 2FA enabled.)
+
+1. Now that master has the commit for the release, pull down master. Run `yarn build` to ensure the target JS build is there for the NPM release.
+
+2. Run the following commands. (Please ensure you have 2FA enabled)
+
+```bash
+npm login # Only necessary if not already logged in
+npm publish
+```

--- a/README.md
+++ b/README.md
@@ -308,26 +308,28 @@ All the commits in this repo follow the [Conventional Commits spec](https://www.
 
 #### Release on GitHub
 
-1. Make sure the tag reflects your corresponding version, and run:
+1. Now that master has the commit for the release, pull down `master` branch.
+
+2. Make sure the tag reflects your corresponding version, and run:
 
 ```bash
 git tag v5.0.1
 git push origin v5.0.1
 ```
 
-2. Go to tags on github, inside of the repo, and click the three dots to the far right and select the option to create a release. 
+3. Go to tags on github, inside of the repo, and click the three dots to the far right and select the option to create a release.
 
-3. Generally you can copy the changelog information and set the release notes to that. You can also observe past releases as a reference.
+4. Generally you can copy the changelog information and set the release notes to that. You can also observe past releases as a reference.
 
 #### Publish to NPM
 
-NOTE: You must be a member of the @substrate NPM org and must belong to the developers team within the org. (Please make sure you have 2FA enabled.)
+NOTE: You must be a member of the `@substrate` NPM org and must belong to the `Developers` team within the org. (Please make sure you have 2FA enabled.)
 
-1. Now that master has the commit for the release, pull down master. Run `yarn build` to ensure the target JS build is there for the NPM release.
+1. Now that master has the commit for the release, pull down `master` branch.
 
 2. Run the following commands. (Please ensure you have 2FA enabled)
 
 ```bash
 npm login # Only necessary if not already logged in
-npm publish
+yarn deploy # Builds JS target and then runs npm publish
 ```

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "bugs": {
     "url": "https://github.com/paritytech/substrate-api-sidecar/issues"
   },
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build": "rimraf build/ && tsc",
     "build:calc": "bash ./calc/build.sh",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:docs": "(cd docs && yarn && yarn build)",
     "main": "node ./build/src/main.js",
     "lint": "substrate-dev-run-lint",
-    "deploy": "yarn build && standard-version",
+    "deploy": "yarn build && npm publish",
     "start": "yarn run main",
     "start:log-rpc": "yarn run build && NODE_ENV=test yarn run main ",
     "dev": "tsc-watch --onSuccess \"yarn run main\"",


### PR DESCRIPTION
Changes:
- This makes sure we only ship the JS target by adding the `"files"` key with just the `build` folder. There was some regression in bundling where the distribution went from ~9mb => ~90mb. This brings it back down to ~9mb. 
- Update `yarn deploy` to reflect that we do not automate changelong generation and prevent the footgun of forgetting to build right before publishing.
- Update README instructions