### PR TITLE
fix: update deps, reconfigure tests to reflect most recent polkadot-js changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "test:init-e2e-tests": "python3 ./scripts/run_chain_tests.py"
   },
   "dependencies": {
-    "@polkadot/api": "^4.13.1",
-    "@polkadot/apps-config": "^0.92.1",
-    "@polkadot/util-crypto": "^6.7.1",
+    "@polkadot/api": "^4.14.1",
+    "@polkadot/apps-config": "^0.93.1",
+    "@polkadot/util-crypto": "^6.8.1",
     "@substrate/calc": "^0.2.0",
     "confmgr": "^1.0.6",
     "express": "^4.17.1",
@@ -54,7 +54,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@substrate/dev": "^0.5.2",
+    "@substrate/dev": "^0.5.3",
     "@types/argparse": "^2.0.8",
     "@types/express": "^4.17.11",
     "@types/express-serve-static-core": "^4.17.19",

--- a/src/sanitize/mockData.ts
+++ b/src/sanitize/mockData.ts
@@ -30,7 +30,7 @@ export const PRE_SANITIZED_BALANCE_LOCK = kusamaRegistry.createType(
 	'Vec<BalanceLock>',
 	[
 		{
-			id: 'LockId',
+			id: '00000000',
 			amount: kusamaRegistry.createType(
 				'Balance',
 				'0x0000000000000000ff49f24a6a9c00'

--- a/src/sanitize/sanitizeNumbers.spec.ts
+++ b/src/sanitize/sanitizeNumbers.spec.ts
@@ -30,6 +30,9 @@ import { UInt } from '@polkadot/types/codec/UInt';
 import BN from 'bn.js';
 
 import {
+	H160_U16,
+	H256_U32,
+	H512_U64,
 	MAX_I8,
 	MAX_I16,
 	MAX_I32,
@@ -253,23 +256,23 @@ describe('sanitizeNumbers', () => {
 		});
 
 		it('handles H512', () => {
-			const h = kusamaRegistry.createType('H512', MAX_U64);
+			const h = kusamaRegistry.createType('H512', H512_U64);
 			expect(sanitizeNumbers(h)).toBe(
-				'0x31383434363734343037333730393535313631350000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+				'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 			);
 		});
 
 		it('handles H256', () => {
-			const h = kusamaRegistry.createType('H256', MAX_U32);
+			const h = kusamaRegistry.createType('H256', H256_U32);
 			expect(sanitizeNumbers(h)).toBe(
-				'0x3432393439363732393500000000000000000000000000000000000000000000'
+				'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 			);
 		});
 
 		it('handles H160', () => {
-			const h = kusamaRegistry.createType('H160', MAX_U16);
+			const h = kusamaRegistry.createType('H160', H160_U16);
 			expect(sanitizeNumbers(h)).toBe(
-				'0x3635353335000000000000000000000000000000'
+				'0xffffffffffffffffffffffffffffffffffffffff'
 			);
 		});
 
@@ -806,7 +809,10 @@ describe('sanitizeNumbers', () => {
 		});
 
 		it('converts U8a fixed', () => {
-			const u8a = new (U8aFixed.with(32))(kusamaRegistry, [0x02, 0x03]);
+			const u8a = new (U8aFixed.with(32))(
+				kusamaRegistry,
+				[0x02, 0x03, 0x00, 0x00]
+			);
 			expect(sanitizeNumbers(u8a)).toStrictEqual('0x02030000');
 		});
 
@@ -974,9 +980,9 @@ describe('sanitizeNumbers', () => {
 		});
 
 		it('converts Signature', () => {
-			const s = kusamaRegistry.createType('Signature', MAX_U64);
+			const s = kusamaRegistry.createType('Signature', H512_U64);
 			expect(sanitizeNumbers(s)).toBe(
-				'0x31383434363734343037333730393535313631350000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+				'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 			);
 		});
 
@@ -1102,7 +1108,7 @@ describe('sanitizeNumbers', () => {
 		it('converts Vec<BalanceLock>', () => {
 			expect(sanitizeNumbers(PRE_SANITIZED_BALANCE_LOCK)).toStrictEqual([
 				{
-					id: '0x4c6f636b49640000',
+					id: '0x3030303030303030',
 					amount: '71857424040631296',
 					reasons: 'Misc',
 				},

--- a/src/sanitize/sanitizeNumbers.spec.ts
+++ b/src/sanitize/sanitizeNumbers.spec.ts
@@ -30,9 +30,9 @@ import { UInt } from '@polkadot/types/codec/UInt';
 import BN from 'bn.js';
 
 import {
-	H160_U16,
-	H256_U32,
-	H512_U64,
+	MAX_H160,
+	MAX_H256,
+	MAX_H512,
 	MAX_I8,
 	MAX_I16,
 	MAX_I32,
@@ -256,21 +256,21 @@ describe('sanitizeNumbers', () => {
 		});
 
 		it('handles H512', () => {
-			const h = kusamaRegistry.createType('H512', H512_U64);
+			const h = kusamaRegistry.createType('H512', MAX_H512);
 			expect(sanitizeNumbers(h)).toBe(
 				'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 			);
 		});
 
 		it('handles H256', () => {
-			const h = kusamaRegistry.createType('H256', H256_U32);
+			const h = kusamaRegistry.createType('H256', MAX_H256);
 			expect(sanitizeNumbers(h)).toBe(
 				'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 			);
 		});
 
 		it('handles H160', () => {
-			const h = kusamaRegistry.createType('H160', H160_U16);
+			const h = kusamaRegistry.createType('H160', MAX_H160);
 			expect(sanitizeNumbers(h)).toBe(
 				'0xffffffffffffffffffffffffffffffffffffffff'
 			);
@@ -980,7 +980,7 @@ describe('sanitizeNumbers', () => {
 		});
 
 		it('converts Signature', () => {
-			const s = kusamaRegistry.createType('Signature', H512_U64);
+			const s = kusamaRegistry.createType('Signature', MAX_H512);
 			expect(sanitizeNumbers(s)).toBe(
 				'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 			);

--- a/src/test-helpers/constants.ts
+++ b/src/test-helpers/constants.ts
@@ -23,8 +23,8 @@ export const MAX_U8 = '255';
 export const MAX_I8 = '127';
 export const MIN_I8 = '-128';
 
-export const H512_U64 =
+export const MAX_H512 =
 	'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-export const H256_U32 =
+export const MAX_H256 =
 	'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-export const H160_U16 = '0xffffffffffffffffffffffffffffffffffffffffffffffff';
+export const MAX_H160 = '0xffffffffffffffffffffffffffffffffffffffffffffffff';

--- a/src/test-helpers/constants.ts
+++ b/src/test-helpers/constants.ts
@@ -22,3 +22,9 @@ export const MAX_U8 = '255';
 
 export const MAX_I8 = '127';
 export const MIN_I8 = '-128';
+
+export const H512_U64 =
+	'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+export const H256_U32 =
+	'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+export const H160_U16 = '0xffffffffffffffffffffffffffffffffffffffffffffffff';

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/code-frame@npm:7.14.5"
+  dependencies:
+    "@babel/highlight": ^7.14.5
+  checksum: 48c584cad9aa05ff16fa965b4572deae0343d51abe658a2fb72640e924c229d47f71f880a474cc1e14e613f88a4bfd576609b1e0d8073bbc4e50e60f7e678626
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.13.15":
   version: 7.14.0
   resolution: "@babel/compat-data@npm:7.14.0"
@@ -73,6 +82,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/generator@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 3ba48b75f7680d17b4c3657063339252cf63ea0038b05e24d1611dff2c8f136fc8ca5cb1c293fbc1abc79b153e264bc23a01dc5f440030282e4da0631f12e0b7
+  languageName: node
+  linkType: hard
+
 "@babel/helper-compilation-targets@npm:^7.13.16":
   version: 7.13.16
   resolution: "@babel/helper-compilation-targets@npm:7.13.16"
@@ -98,12 +118,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-function-name@npm:7.14.5"
+  dependencies:
+    "@babel/helper-get-function-arity": ^7.14.5
+    "@babel/template": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: bf2172f932ce3bd8fdaa6df5464a581eee47484952c69115361439727e87d3289925a292655957b39446b6052119896da358022337985eed795444c550f7e4f3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-get-function-arity@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-get-function-arity@npm:7.12.13"
   dependencies:
     "@babel/types": ^7.12.13
   checksum: cfb5c39959ea9f1cc21ee0f4a23054be66a615fa5392f25763ea98f0c690a5b47500af9a63f28a42a2fb3f699684c113c45a95c4ce6303dfecb3358e32e56c76
+  languageName: node
+  linkType: hard
+
+"@babel/helper-get-function-arity@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-get-function-arity@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 1bd0ae6c25af61a7795032452500362bb3f63042aadb1076184ebccc0afcb38e0565da3f02534f806ea0acb915efd75bc1de8530417f7be10f74c4a3efbacb3a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-hoist-variables@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: c2fdc5a2391f13fac73089c563f2a3fcfbec460bd866d6ceb4f97e7138b38a5e16703e6ced3ff1a0e6058aece138e19c30fe11e9e2a65d564d73a6c4a34313e2
   languageName: node
   linkType: hard
 
@@ -116,6 +165,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-member-expression-to-functions@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 9dc1a8a5de887cb3160e4890d4a68a3f43b09f910cdd1b5268c0882c6d5f9b5ba4e4e4f451dc8ed27691fe89a480aec578007503a9204052c381b0eb0d714997
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.13.12":
   version: 7.13.12
   resolution: "@babel/helper-module-imports@npm:7.13.12"
@@ -125,7 +183,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.14.0, @babel/helper-module-transforms@npm:^7.14.2":
+"@babel/helper-module-imports@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-module-imports@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 483919bf31611dc5905acb6a01b888fad1264ddcecaae706c0dde46ff81fa708d98c4a093ab0d4ad71791eb0a30b6dafbfa5364003e71486d6b3c5c718eccf7d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.14.2":
   version: 7.14.2
   resolution: "@babel/helper-module-transforms@npm:7.14.2"
   dependencies:
@@ -141,6 +208,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-module-transforms@npm:7.14.5"
+  dependencies:
+    "@babel/helper-module-imports": ^7.14.5
+    "@babel/helper-replace-supers": ^7.14.5
+    "@babel/helper-simple-access": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/helper-validator-identifier": ^7.14.5
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: b6f47b812d264ea204802d98d6b5a8e47b8fad5a4406a349e7a913b7b881d9be509f95f405a06d5416e95d07539386fa5c50f46eb07e033f0fb9a35f06632bf5
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-optimise-call-expression@npm:7.12.13"
@@ -150,10 +233,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.13.0, @babel/helper-plugin-utils@npm:^7.8.0":
+"@babel/helper-optimise-call-expression@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-optimise-call-expression@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 68845ee7fb88cf7bfbea9635d3fddcc953818b86732985f3fb228f77012652b36f4e41f00d8e7b5e3be2b2d41b6b9f189a36fd49874e58a29dd2e3b1dc753f5c
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.8.0":
   version: 7.13.0
   resolution: "@babel/helper-plugin-utils@npm:7.13.0"
   checksum: 229ac1917b43ad38732d2d4a9a826f87d8945719249efe1d6191f3e25ba6027a289af70380d82d62a03fc9e82558a0ea6f12739cbb55b64bb280d6b511b4ca65
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-plugin-utils@npm:7.14.5"
+  checksum: 76404ef3aadc25879f7b4c5945bafcca935d4af0cf451a95ff9f131f29ac3dc589e2ed19904ce746c7cf6c2a8a7ea33fa4eaf881b9b272d31f2be91984f505d6
   languageName: node
   linkType: hard
 
@@ -169,12 +268,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-replace-supers@npm:7.14.5"
+  dependencies:
+    "@babel/helper-member-expression-to-functions": ^7.14.5
+    "@babel/helper-optimise-call-expression": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 368aba02e75a3bdae7e79d424c7ec98c72a3d8ced95920899e9efc39d274a414c7ab0ac9ed49c9af21e6430a5c5063e382de93d2dd83ff27c8f469a011a658a0
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.13.12":
   version: 7.13.12
   resolution: "@babel/helper-simple-access@npm:7.13.12"
   dependencies:
     "@babel/types": ^7.13.12
   checksum: eff532a1572a4ac562c5918a409871ddf9baee9ece197b98a54622184d3b9e01bdd465597f27ca3d452e71638c913a14819cf261dc095a466032dfd92a88bc73
+  languageName: node
+  linkType: hard
+
+"@babel/helper-simple-access@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-simple-access@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: dd6de62de59ab05121aa1198d01080415584ac4a4d4f5d4e53fd22a1c8d5359d19667cd61663937dffa9ab7761aecbe66eee9e1d266def6a59b4ede2dc15ea57
   languageName: node
   linkType: hard
 
@@ -187,10 +307,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-split-export-declaration@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-split-export-declaration@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 80965627683125d6e4d3ead34f685219933203d7852f2f8af87883702367da5b43bde05b772040434841d7259a4e7045b3ab0ff1768a37c90b6563928191a562
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.14.0":
   version: 7.14.0
   resolution: "@babel/helper-validator-identifier@npm:7.14.0"
   checksum: bd67b4a1a49eba151aa0fe95508579638287fee0a3e7a3bf8c5ab480de8eaad4b4231c523d7db401eb0cecc7cf03b76ee72453fab53bab8cb8ccd154bb67feb7
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-validator-identifier@npm:7.14.5"
+  checksum: 778312189a7c5228daac9f7767795a74f11d1eac595ca38bfea248324666459b24aaae6aef43c957ce01bbe61672039ea1c08c5623067c3701beeb1bb1f1ee33
   languageName: node
   linkType: hard
 
@@ -223,12 +359,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/highlight@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/highlight@npm:7.14.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.5
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: a1ed599c2655eb0b13134875ba2626b547a2634940e532c86a02896fb403f197cd56d1adaa474c7859ae4f53fabc5f1621e90770e75d235ca3350952ba78aa5c
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.13, @babel/parser@npm:^7.14.2":
   version: 7.14.2
   resolution: "@babel/parser@npm:7.14.2"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 18dffc18a2c15f8877988c9b5a46c87f1763e8a383c3210c9b5b651955b1ac46dc54da27acc09acd7fb917f37e0bd92b8985dc4c9d7f1e750dfccbcea730aa0e
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/parser@npm:7.14.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 55c14793888cb7d54275811e7f13136875df1ee4fc368f3f10cff46ebdf95b6a072e706a0486be0ac5686a597cbfb82f33b5f66aa6ba80ff50b73bca945035c6
   languageName: node
   linkType: hard
 
@@ -364,17 +520,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.13.8":
-  version: 7.14.0
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.14.0"
+"@babel/plugin-transform-modules-commonjs@npm:^7.14.0":
+  version: 7.14.5
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.14.5"
   dependencies:
-    "@babel/helper-module-transforms": ^7.14.0
-    "@babel/helper-plugin-utils": ^7.13.0
-    "@babel/helper-simple-access": ^7.13.12
+    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-simple-access": ^7.14.5
     babel-plugin-dynamic-import-node: ^2.3.3
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 61d9f7a8a1386863f61848f7f52180789295ffb3319ccea4079f61bf1d5c9be5cd996ce57b0273861f2dfc88e63f0e23e34acc386ca13a9a56e22b1392c6ad60
+  checksum: 569e82c8deb34f4418383eccd090df0335e715a8c0bdae29dc6fd5545ca317522825ef0c99b16f831d834e7f8044a21fd2e430a8449f01e832910abb594fadd3
   languageName: node
   linkType: hard
 
@@ -396,6 +552,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/runtime@npm:7.14.5"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 1e7b7bd939488df0e9af92fac7cf65a38d6de0e5be71883ac2e5f59e6c1199086a9be723b483f9c79adca9f7a62fdffc9ce6f85b953c7efb3469f01f64a41f27
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.12.13, @babel/template@npm:^7.3.3":
   version: 7.12.13
   resolution: "@babel/template@npm:7.12.13"
@@ -404,6 +569,17 @@ __metadata:
     "@babel/parser": ^7.12.13
     "@babel/types": ^7.12.13
   checksum: 665977068a7036233b017396c0cd4856b6bb2ad9759e95e2325cbd198b98d2e26796f25977c8e12b5936d7d94f49cf883df9cffa3c91c797abdf27fc9b6bec65
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/template@npm:7.14.5"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/parser": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 71619e2e3d6d518bf6c40ebd610379b050a6e8e9a2ec0cda8b5c28aea5105f69006758b575dae63a21a6d4f64f854e92c0cb6cf8841d59f5585596165df78060
   languageName: node
   linkType: hard
 
@@ -423,6 +599,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/traverse@npm:7.14.5"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.5
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-hoist-variables": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/parser": ^7.14.5
+    "@babel/types": ^7.14.5
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 3104bd5c4cd26403964234a22e30ec69a10d61504acb8b5198af32a69a3a2f9ad1fb74b4321e475394ed3d6582bb518e53a765f1e27d61ac54a8627764ab222a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.13, @babel/types@npm:^7.13.12, @babel/types@npm:^7.14.0, @babel/types@npm:^7.14.2, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
   version: 7.14.2
   resolution: "@babel/types@npm:7.14.2"
@@ -430,6 +623,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.14.0
     to-fast-properties: ^2.0.0
   checksum: 34893ac415826cd2ddead0511be9c3cb876bf626148b00b0a471c4630b193939ba46a9bf9d8b2be88e46fceb3ae9204ed7488ceb6a08a67550211d40df65a7c7
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/types@npm:7.14.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.5
+    to-fast-properties: ^2.0.0
+  checksum: 45575b46df5ec0e63454b794a60f362596c6f16beda7df3693b134db5be15eb43f7b98ca7b2a5a9628171db5192eed5b8965e43c0a6f5383bca4ddefd0ea8d30
   languageName: node
   linkType: hard
 
@@ -493,6 +696,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@digitalnative/type-definitions@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "@digitalnative/type-definitions@npm:1.1.9"
+  dependencies:
+    "@polkadot/types": ^4.13.1
+  checksum: 498a127a118a703006fb00e69497ee79b2442107bc5c288a68035b8d9051f969f051a6f584cc0daa8761c7c72356d9e45d9a2a1fca39d956ea3e4605834cfcf0
+  languageName: node
+  linkType: hard
+
+"@docknetwork/node-types@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "@docknetwork/node-types@npm:0.4.6"
+  checksum: 71a781392f82acc528d3d41c2dfd43a8e982f48374d9ca7fb09e1bd1451cc0102690fd051566db447e84290c565845d660d4fccfe5a1650537258f879486bd29
+  languageName: node
+  linkType: hard
+
 "@edgeware/node-types@npm:^3.5.1-erup-4":
   version: 3.5.1-erup-4
   resolution: "@edgeware/node-types@npm:3.5.1-erup-4"
@@ -500,27 +719,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@equilab/definitions@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@equilab/definitions@npm:1.1.1"
-  checksum: 775d83e15be64c9e58ab65263ce4d362768127fcfa75dc97893c8588ab5fde80f798325026f9afcb8881718939fd661efc0333cc6c7263b36b862ad310a852d1
+"@equilab/definitions@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@equilab/definitions@npm:1.2.2"
+  checksum: d6e46452ad884051a635cf9901539404a9a9c4b2c236f21ce7d07bce24a5eb0ad43f313039ed4a51cd7b61cc8dbc72ead563ccd030982491729baba1b286c5ba
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@eslint/eslintrc@npm:0.4.1"
+"@eslint/eslintrc@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@eslint/eslintrc@npm:0.4.2"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.1.1
     espree: ^7.3.0
-    globals: ^12.1.0
+    globals: ^13.9.0
     ignore: ^4.0.6
     import-fresh: ^3.2.1
     js-yaml: ^3.13.1
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
-  checksum: 418f5810c8dd9897d2457ceef098197d0e5f1ad345fbe4cd9256fd4223d7ea83d5e350f9091b3ab3483b6b1c367fa560df3ba1fccc7eb8ca6e1aae5a5b126d60
+  checksum: 60b66ce4257bf5c36a920dea83a056102fef746e7afd7100a6fe245a126ff455f67f4948e75d28ed73090bff8f8556b6a996e74a124911ca703440bc245dbc23
   languageName: node
   linkType: hard
 
@@ -820,70 +1039,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:4.13.1":
-  version: 4.13.1
-  resolution: "@polkadot/api-derive@npm:4.13.1"
+"@polkadot/api-derive@npm:4.14.1":
+  version: 4.14.1
+  resolution: "@polkadot/api-derive@npm:4.14.1"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@polkadot/api": 4.13.1
-    "@polkadot/rpc-core": 4.13.1
-    "@polkadot/types": 4.13.1
-    "@polkadot/util": ^6.7.1
-    "@polkadot/util-crypto": ^6.7.1
-    "@polkadot/x-rxjs": ^6.7.1
-    bn.js: ^4.11.9
-  checksum: 675a90dfb60cb5e917549f95be9ba0dc709a5361ecf7f5fd145715088eefe1250ed9250b0049b81f368ee0119b83727d9c763fab0a37dfc07041614ad0ec38f8
+    "@babel/runtime": ^7.14.5
+    "@polkadot/api": 4.14.1
+    "@polkadot/rpc-core": 4.14.1
+    "@polkadot/types": 4.14.1
+    "@polkadot/util": ^6.8.1
+    "@polkadot/util-crypto": ^6.8.1
+    "@polkadot/x-rxjs": ^6.8.1
+  checksum: 315ff94eef908b27e3ce281e0bbd0f1ea64ee95517b617944c4a1984a4c349e8bdd807170d27ca682047859677e790d40af94aca8fb19ceab25f8366d3a2a2ff
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:4.13.1, @polkadot/api@npm:^4.13.1":
-  version: 4.13.1
-  resolution: "@polkadot/api@npm:4.13.1"
+"@polkadot/api@npm:4.14.1, @polkadot/api@npm:^4.14.1":
+  version: 4.14.1
+  resolution: "@polkadot/api@npm:4.14.1"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@polkadot/api-derive": 4.13.1
-    "@polkadot/keyring": ^6.7.1
-    "@polkadot/metadata": 4.13.1
-    "@polkadot/rpc-core": 4.13.1
-    "@polkadot/rpc-provider": 4.13.1
-    "@polkadot/types": 4.13.1
-    "@polkadot/types-known": 4.13.1
-    "@polkadot/util": ^6.7.1
-    "@polkadot/util-crypto": ^6.7.1
-    "@polkadot/x-rxjs": ^6.7.1
-    bn.js: ^4.11.9
+    "@babel/runtime": ^7.14.5
+    "@polkadot/api-derive": 4.14.1
+    "@polkadot/keyring": ^6.8.1
+    "@polkadot/metadata": 4.14.1
+    "@polkadot/rpc-core": 4.14.1
+    "@polkadot/rpc-provider": 4.14.1
+    "@polkadot/types": 4.14.1
+    "@polkadot/types-known": 4.14.1
+    "@polkadot/util": ^6.8.1
+    "@polkadot/util-crypto": ^6.8.1
+    "@polkadot/x-rxjs": ^6.8.1
     eventemitter3: ^4.0.7
-  checksum: 2c3426a39727dca1123764364f9e3fc85ac5d5bd96b69f70e0edefa97ca7693b7fb89779d6b5b3f85fa67eea86a20281b52a6f89cf9396cf522ea79e55815582
+  checksum: 58983f6aad5d072970a2d9aef19bbb057565e46d2c44fc9dbbfd63333af152805f47925cb89684426e61bce31c61a7b5c39a82a426f42f56ea9ebcf813c4168b
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:^0.92.1":
-  version: 0.92.1
-  resolution: "@polkadot/apps-config@npm:0.92.1"
+"@polkadot/apps-config@npm:^0.93.1":
+  version: 0.93.1
+  resolution: "@polkadot/apps-config@npm:0.93.1"
   dependencies:
     "@acala-network/type-definitions": ^0.7.4-11
     "@babel/runtime": ^7.14.0
     "@crustio/type-definitions": 0.0.10
     "@darwinia/types": ^1.1.0-alpha.21
+    "@digitalnative/type-definitions": ^1.1.9
+    "@docknetwork/node-types": ^0.4.6
     "@edgeware/node-types": ^3.5.1-erup-4
-    "@equilab/definitions": 1.1.1
+    "@equilab/definitions": 1.2.2
     "@interlay/polkabtc-types": ^0.7.3
     "@kiltprotocol/type-definitions": ^0.1.6
     "@laminar/type-definitions": ^0.3.1
     "@phala/typedefs": ^0.1.3
-    "@polkadot/networks": ^6.7.1
+    "@polkadot/networks": ^6.8.1
     "@polymathnetwork/polymesh-types": ^0.0.2
     "@snowfork/snowbridge-types": ^0.2.3
     "@sora-substrate/type-definitions": ^1.3.17
     "@subsocial/types": ^0.5.3
     "@zeitgeistpm/type-defs": ^0.1.51
-    moonbeam-types-bundle: 1.1.21
+    moonbeam-types-bundle: 1.1.22
     pontem-types-bundle: ^1.0.5
-  checksum: 215e40e1ea888653e19541aac1dccb0eae39e73fe4cbf4cd48d894494a6ab5af2bb53a6d3ad14d67507769f0678b077a1a5062ef004823d0a442c05135a0f347
+  checksum: b5e7f0e36df5172f8844ebf0b16cb63aa7f996e8cd557511702434c6ba0177c2c509a9e128b657baa0ca4d0c06a0599b0a8e3da4a0f6910d6e314a3a2576f02d
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1, @polkadot/keyring@npm:^6.7.1":
+"@polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1":
   version: 6.7.1
   resolution: "@polkadot/keyring@npm:6.7.1"
   dependencies:
@@ -894,6 +1113,20 @@ __metadata:
     "@polkadot/util": 6.7.1
     "@polkadot/util-crypto": 6.7.1
   checksum: fe60968450fc5bcfe611361bc2f0c5bd7567df621b52273952eb07511d9080960d0de26623b81ce37d0c36ef8d9bf1606eed301d045e1a749b4d1965916457d8
+  languageName: node
+  linkType: hard
+
+"@polkadot/keyring@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/keyring@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/util": 6.8.1
+    "@polkadot/util-crypto": 6.8.1
+  peerDependencies:
+    "@polkadot/util": 6.8.1
+    "@polkadot/util-crypto": 6.8.1
+  checksum: da99b7816e520b721d542aa01874f27b0ff196d3582fe2772304fe73e2cbe2362717338db4307e53a0480defd3d7e3b80165faa2873d83fb8471c9e7e0f87fbc
   languageName: node
   linkType: hard
 
@@ -939,6 +1172,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/metadata@npm:4.14.1":
+  version: 4.14.1
+  resolution: "@polkadot/metadata@npm:4.14.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/types": 4.14.1
+    "@polkadot/types-known": 4.14.1
+    "@polkadot/util": ^6.8.1
+    "@polkadot/util-crypto": ^6.8.1
+  checksum: da2afe8cb56c6719685eda9bd2ab1d4222d90f8a15423f444dcc55344e2f312ec5eb376f69d0577407ce370c642d8f3522d9336371bef06a13f24357f105111c
+  languageName: node
+  linkType: hard
+
 "@polkadot/networks@npm:5.9.2, @polkadot/networks@npm:^5.9.2":
   version: 5.9.2
   resolution: "@polkadot/networks@npm:5.9.2"
@@ -957,34 +1203,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:4.13.1":
-  version: 4.13.1
-  resolution: "@polkadot/rpc-core@npm:4.13.1"
+"@polkadot/networks@npm:6.8.1, @polkadot/networks@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/networks@npm:6.8.1"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@polkadot/metadata": 4.13.1
-    "@polkadot/rpc-provider": 4.13.1
-    "@polkadot/types": 4.13.1
-    "@polkadot/util": ^6.7.1
-    "@polkadot/x-rxjs": ^6.7.1
-  checksum: e5dec478ca607998246d5a165517331e956dd570028e63a216f0fde2fa509d599e760b2b94ace8c0e68ddc780bcbaf4466f474913d4f9c4bdb8a4871ae86d0e9
+    "@babel/runtime": ^7.14.5
+  checksum: 6f76d5f8191c3f0b31aee439038ae4da640d95c109a532890a5f7e2108799d72425e00424d7524de4c6c0646747f7b7a8b261efb5565b38a8e697285948d6353
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:4.13.1":
-  version: 4.13.1
-  resolution: "@polkadot/rpc-provider@npm:4.13.1"
+"@polkadot/rpc-core@npm:4.14.1":
+  version: 4.14.1
+  resolution: "@polkadot/rpc-core@npm:4.14.1"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@polkadot/types": 4.13.1
-    "@polkadot/util": ^6.7.1
-    "@polkadot/util-crypto": ^6.7.1
-    "@polkadot/x-fetch": ^6.7.1
-    "@polkadot/x-global": ^6.7.1
-    "@polkadot/x-ws": ^6.7.1
-    bn.js: ^4.11.9
+    "@babel/runtime": ^7.14.5
+    "@polkadot/metadata": 4.14.1
+    "@polkadot/rpc-provider": 4.14.1
+    "@polkadot/types": 4.14.1
+    "@polkadot/util": ^6.8.1
+    "@polkadot/x-rxjs": ^6.8.1
+  checksum: c6807c4e4c76140e05e9eccc22fb43bfd3bd4a85b0d35a20b2dce3a87bd3ae23164d76b5ba2b7d8292ed72130334642f79039567df4b628b976435074c176b45
+  languageName: node
+  linkType: hard
+
+"@polkadot/rpc-provider@npm:4.14.1":
+  version: 4.14.1
+  resolution: "@polkadot/rpc-provider@npm:4.14.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/types": 4.14.1
+    "@polkadot/util": ^6.8.1
+    "@polkadot/util-crypto": ^6.8.1
+    "@polkadot/x-fetch": ^6.8.1
+    "@polkadot/x-global": ^6.8.1
+    "@polkadot/x-ws": ^6.8.1
     eventemitter3: ^4.0.7
-  checksum: 4ebe1b50dfd6fef1e8b67007aa072b88889a836171572e1a418d93a1d0c8738724c5d465c1a49ecbc11a6c260fddbb4d7d86d09f03440d2417d99e803320856c
+  checksum: c44fb41d1ac730867978acb34e337c0b46843cdd9db50ad3214c20838f514622a0b5f089bb06099d6cd65296274b124b0d2d6e2b21ded321ea2a44d1150f39f9
   languageName: node
   linkType: hard
 
@@ -1024,6 +1278,18 @@ __metadata:
     "@polkadot/util": ^6.7.1
     bn.js: ^4.11.9
   checksum: 9e51d219e9ac5acbabe66e710b496e6f0fe92f6dd851ab8afdf58b880e45ce6e79cd69800f96a7070e0e106360ec5de636838930ca150ca95413d74a9d893d02
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-known@npm:4.14.1":
+  version: 4.14.1
+  resolution: "@polkadot/types-known@npm:4.14.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/networks": ^6.8.1
+    "@polkadot/types": 4.14.1
+    "@polkadot/util": ^6.8.1
+  checksum: 81ad156fe33991aa2126c71206a7fb65a4ae7876d6604d315a294e9a51bdc8fcb2464d10ba5fe9ea2b2d24686bfebe81d4881e5c8819b7562c1d5d0f8f4ad2ef
   languageName: node
   linkType: hard
 
@@ -1072,6 +1338,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/types@npm:4.14.1, @polkadot/types@npm:^4.13.1":
+  version: 4.14.1
+  resolution: "@polkadot/types@npm:4.14.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/metadata": 4.14.1
+    "@polkadot/util": ^6.8.1
+    "@polkadot/util-crypto": ^6.8.1
+    "@polkadot/x-rxjs": ^6.8.1
+  checksum: 90567a450e0fb65577c475b25982484393d0702308262a032807149b8417323ba47148840ea4729d33f0bae9666d9dbf4ad2224c0e2a89d07194807c39b4cc4b
+  languageName: node
+  linkType: hard
+
 "@polkadot/util-crypto@npm:6.7.1, @polkadot/util-crypto@npm:^6.0.5, @polkadot/util-crypto@npm:^6.7.1":
   version: 6.7.1
   resolution: "@polkadot/util-crypto@npm:6.7.1"
@@ -1095,6 +1374,32 @@ __metadata:
   peerDependencies:
     "@polkadot/util": 6.7.1
   checksum: 9cf25952f579d497668110e9269fa5a1ad2a7adda0050ce14a323c0e6d9c72c66f3987fc07423b558efa2766e5732560713e522d4c605590fc27fc6cf740d249
+  languageName: node
+  linkType: hard
+
+"@polkadot/util-crypto@npm:6.8.1, @polkadot/util-crypto@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/util-crypto@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/networks": 6.8.1
+    "@polkadot/util": 6.8.1
+    "@polkadot/wasm-crypto": ^4.0.2
+    "@polkadot/x-randomvalues": 6.8.1
+    base-x: ^3.0.8
+    base64-js: ^1.5.1
+    blakejs: ^1.1.0
+    bn.js: ^4.11.9
+    create-hash: ^1.2.0
+    elliptic: ^6.5.4
+    hash.js: ^1.1.7
+    js-sha3: ^0.8.0
+    scryptsy: ^2.1.0
+    tweetnacl: ^1.0.3
+    xxhashjs: ^0.2.2
+  peerDependencies:
+    "@polkadot/util": 6.8.1
+  checksum: a5e7258cca02621c386eeabdaf628a9c7073fc5e2cd6a7f1750737ce96fa29fe4c0b3bbe0ffb5a3b68c5383655d46a8fd9729de9ac40cb7441d4296ee68e7c12
   languageName: node
   linkType: hard
 
@@ -1169,6 +1474,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/util@npm:6.8.1, @polkadot/util@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/util@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/x-textdecoder": 6.8.1
+    "@polkadot/x-textencoder": 6.8.1
+    "@types/bn.js": ^4.11.6
+    bn.js: ^4.11.9
+    camelcase: ^5.3.1
+    ip-regex: ^4.3.0
+  checksum: b1035e6f37b7298be32e6494c9eff2013aa1293c20d64d7e861aa451fef4b8b19495337f689e7db218ea91b671699e4cb00e828a7b976546501d43e3cc7fe0d4
+  languageName: node
+  linkType: hard
+
 "@polkadot/wasm-crypto-asmjs@npm:^3.2.4":
   version: 3.2.4
   resolution: "@polkadot/wasm-crypto-asmjs@npm:3.2.4"
@@ -1233,15 +1553,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^6.7.1":
-  version: 6.7.1
-  resolution: "@polkadot/x-fetch@npm:6.7.1"
+"@polkadot/x-fetch@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-fetch@npm:6.8.1"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@polkadot/x-global": 6.7.1
+    "@babel/runtime": ^7.14.5
+    "@polkadot/x-global": 6.8.1
     "@types/node-fetch": ^2.5.10
     node-fetch: ^2.6.1
-  checksum: 26197a42ec4050042eded5e082b7e614684b052fb4342b3cc4fa394ab49d4f4ea6c1dce3edda7544dd79d7018337e9efc0a98b46bdc07a976bb7b826e7f7ed01
+  checksum: 5c66c8f7a37e0f9b1b7d4d13c86c2d463a975ebf30dc84f1001bfc0df44b169385d547262e58835bcd00ec73a7c62a8ad42f12fa382bdb0fc0dcfb0c1c5fd6c2
   languageName: node
   linkType: hard
 
@@ -1267,7 +1587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:6.7.1, @polkadot/x-global@npm:^6.7.1":
+"@polkadot/x-global@npm:6.7.1":
   version: 6.7.1
   resolution: "@polkadot/x-global@npm:6.7.1"
   dependencies:
@@ -1275,6 +1595,17 @@ __metadata:
     "@types/node-fetch": ^2.5.10
     node-fetch: ^2.6.1
   checksum: f242b4ef61821dd142b662fbbbff65490e990199b8066708e6ddc70f203a48390a7d7b902ee93ef6561d0fe5dbff61c4052be88d488de4be85cf25a44b9b2649
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-global@npm:6.8.1, @polkadot/x-global@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-global@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@types/node-fetch": ^2.5.10
+    node-fetch: ^2.6.1
+  checksum: aca3fb27cfd72419d721b09e74fef717b69658dd3f732daa5567f1fe6d27e517d0ddd06ca7c4a8a01aa83ea9e17c853b275bb8e87b0122e0f566303abf322c44
   languageName: node
   linkType: hard
 
@@ -1298,6 +1629,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/x-randomvalues@npm:6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-randomvalues@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/x-global": 6.8.1
+  checksum: 6fe30c4f62aa25cb9e3c70ea965c792a1452088801ac3f0c67f220ae6def6788f4437e8eaee16c018504d84f24757e809390b95be9d93f87b63d7b8a943a3ca3
+  languageName: node
+  linkType: hard
+
 "@polkadot/x-rxjs@npm:^5.9.2":
   version: 5.9.2
   resolution: "@polkadot/x-rxjs@npm:5.9.2"
@@ -1315,6 +1656,16 @@ __metadata:
     "@babel/runtime": ^7.14.0
     rxjs: ^6.6.7
   checksum: 15ea88f5be20675caf6fe7bcf3413acea1915b7a939bb6c125d418c2a59aa32c83f74c99af1b8d5ab3e982f142e54634a813d795b67308c9e60b811c79e3d2b7
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-rxjs@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-rxjs@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    rxjs: ^6.6.7
+  checksum: dec6877bfe09e3e4ddbaca9aba2e7bd4169aa1045772b52d916b22817666490c80102e062d09ec7f3cf2a0feba6cdea20bc462c048774a04b11884651eb0f3b1
   languageName: node
   linkType: hard
 
@@ -1348,6 +1699,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/x-textdecoder@npm:6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-textdecoder@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/x-global": 6.8.1
+  checksum: 074e90ac798c6bf1b01478bf8980e29c5b0683f837895836d27aa60bce4f08c481a0c7f85c6044d40713bad1257e96cfcf0f9f98dc8efcdfb1321af2185d4d60
+  languageName: node
+  linkType: hard
+
 "@polkadot/x-textencoder@npm:5.9.2":
   version: 5.9.2
   resolution: "@polkadot/x-textencoder@npm:5.9.2"
@@ -1378,15 +1739,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^6.7.1":
-  version: 6.7.1
-  resolution: "@polkadot/x-ws@npm:6.7.1"
+"@polkadot/x-textencoder@npm:6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-textencoder@npm:6.8.1"
   dependencies:
-    "@babel/runtime": ^7.14.0
-    "@polkadot/x-global": 6.7.1
+    "@babel/runtime": ^7.14.5
+    "@polkadot/x-global": 6.8.1
+  checksum: 1513870be11e2fa55b7809631b6761bf8aaeb136ca17ff431801899596cb5adc5ac33eafc8b12670b032ce3542956e0f8538a1513a351fc503501009db6993c0
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-ws@npm:^6.8.1":
+  version: 6.8.1
+  resolution: "@polkadot/x-ws@npm:6.8.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/x-global": 6.8.1
     "@types/websocket": ^1.0.2
     websocket: ^1.0.34
-  checksum: 0fc80aedeed72f5c359a6474f03831115f9026a2540c0f6afa5ec1646faf58de55c844d722fa1cd5be52e584c837e158e247ae594ef075f0e99e471486d04aad
+  checksum: a9b7b15c7db05e998b7c751ccf5e1d02409a9c502a6b53787cb6f62e3d82133c306c660041188d5f7fa5a7eeb6c4705578c025709b43166b807670cc936da1bc
   languageName: node
   linkType: hard
 
@@ -1484,11 +1855,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^4.13.1
-    "@polkadot/apps-config": ^0.92.1
-    "@polkadot/util-crypto": ^6.7.1
+    "@polkadot/api": ^4.14.1
+    "@polkadot/apps-config": ^0.93.1
+    "@polkadot/util-crypto": ^6.8.1
     "@substrate/calc": ^0.2.0
-    "@substrate/dev": ^0.5.2
+    "@substrate/dev": ^0.5.3
     "@types/argparse": ^2.0.8
     "@types/express": ^4.17.11
     "@types/express-serve-static-core": ^4.17.19
@@ -1516,29 +1887,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/dev@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@substrate/dev@npm:0.5.2"
+"@substrate/dev@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "@substrate/dev@npm:0.5.3"
   dependencies:
-    "@babel/plugin-transform-modules-commonjs": ^7.13.8
-    "@types/jest": ^26.0.20
-    "@typescript-eslint/eslint-plugin": ^4.22.0
-    "@typescript-eslint/parser": ^4.22.0
-    eslint: ^7.22.0
-    eslint-config-prettier: ^8.1.0
-    eslint-plugin-prettier: ^3.3.1
+    "@babel/plugin-transform-modules-commonjs": ^7.14.0
+    "@types/jest": ^26.0.23
+    "@typescript-eslint/eslint-plugin": ^4.24.0
+    "@typescript-eslint/parser": ^4.24.0
+    eslint: ^7.27.0
+    eslint-config-prettier: ^8.3.0
+    eslint-plugin-prettier: ^3.4.0
     eslint-plugin-simple-import-sort: ^7.0.0
     jest: ^26.6.3
-    prettier: ^2.2.1
-    ts-jest: ^26.5.3
-    typescript: ^4.2.3
-    yargs: ^16.2.0
+    prettier: ^2.3.0
+    ts-jest: ^26.5.6
+    typescript: ^4.2.4
+    yargs: ^17.0.1
   bin:
     substrate-dev-run-lint: ./scripts/substrate-dev-run-lint.cjs
     substrate-exec-eslint: ./scripts/substrate-exec-eslint.cjs
     substrate-exec-jest: ./scripts/substrate-exec-jest.cjs
     substrate-exec-tsc: ./scripts/substrate-exec-tsc.cjs
-  checksum: a04100f895172ce061c2f8a80bff62f98779900210606eb40b8421b23a6912db6548235148e3619f689d36a8dce8ef6ce16f6a341579b5cf5f8faee0740ad9bb
+  checksum: 64051e9cc5564fe52d89691a76ca7178e3cfd7eb72e2ed71aa17e344dac2f15163b8887b740d2e21ccae657c497976e30391986a55bd9f05bb92539f97466336
   languageName: node
   linkType: hard
 
@@ -1689,7 +2060,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:^26.0.20":
+"@types/jest@npm:^26.0.23":
   version: 26.0.23
   resolution: "@types/jest@npm:26.0.23"
   dependencies:
@@ -1699,7 +2070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.3":
+"@types/json-schema@npm:^7.0.7":
   version: 7.0.7
   resolution: "@types/json-schema@npm:7.0.7"
   checksum: b9d2c509fa4e0b82f58e73f5e6ab76c60ff1884ba41bb82f37fb1cece226d4a3e5a62fedf78a43da0005373a6713d9abe61c1e592906402c41c08ad6ab26d52b
@@ -1848,103 +2219,103 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^4.22.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.23.0"
+"@typescript-eslint/eslint-plugin@npm:^4.24.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:4.27.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 4.23.0
-    "@typescript-eslint/scope-manager": 4.23.0
-    debug: ^4.1.1
+    "@typescript-eslint/experimental-utils": 4.27.0
+    "@typescript-eslint/scope-manager": 4.27.0
+    debug: ^4.3.1
     functional-red-black-tree: ^1.0.1
-    lodash: ^4.17.15
-    regexpp: ^3.0.0
-    semver: ^7.3.2
-    tsutils: ^3.17.1
+    lodash: ^4.17.21
+    regexpp: ^3.1.0
+    semver: ^7.3.5
+    tsutils: ^3.21.0
   peerDependencies:
     "@typescript-eslint/parser": ^4.0.0
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 846ecf021aaa7de34ac306866e2aca5ffa89711bc2c4ffe916fc632dde880eb94f0665009161086d3d91ccc21f2600a27271e041de505363758548511c463907
+  checksum: 6f5e556c92cdbb25c394799c5cb442bb541717c2953a368034a06deacb158e5f4bd5f3f743a4e0a58b9446bf18387bd8fd19ded303fe1269e8c193f30fe194c4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/experimental-utils@npm:4.23.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/experimental-utils@npm:4.23.0"
+"@typescript-eslint/experimental-utils@npm:4.27.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/experimental-utils@npm:4.27.0"
   dependencies:
-    "@types/json-schema": ^7.0.3
-    "@typescript-eslint/scope-manager": 4.23.0
-    "@typescript-eslint/types": 4.23.0
-    "@typescript-eslint/typescript-estree": 4.23.0
-    eslint-scope: ^5.0.0
-    eslint-utils: ^2.0.0
+    "@types/json-schema": ^7.0.7
+    "@typescript-eslint/scope-manager": 4.27.0
+    "@typescript-eslint/types": 4.27.0
+    "@typescript-eslint/typescript-estree": 4.27.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
   peerDependencies:
     eslint: "*"
-  checksum: 8583b9f016c08199789e0439af3a77bc46304165d3878a5d0851dfbeee8d89807ceda9d33a74b8854022f7dfe82cbe1eb4debb59ce7085d7f376d79abf78d09d
+  checksum: b8c66eceeba674b21750eb795a91a1f20814f9be41e9d249f2ddd2bab85ad0a418322cfbbd9af845a9907921ce762df115e361467f86317f2a33330bc4461134
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^4.22.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/parser@npm:4.23.0"
+"@typescript-eslint/parser@npm:^4.24.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/parser@npm:4.27.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 4.23.0
-    "@typescript-eslint/types": 4.23.0
-    "@typescript-eslint/typescript-estree": 4.23.0
-    debug: ^4.1.1
+    "@typescript-eslint/scope-manager": 4.27.0
+    "@typescript-eslint/types": 4.27.0
+    "@typescript-eslint/typescript-estree": 4.27.0
+    debug: ^4.3.1
   peerDependencies:
     eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 364874cf13b50e8e7adf5a424f5b0364689046ebdffaa715146b5b2f25e008ed99bd52d190e33d1b06378bfa35f0c9140c26ccb943a01732e952ee2032bd715c
+  checksum: cfe1b6b2c195e56396ffe1869af9aa660bc1427c7923cccff5b248aba95def2097eea0df40c748ee43e9796783332e7e6bbf41c2b92bebbcfe8557fa8c69ffdc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:4.23.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.23.0"
+"@typescript-eslint/scope-manager@npm:4.27.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/scope-manager@npm:4.27.0"
   dependencies:
-    "@typescript-eslint/types": 4.23.0
-    "@typescript-eslint/visitor-keys": 4.23.0
-  checksum: d51c7efa22946bc0d7d9d330b51fe114df1f8a9a64194d403043d6e3ed7564fea8452d8b57cbc74a92b03894fd6cc12e64445220961edbee2348421608e5fdc6
+    "@typescript-eslint/types": 4.27.0
+    "@typescript-eslint/visitor-keys": 4.27.0
+  checksum: 5d39a2dda0722a00e5707fddb1e83608c30c08af70e4a6f70106ecaf51359dd9ea8a64aec37cbfa23f9b286041da012a59158f7200df6007734c1d02184d0472
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:4.23.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/types@npm:4.23.0"
-  checksum: b0ddf4ca0176566f27388ea6b74a32d7efe585c79db998ec1d51515ab7ef88de651d4b531410a763ef73a04a645b181d78559960c08e6c9d0e21796cc0708888
+"@typescript-eslint/types@npm:4.27.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/types@npm:4.27.0"
+  checksum: b9540fdf5cacbb36c918e3cfef07896b0c70fb49d45568ee08ea4743072925e5f89ad07549210bd362691f9a2c5b3522d97430f38cb35a25ddc1304cd5ec9823
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.23.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.23.0"
+"@typescript-eslint/typescript-estree@npm:4.27.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/typescript-estree@npm:4.27.0"
   dependencies:
-    "@typescript-eslint/types": 4.23.0
-    "@typescript-eslint/visitor-keys": 4.23.0
-    debug: ^4.1.1
-    globby: ^11.0.1
+    "@typescript-eslint/types": 4.27.0
+    "@typescript-eslint/visitor-keys": 4.27.0
+    debug: ^4.3.1
+    globby: ^11.0.3
     is-glob: ^4.0.1
-    semver: ^7.3.2
-    tsutils: ^3.17.1
+    semver: ^7.3.5
+    tsutils: ^3.21.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: dec87f62c7301f7f6dec1cd8b30c0d4ba6c86cb78c3acb2070ee7ca2fcf9e2d1613fbbfb64561c2f4a6267217d435f7a48b3b1189ada8c938e2814b2e9b05b09
+  checksum: dc9711dab7fc6d53bb9471e21d27e2c65f2840c52d86fc8a368dedf714297bde43b30ea4af952c1def8d063f3dbef8eda4196b85db6d7fd0062da8b304810585
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:4.23.0":
-  version: 4.23.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.23.0"
+"@typescript-eslint/visitor-keys@npm:4.27.0":
+  version: 4.27.0
+  resolution: "@typescript-eslint/visitor-keys@npm:4.27.0"
   dependencies:
-    "@typescript-eslint/types": 4.23.0
+    "@typescript-eslint/types": 4.27.0
     eslint-visitor-keys: ^2.0.0
-  checksum: a5e86b76e37fa11d061c5b1dcbc77e8faca6afb112c93240880563cc26306c7ba52d9baa824fd8b75b9deda1736340f93f38cae1782d3fe9e4e46d335b6236d1
+  checksum: d600de56ce12ee1195fbc76fd82ec56116f5301093b4f313dbf9fa1ee82a3609bbfdf48bdb722cb253256da80f46b71070fddbda47d77e8808d0a04c4f5e6a2c
   languageName: node
   linkType: hard
 
@@ -3488,7 +3859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -3901,7 +4272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^8.1.0":
+"eslint-config-prettier@npm:^8.3.0":
   version: 8.3.0
   resolution: "eslint-config-prettier@npm:8.3.0"
   peerDependencies:
@@ -3912,7 +4283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^3.3.1":
+"eslint-plugin-prettier@npm:^3.4.0":
   version: 3.4.0
   resolution: "eslint-plugin-prettier@npm:3.4.0"
   dependencies:
@@ -3936,7 +4307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^5.0.0, eslint-scope@npm:^5.1.1":
+"eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
@@ -3946,12 +4317,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-utils@npm:^2.0.0, eslint-utils@npm:^2.1.0":
+"eslint-utils@npm:^2.1.0":
   version: 2.1.0
   resolution: "eslint-utils@npm:2.1.0"
   dependencies:
     eslint-visitor-keys: ^1.1.0
   checksum: a43892372a4205374982ac9d4c8edc5fe180cba76535ab9184c48f18a3d931b7ffdd6862cb2f8ca4305c47eface0e614e39884a75fbf169fcc55a6131af2ec48
+  languageName: node
+  linkType: hard
+
+"eslint-utils@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "eslint-utils@npm:3.0.0"
+  dependencies:
+    eslint-visitor-keys: ^2.0.0
+  peerDependencies:
+    eslint: ">=5"
+  checksum: 035451529f016e28edd26e8951f15e28a6a4e58adff67bd0cb494879f360080750b9c779e46561369aec0657ac2b89dd8b0aa38476e8cdf50e635aa872fa27b6
   languageName: node
   linkType: hard
 
@@ -3969,27 +4351,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^7.22.0":
-  version: 7.26.0
-  resolution: "eslint@npm:7.26.0"
+"eslint@npm:^7.27.0":
+  version: 7.28.0
+  resolution: "eslint@npm:7.28.0"
   dependencies:
     "@babel/code-frame": 7.12.11
-    "@eslint/eslintrc": ^0.4.1
+    "@eslint/eslintrc": ^0.4.2
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
     debug: ^4.0.1
     doctrine: ^3.0.0
     enquirer: ^2.3.5
+    escape-string-regexp: ^4.0.0
     eslint-scope: ^5.1.1
     eslint-utils: ^2.1.0
     eslint-visitor-keys: ^2.0.0
     espree: ^7.3.1
     esquery: ^1.4.0
     esutils: ^2.0.2
+    fast-deep-equal: ^3.1.3
     file-entry-cache: ^6.0.1
     functional-red-black-tree: ^1.0.1
-    glob-parent: ^5.0.0
+    glob-parent: ^5.1.2
     globals: ^13.6.0
     ignore: ^4.0.6
     import-fresh: ^3.0.0
@@ -3998,7 +4382,7 @@ __metadata:
     js-yaml: ^3.13.1
     json-stable-stringify-without-jsonify: ^1.0.1
     levn: ^0.4.1
-    lodash: ^4.17.21
+    lodash.merge: ^4.6.2
     minimatch: ^3.0.4
     natural-compare: ^1.4.0
     optionator: ^0.9.1
@@ -4007,12 +4391,12 @@ __metadata:
     semver: ^7.2.1
     strip-ansi: ^6.0.0
     strip-json-comments: ^3.1.0
-    table: ^6.0.4
+    table: ^6.0.9
     text-table: ^0.2.0
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 08f99befd764fbd6ea811e9eec27d5c6b9dc9d1bbfe5ffa1016e4f1fe526a4f45ea127c4e30c554c423ee55eb290ce9af4fb7fedf9b7af3f84076a444c2bbdf6
+  checksum: 9d49d53ed56a1f1ccba9c71482722a91f2423432df70a3694d36ea478f0e3bb058034f170219f34f3d6b5cd5d47510b269b75e2b4117f88a3241b1db9cb95828
   languageName: node
   linkType: hard
 
@@ -4295,7 +4679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1":
+"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 451526766b219503131d11e823eaadd1533080b0be4860e316670b039dcaf31cd1007c2fe036a9b922abba7c040dfad5e942ed79d21f2ff849e50049f36e0fb7
@@ -4768,7 +5152,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.0.0, glob-parent@npm:^5.1.0":
+"glob-parent@npm:^5.1.0, glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -4798,15 +5182,6 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"globals@npm:^12.1.0":
-  version: 12.4.0
-  resolution: "globals@npm:12.4.0"
-  dependencies:
-    type-fest: ^0.8.1
-  checksum: 0b9764bdeab0bc9762dea8954a0d4c5db029420bd8bf693df9098ce7e045ccaf9b2d259185396fd048b051d42fdc8dc7ab02af62e3dbeb2324a78a05aac8d33c
-  languageName: node
-  linkType: hard
-
 "globals@npm:^13.6.0":
   version: 13.8.0
   resolution: "globals@npm:13.8.0"
@@ -4816,7 +5191,16 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.1":
+"globals@npm:^13.9.0":
+  version: 13.9.0
+  resolution: "globals@npm:13.9.0"
+  dependencies:
+    type-fest: ^0.20.2
+  checksum: 26d71f2c286c80d806faad49c801bfb2ac5144497b5c844c5a718b2c3fad51e0d507d9069474e89f110f16a38bf212ec56e6e40936a4f24b1a645e7f21001d1d
+  languageName: node
+  linkType: hard
+
+"globby@npm:^11.0.3":
   version: 11.0.3
   resolution: "globby@npm:11.0.3"
   dependencies:
@@ -6464,6 +6848,13 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
+"lodash.merge@npm:^4.6.2":
+  version: 4.6.2
+  resolution: "lodash.merge@npm:4.6.2"
+  checksum: 4e2bb42a87a148991458d7c384bc197e96f7115e9536fc8e2c86ae9e99ce1c1f693ff15eb85761952535f48d72253aed8e673d9f32dde3e671cd91e3fde220a7
+  languageName: node
+  linkType: hard
+
 "lodash.truncate@npm:^4.4.2":
   version: 4.4.2
   resolution: "lodash.truncate@npm:4.4.2"
@@ -6950,14 +7341,14 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"moonbeam-types-bundle@npm:1.1.21":
-  version: 1.1.21
-  resolution: "moonbeam-types-bundle@npm:1.1.21"
+"moonbeam-types-bundle@npm:1.1.22":
+  version: 1.1.22
+  resolution: "moonbeam-types-bundle@npm:1.1.22"
   dependencies:
     "@polkadot/keyring": ^6.6.1
     "@polkadot/types": ^4.12.1
     typescript: ^4.1.3
-  checksum: 08f857b4f52697aa8f7946e2627b6917aef0fcbedc0e174db953fd090264d304280803ca988544b53bc8a5d72eff3931ecf3b80a098801e24d067cbe27a62a2e
+  checksum: cb0a5bb230b650441e774fa3bab1f4d3e35b84cffc81ecd9ed7219433aaf5091cd2d74f9434bcab5c5eaad6f4c7fab210c20663477d6a4f080351345bd3ff418
   languageName: node
   linkType: hard
 
@@ -7771,12 +8162,12 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.2.1":
-  version: 2.3.0
-  resolution: "prettier@npm:2.3.0"
+"prettier@npm:^2.3.0":
+  version: 2.3.1
+  resolution: "prettier@npm:2.3.1"
   bin:
     prettier: bin-prettier.js
-  checksum: 652640cc8b71bc5277cfb8bf6f161783ca588efcf683c3d630837b39da8d57fef35c9e00ae5855a8e3c75136c42274046c913cc2b2d2968558315f31c6a26981
+  checksum: 9b4a695b87ce5f510fc20feec01cce7371f0fa0b92ffe79d543f6be52e2004c532861629de4d7ab1c577e1f649dce3cfccd62cb2ca6526b1da8d9c63eb84bf36
   languageName: node
   linkType: hard
 
@@ -8076,7 +8467,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"regexpp@npm:^3.0.0, regexpp@npm:^3.1.0":
+"regexpp@npm:^3.1.0":
   version: 3.1.0
   resolution: "regexpp@npm:3.1.0"
   checksum: 69d0ce6b449cf35d3732d6341a1e70850360ffc619f8eef10629871c462e614853fffb80d3f00fc17cd0bb5b8f34b0cde5be4b434e72c0eb3fbba2360c8b5ac4
@@ -9100,7 +9491,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"table@npm:^6.0.4":
+"table@npm:^6.0.9":
   version: 6.7.1
   resolution: "table@npm:6.7.1"
   dependencies:
@@ -9329,7 +9720,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^26.5.3":
+"ts-jest@npm:^26.5.6":
   version: 26.5.6
   resolution: "ts-jest@npm:26.5.6"
   dependencies:
@@ -9376,7 +9767,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"tsutils@npm:^3.17.1":
+"tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
   dependencies:
@@ -9520,7 +9911,7 @@ typescript@3.9.6:
   languageName: node
   linkType: hard
 
-"typescript@^4.1.3, typescript@^4.2.3, typescript@^4.2.4":
+"typescript@^4.1.3, typescript@^4.2.4":
   version: 4.3.2
   resolution: "typescript@npm:4.3.2"
   bin:
@@ -9540,7 +9931,7 @@ typescript@3.9.6:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.1.3#builtin<compat/typescript>, typescript@patch:typescript@^4.2.3#builtin<compat/typescript>, typescript@patch:typescript@^4.2.4#builtin<compat/typescript>":
+"typescript@patch:typescript@^4.1.3#builtin<compat/typescript>, typescript@patch:typescript@^4.2.4#builtin<compat/typescript>":
   version: 4.3.2
   resolution: "typescript@patch:typescript@npm%3A4.3.2#builtin<compat/typescript>::version=4.3.2&hash=ddfc1b"
   bin:
@@ -10101,7 +10492,7 @@ typescript@3.9.6:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.0.0, yargs@npm:^16.2.0":
+"yargs@npm:^16.0.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:
@@ -10113,6 +10504,21 @@ typescript@3.9.6:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: a79ce1f043021cd645de1ffebb6149541d382ba68f4a6b5eca5d2ad65af51893371bbd78e240dc3b6cf0cbb419511ba5bda715dec992e4266e6863ea49f14feb
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.0.1":
+  version: 17.0.1
+  resolution: "yargs@npm:17.0.1"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.0
+    y18n: ^5.0.5
+    yargs-parser: ^20.2.2
+  checksum: a7969b48d2dea129a7d4fcc3f13e88d4f94bacbd24f720b2ce19946fa9facc42cfed89c059d953091241f4e9e9000ed9dbf86e4bb4b6ceb3a26af10ddebdd0b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the deps for polkadot-js, and substrate/dev

I also reconfigured tests in order to reflect the most recent internal changes to polkadot-js [here](https://github.com/polkadot-js/api/commit/400e14d6c94613e3b013f207607e4c16c61d9b4b#diff-4057209e51321417a7ba8384eeaa7221603262b495ae1f975753c129de848f4eR24)

