### PR TITLE
fix: createCalcFee bug

### DIFF
--- a/e2e-tests/endpoints/kusama/9253.json
+++ b/e2e-tests/endpoints/kusama/9253.json
@@ -1,0 +1,469 @@
+{
+    "number": "9253",
+    "hash": "0xced7d69ee71848b6563095e203a125583194e87588d6d3f65e8d3a4ed4e5013f",
+    "parentHash": "0x5952de3b6ab0cda67fa3a2acfee3a6cc9866ac08539b2d7e84813e4f7311edb8",
+    "stateRoot": "0x6c0dd83af8bcbdfba85d814295466a1a01e00607746ee8b9f2664aab1e6ed687",
+    "extrinsicsRoot": "0xb66c518acba8c4b106a36fb4e7a18c6e483cf3daa87df6e69e74e0ee7529a42f",
+    "authorId": "DtbB3Uy8zX9khHRf7SsSVk7esY5AngKvC9EJVhpjSzza2MU",
+    "logs": [
+        {
+            "type": "PreRuntime",
+            "index": "6",
+            "value": [
+                "0x42414245",
+                "0x02020000001a7aa50f00000000"
+            ]
+        },
+        {
+            "type": "Seal",
+            "index": "5",
+            "value": [
+                "0x42414245",
+                "0x8e8ec87149f81c0bcf921056f4cfd5fd0e8d93efe08ade2d15a84f684be879453b3238a97ef6c21f2d5c3532146260f0fdc4c47a07e9b9de45c7172bf563158e"
+            ]
+        }
+    ],
+    "onInitialize": {
+        "events": []
+    },
+    "extrinsics": [
+        {
+            "method": {
+                "pallet": "timestamp",
+                "method": "set"
+            },
+            "signature": null,
+            "nonce": null,
+            "args": {
+                "now": "1575017628000"
+            },
+            "tip": null,
+            "hash": "0x400edae8b9c35c43fec0e2fef7d39ab739a4e7fc0145a6c98d670898cad91083",
+            "info": {},
+            "events": [
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "10000",
+                            "class": "Operational",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": false
+        },
+        {
+            "method": {
+                "pallet": "finalityTracker",
+                "method": "finalHint"
+            },
+            "signature": null,
+            "nonce": null,
+            "args": {
+                "hint": "9251"
+            },
+            "tip": null,
+            "hash": "0x007224b0a6a6987659ab781cc598564876ede542af15918f08ae8b4190513f2f",
+            "info": {},
+            "events": [
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "10000",
+                            "class": "Normal",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": false
+        },
+        {
+            "method": {
+                "pallet": "parachains",
+                "method": "setHeads"
+            },
+            "signature": null,
+            "nonce": null,
+            "args": {
+                "heads": []
+            },
+            "tip": null,
+            "hash": "0xcf52705d1ade64fc0b05859ac28358c0770a217dd76b75e586ae848c56ae810d",
+            "info": {},
+            "events": [
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "1000000",
+                            "class": "Normal",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": false
+        },
+        {
+            "method": {
+                "pallet": "sudo",
+                "method": "sudoAs"
+            },
+            "signature": {
+                "signature": "0xc84a848fa34bbd5decef0c72fac45a9bfb8c4848f250cfe32930026a71ae711580bdd7543342cddf85d717d962d5055e342d75861bdae5c35f0660c60b9e0603",
+                "signer": "CdA6gJUJRAZadvkZ2XHyaiunC7hhgY1MaWQ7A7b3dfLQHMk"
+            },
+            "nonce": "670",
+            "args": {
+                "who": "CcKPhXSyZgATZD1wVaRsSk81UfLcQvyuuS2i9FNhsoeQeWr",
+                "proposal": {
+                    "method": {
+                        "pallet": "session",
+                        "method": "setKeys"
+                    },
+                    "args": {
+                        "keys": [
+                            "J6m23BicKeyikog5wk8Yr2rXdnieWSmXibgDzeWRJ9AupK9",
+                            "GuRfx5ZXVDqzTDKjbPUWmFc1rJdF3TReyrsQjZZprTazXhi",
+                            "HARc7Yt16RfFafzQE1vFB2yvZJGyCSVeUi86qkbSXY7MgKA",
+                            "FdAq9nJzb3w5QeejNZiGWTzVheYsowatEcJQNx7ZbitHQBr",
+                            "CaKWz5omakTK7ovp4m3koXrHyHb7NG3Nt7GENHbviByZpKp"
+                        ],
+                        "proof": "0x"
+                    }
+                }
+            },
+            "tip": "0",
+            "hash": "0x4e478caa1f4e5e87a493f51abe9e2204a431fdfdbe91c2ec4420696d7aac7777",
+            "info": {
+                "error": "Fee calculation not supported for 1020#kusama"
+            },
+            "events": [
+                {
+                    "method": {
+                        "pallet": "treasury",
+                        "method": "Deposit"
+                    },
+                    "data": [
+                        "292571552"
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "sudo",
+                        "method": "SudoAsDone"
+                    },
+                    "data": [
+                        false
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "0",
+                            "class": "Operational",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": true
+        },
+        {
+            "method": {
+                "pallet": "sudo",
+                "method": "sudoAs"
+            },
+            "signature": {
+                "signature": "0x20f450020da9a6f237dc4b56b5bfb28ad31d94f3f7bb47bf9ce67e7401c11820dc3568614c18d3a79b5f228c79fdb05893dd0c7dfd26f21a04ed74e66bf06b06",
+                "signer": "CdA6gJUJRAZadvkZ2XHyaiunC7hhgY1MaWQ7A7b3dfLQHMk"
+            },
+            "nonce": "671",
+            "args": {
+                "who": "DzH55mvzrYmVNM4mgkV5HQs2TrRfUMpEhJswaixS6FF9vvD",
+                "proposal": {
+                    "method": {
+                        "pallet": "session",
+                        "method": "setKeys"
+                    },
+                    "args": {
+                        "keys": [
+                            "GWeSzwAsRv51T8GGBF7uUduH5VnxZhNCyrREFrhx6JhoPR5",
+                            "CaiknS9v4ywFwve3WEemvyqxNWnsocAFFUedmwsbNtzJvy5",
+                            "FAzhGUpFCVkUr2RUNVgmnwKpkYQ1xn6n9nZxHvk7FYNhxmK",
+                            "ERszp87brWD1uyUJ5cCvQmJWr58nt2Be4DoNkmVbcSkTEmw",
+                            "CaKWz5omakTK7ovp4m3koXrHyHb7NG3Nt7GENHbviByZpKp"
+                        ],
+                        "proof": "0x"
+                    }
+                }
+            },
+            "tip": "0",
+            "hash": "0xa1f88146785c6f3a1bb65b8ca0a76baef7af286e5ce0b4a2f680253d85261c4f",
+            "info": {
+                "error": "Fee calculation not supported for 1020#kusama"
+            },
+            "events": [
+                {
+                    "method": {
+                        "pallet": "treasury",
+                        "method": "Deposit"
+                    },
+                    "data": [
+                        "292571552"
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "sudo",
+                        "method": "SudoAsDone"
+                    },
+                    "data": [
+                        false
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "0",
+                            "class": "Operational",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": true
+        },
+        {
+            "method": {
+                "pallet": "sudo",
+                "method": "sudoAs"
+            },
+            "signature": {
+                "signature": "0x4c602ec5d48612076259a17f2097fa4968b6d23a06b8b5dd10be2f6b51a4b8776e820b72c1693992a6bbfa029375d7ed0738707ffcca27702fcf3c0dbbbbe908",
+                "signer": "CdA6gJUJRAZadvkZ2XHyaiunC7hhgY1MaWQ7A7b3dfLQHMk"
+            },
+            "nonce": "672",
+            "args": {
+                "who": "F7LENZtaVzUeog9fNccW15qUhyMMXKPLhH6LNCv4QGg1ADv",
+                "proposal": {
+                    "method": {
+                        "pallet": "staking",
+                        "method": "withdrawUnbonded"
+                    },
+                    "args": {}
+                }
+            },
+            "tip": "0",
+            "hash": "0x2c1a587bdd81095e6f58a0633b2e2080f3eaa4a7a6b4673e3ca3fbe4761c3347",
+            "info": {
+                "error": "Fee calculation not supported for 1020#kusama"
+            },
+            "events": [
+                {
+                    "method": {
+                        "pallet": "treasury",
+                        "method": "Deposit"
+                    },
+                    "data": [
+                        "175688128"
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "sudo",
+                        "method": "SudoAsDone"
+                    },
+                    "data": [
+                        true
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "0",
+                            "class": "Operational",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": true
+        },
+        {
+            "method": {
+                "pallet": "sudo",
+                "method": "sudoAs"
+            },
+            "signature": {
+                "signature": "0xbee65d52dfc48707fa38385af6ffda72d6dfa8c0b4deed1093ae53541925633d4b8b7540cb5983daba5995aa5f33de3d59afb058513f1fa7e8253f82a1d62c0b",
+                "signer": "CdA6gJUJRAZadvkZ2XHyaiunC7hhgY1MaWQ7A7b3dfLQHMk"
+            },
+            "nonce": "673",
+            "args": {
+                "who": "EZnvefir4bQfzEVFFdTzqjWohxM8Wpx7KxbRJJ5CHo3nCBH",
+                "proposal": {
+                    "method": {
+                        "pallet": "session",
+                        "method": "setKeys"
+                    },
+                    "args": {
+                        "keys": [
+                            "Fo4E3tXSUD6GT2PxxMTT6KCVb2XyBk9vFVcpUicjPtFDmpV",
+                            "D7gCzpCRqkBZ6ZjzHQ11Aj8cC7UUvaQ9teRWbCBHH7E1m3u",
+                            "H4wydQCFSBCt2t4capBS1RtfYAkVq9xK4EAU9K1Xee6pjAN",
+                            "GHv8sFDKmmL73rrhnAnBva85fhGJVor3x62BJATEbvsCN2s",
+                            "CaKWz5omakTK7ovp4m3koXrHyHb7NG3Nt7GENHbviByZpKp"
+                        ],
+                        "proof": "0x"
+                    }
+                }
+            },
+            "tip": "0",
+            "hash": "0xf96c9904d4acf5850cbb0b748bb6e59afa4dd6fa4a35d039eb7ea004b07beb83",
+            "info": {
+                "error": "Fee calculation not supported for 1020#kusama"
+            },
+            "events": [
+                {
+                    "method": {
+                        "pallet": "treasury",
+                        "method": "Deposit"
+                    },
+                    "data": [
+                        "292571552"
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "sudo",
+                        "method": "SudoAsDone"
+                    },
+                    "data": [
+                        false
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "0",
+                            "class": "Operational",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": true
+        },
+        {
+            "method": {
+                "pallet": "sudo",
+                "method": "sudoAs"
+            },
+            "signature": {
+                "signature": "0x080a1ae5bb8d85b1241bcdc49fd93bc5f492fdd46ba8d7bc2744f350aea17b710112ba8f7c1a47f72d681efb8e94ea0adc9325c48c90b44f3c6a47cde684d500",
+                "signer": "CdA6gJUJRAZadvkZ2XHyaiunC7hhgY1MaWQ7A7b3dfLQHMk"
+            },
+            "nonce": "674",
+            "args": {
+                "who": "G7Ur4BnMSfP2qE7ruSob5gwGQ5nzkGWu7Yqh14FcMqnDtgB",
+                "proposal": {
+                    "method": {
+                        "pallet": "session",
+                        "method": "setKeys"
+                    },
+                    "args": {
+                        "keys": [
+                            "GbxZfvgixswNj4FgVYLqPey43Mcty4urJr8tRtGAxLfnQXh",
+                            "GY2xR1AEgArZ8m9fYMphUpR31NsCcBj3Ty4hKLdpUJmQbkb",
+                            "FZfmiPtbtjmG5xhRZhzK3GzaLJgTFadw5zqM9QGs7sftJok",
+                            "Dg2DTnANDa5QHiEYuQHL2ipt7XaFdCoi3fGWWaKeobrVsLa",
+                            "CaKWz5omakTK7ovp4m3koXrHyHb7NG3Nt7GENHbviByZpKp"
+                        ],
+                        "proof": "0x"
+                    }
+                }
+            },
+            "tip": "0",
+            "hash": "0xfbeb261f7419a7869b744393caf84ecc49c4ce51fd9c33e27330d435ea38944a",
+            "info": {
+                "error": "Fee calculation not supported for 1020#kusama"
+            },
+            "events": [
+                {
+                    "method": {
+                        "pallet": "treasury",
+                        "method": "Deposit"
+                    },
+                    "data": [
+                        "292571552"
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "sudo",
+                        "method": "SudoAsDone"
+                    },
+                    "data": [
+                        false
+                    ]
+                },
+                {
+                    "method": {
+                        "pallet": "system",
+                        "method": "ExtrinsicSuccess"
+                    },
+                    "data": [
+                        {
+                            "weight": "0",
+                            "class": "Operational",
+                            "paysFee": true
+                        }
+                    ]
+                }
+            ],
+            "success": true,
+            "paysFee": true
+        }
+    ],
+    "onFinalize": {
+        "events": []
+    },
+    "finalized": true
+}

--- a/e2e-tests/endpoints/kusama/index.ts
+++ b/e2e-tests/endpoints/kusama/index.ts
@@ -1,3 +1,4 @@
+import block9253 from './9253.json';
 import block2350438 from './2350438.json';
 import block2684767 from './2684767.json';
 import block2713513 from './2713513.json';
@@ -19,6 +20,7 @@ import block7354817 from './7354817.json';
 import block7519631 from './7519631.json';
 
 export const kusamaEndpoints = [
+	['/blocks/9253', JSON.stringify(block9253)],
 	['/blocks/2350438', JSON.stringify(block2350438)], //v1062
 	['/blocks/2684767', JSON.stringify(block2684767)], //v2005
 	['/blocks/2713513', JSON.stringify(block2713513)], //v2007

--- a/e2e-tests/endpoints/kusama/index.ts
+++ b/e2e-tests/endpoints/kusama/index.ts
@@ -20,7 +20,7 @@ import block7354817 from './7354817.json';
 import block7519631 from './7519631.json';
 
 export const kusamaEndpoints = [
-	['/blocks/9253', JSON.stringify(block9253)],
+	['/blocks/9253', JSON.stringify(block9253)], //v1020
 	['/blocks/2350438', JSON.stringify(block2350438)], //v1062
 	['/blocks/2684767', JSON.stringify(block2684767)], //v2005
 	['/blocks/2713513', JSON.stringify(block2713513)], //v2007

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -179,7 +179,7 @@ export class BlocksService extends AbstractService {
 
 			if (calcFee === null || calcFee === undefined) {
 				extrinsics[idx].info = {
-					error: `Fee calculation not supported for this specVersion. ${specVersion}#${specName}`,
+					error: `Fee calculation not supported for ${specVersion}#${specName}`,
 				};
 				continue;
 			}
@@ -460,9 +460,8 @@ export class BlocksService extends AbstractService {
 
 		if (this.minCalcFeeRuntime && specVersion < this.minCalcFeeRuntime) {
 			return {
-				specVersion: specVersion,
-				specName: specName,
-				calcFee: undefined,
+				specVersion,
+				specName,
 			};
 		}
 
@@ -475,13 +474,7 @@ export class BlocksService extends AbstractService {
 			api.consts.system.blockWeights.perClass.normal.baseExtrinsic;
 		const { weightToFee } = api.consts.transactionPayment;
 
-		if (
-			!perByte ||
-			!extrinsicBaseWeightExists ||
-			(this.minCalcFeeRuntime && specVersion < this.minCalcFeeRuntime) ||
-			!multiplier ||
-			!weightToFee
-		) {
+		if (!perByte || !extrinsicBaseWeightExists || !multiplier || !weightToFee) {
 			// This particular runtime version is not supported with fee calcs or
 			// does not have the necessay materials to build calcFee
 			return {

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -179,7 +179,7 @@ export class BlocksService extends AbstractService {
 
 			if (calcFee === null || calcFee === undefined) {
 				extrinsics[idx].info = {
-					error: `Fee calculation not supported for ${specVersion}#${specName}`,
+					error: `Fee calculation not supported for this specVersion`,
 				};
 				continue;
 			}

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -453,13 +453,21 @@ export class BlocksService extends AbstractService {
 			block
 		);
 
-		const [version, multiplier] = await Promise.all([
-			api.rpc.state.getRuntimeVersion(parentParentHash),
-			api.query.transactionPayment?.nextFeeMultiplier?.at(parentHash),
-		]);
+		const version = await api.rpc.state.getRuntimeVersion(parentParentHash);
 
 		const specName = version.specName.toString();
 		const specVersion = version.specVersion.toNumber();
+
+		if (this.minCalcFeeRuntime && specVersion < this.minCalcFeeRuntime) {
+			return {
+				specVersion: -1,
+				specName: 'ERROR',
+				calcFee: undefined,
+			};
+		}
+
+		const multiplier =
+			await api.query.transactionPayment?.nextFeeMultiplier?.at(parentHash);
 
 		const perByte = api.consts.transactionPayment?.transactionByteFee;
 		const extrinsicBaseWeightExists =

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -179,7 +179,7 @@ export class BlocksService extends AbstractService {
 
 			if (calcFee === null || calcFee === undefined) {
 				extrinsics[idx].info = {
-					error: `Fee calculation not supported for this specVersion`,
+					error: `Fee calculation not supported for this specVersion. ${specVersion}#${specName}`,
 				};
 				continue;
 			}
@@ -460,8 +460,8 @@ export class BlocksService extends AbstractService {
 
 		if (this.minCalcFeeRuntime && specVersion < this.minCalcFeeRuntime) {
 			return {
-				specVersion: -1,
-				specName: 'ERROR',
+				specVersion: specVersion,
+				specName: specName,
 				calcFee: undefined,
 			};
 		}


### PR DESCRIPTION
[BUG] Urgent

Using Kusama as an example querying any block with a runtime less than 1062 (the minimum runtime version used to calc fees for kusama) will throw an error because `api.query.transactionPayment?.nextFeeMultiplier?.at` `Multiplier` type isnt supported.  

Currently there is no check before `api.query.transactionPayment?.nextFeeMultiplier?.at` to make sure we don't calculate any fees for runtime's less than the least known runtime for fee's.

This PR fixes that by adding a check. 