### PR TITLE
chore(release): 7.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [7.0.5](https://github.com/paritytech/substrate-api-sidecar/compare/v7.0.4..v7.0.5) (2021-06-27)
+
+### Bug Fixes 
+
+* **types**  Bump polkadot-js/api to decode `electionProviderMultiPhase`.
+
 ## [7.0.4](https://github.com/paritytech/substrate-api-sidecar/compare/v7.0.3..v7.0.4) (2021-06-23)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.4",
+  "version": "7.0.5",
   "name": "@substrate/api-sidecar",
   "description": "REST service that makes it easy to interact with blockchain nodes built using Substrate's FRAME framework.",
   "homepage": "https://github.com/paritytech/substrate-api-sidecar#readme",
@@ -43,9 +43,9 @@
     "test:init-e2e-tests": "python3 ./scripts/run_chain_tests.py"
   },
   "dependencies": {
-    "@polkadot/api": "^4.15.1",
+    "@polkadot/api": "^4.16.2",
     "@polkadot/apps-config": "^0.93.1",
-    "@polkadot/util-crypto": "^6.9.1",
+    "@polkadot/util-crypto": "^6.10.1",
     "@substrate/calc": "^0.2.0",
     "confmgr": "^1.0.6",
     "express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,12 +407,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.13.7, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.13.9, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.9.6":
-  version: 7.14.5
-  resolution: "@babel/runtime@npm:7.14.5"
+"@babel/runtime@npm:^7.13.7, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.13.9, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.9.6":
+  version: 7.14.6
+  resolution: "@babel/runtime@npm:7.14.6"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: 1e7b7bd939488df0e9af92fac7cf65a38d6de0e5be71883ac2e5f59e6c1199086a9be723b483f9c79adca9f7a62fdffc9ce6f85b953c7efb3469f01f64a41f27
+  checksum: dd931f6ef1c8dab295c4a00c592db6352bf12a5c443f8222304d5c1d3e88d795fa949afcb6f053eec2e69e9827a17ff274524c1cd43813f56b61e3a540274d2f
   languageName: node
   linkType: hard
 
@@ -864,38 +864,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:4.15.1":
-  version: 4.15.1
-  resolution: "@polkadot/api-derive@npm:4.15.1"
+"@polkadot/api-derive@npm:4.16.2":
+  version: 4.16.2
+  resolution: "@polkadot/api-derive@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/api": 4.15.1
-    "@polkadot/rpc-core": 4.15.1
-    "@polkadot/types": 4.15.1
-    "@polkadot/util": ^6.9.1
-    "@polkadot/util-crypto": ^6.9.1
-    "@polkadot/x-rxjs": ^6.9.1
-  checksum: 18d78801c1ca9144704c69e2499d3ee80792ad83e92c43d34541edb019a0437cd60f67d163c671223dcaf782592673124a286377efec69e2105a96cb22492b36
+    "@babel/runtime": ^7.14.6
+    "@polkadot/api": 4.16.2
+    "@polkadot/rpc-core": 4.16.2
+    "@polkadot/types": 4.16.2
+    "@polkadot/util": ^6.10.1
+    "@polkadot/util-crypto": ^6.10.1
+    "@polkadot/x-rxjs": ^6.10.1
+  checksum: 3aea8b879d6dbaff492d66aa8db7c8d65ab0f470fa32d4349e1d3f282afb765cf70222e9eb56143b958b4b6d49f58d97a5a20809b8d8a94093301c241bcab668
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:4.15.1, @polkadot/api@npm:^4.15.1":
-  version: 4.15.1
-  resolution: "@polkadot/api@npm:4.15.1"
+"@polkadot/api@npm:4.16.2, @polkadot/api@npm:^4.16.2":
+  version: 4.16.2
+  resolution: "@polkadot/api@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/api-derive": 4.15.1
-    "@polkadot/keyring": ^6.9.1
-    "@polkadot/metadata": 4.15.1
-    "@polkadot/rpc-core": 4.15.1
-    "@polkadot/rpc-provider": 4.15.1
-    "@polkadot/types": 4.15.1
-    "@polkadot/types-known": 4.15.1
-    "@polkadot/util": ^6.9.1
-    "@polkadot/util-crypto": ^6.9.1
-    "@polkadot/x-rxjs": ^6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/api-derive": 4.16.2
+    "@polkadot/keyring": ^6.10.1
+    "@polkadot/metadata": 4.16.2
+    "@polkadot/rpc-core": 4.16.2
+    "@polkadot/rpc-provider": 4.16.2
+    "@polkadot/types": 4.16.2
+    "@polkadot/types-known": 4.16.2
+    "@polkadot/util": ^6.10.1
+    "@polkadot/util-crypto": ^6.10.1
+    "@polkadot/x-rxjs": ^6.10.1
     eventemitter3: ^4.0.7
-  checksum: 542b85ff07ce8cda215fdb2c22cbbadf6fe05069c14cba0191998f50cf31f451c9a899c78db669451a2142244880838cb215426c3e47eaf3ae6cdc456ab2d598
+  checksum: df082c6297ce01cb6d42f963b7d6759c47f343b5485085666d5407888d1bdaf842f2ef882eee82f796494a0d1161931fe26ab7a4e384e5e09a7c7811562e2e89
   languageName: node
   linkType: hard
 
@@ -927,17 +927,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1, @polkadot/keyring@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/keyring@npm:6.9.1"
+"@polkadot/keyring@npm:^6.10.1, @polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1":
+  version: 6.10.1
+  resolution: "@polkadot/keyring@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/util": 6.9.1
-    "@polkadot/util-crypto": 6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/util": 6.10.1
+    "@polkadot/util-crypto": 6.10.1
   peerDependencies:
-    "@polkadot/util": 6.9.1
-    "@polkadot/util-crypto": 6.9.1
-  checksum: 756da85353c22fdf687b0361666da906be19d11c72ea4f48298e892a759a10dc6f0c42b5492ab285d3de0431c66fd55c47d13f681fb14d80c778298d989b2750
+    "@polkadot/util": 6.10.1
+    "@polkadot/util-crypto": 6.10.1
+  checksum: ffd55b9d0ffbd51240698a29f5c6050abc26fe2982ffbd360ff2d5a627765eb5e6eab686b242c975f17f442ae4f9ef12ee2fab4e3d0b06cb93dfc992ac39f318
   languageName: node
   linkType: hard
 
@@ -969,16 +969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/metadata@npm:4.15.1":
-  version: 4.15.1
-  resolution: "@polkadot/metadata@npm:4.15.1"
+"@polkadot/metadata@npm:4.16.2":
+  version: 4.16.2
+  resolution: "@polkadot/metadata@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/types": 4.15.1
-    "@polkadot/types-known": 4.15.1
-    "@polkadot/util": ^6.9.1
-    "@polkadot/util-crypto": ^6.9.1
-  checksum: 496a450a1c8af6ae203662f569012bdcef51d5440a47db06e2714b3a4ef7fcf847e799124603c76542e14f1cffb588b36f7f03d1eb873024b4cb1192791adfb9
+    "@babel/runtime": ^7.14.6
+    "@polkadot/types": 4.16.2
+    "@polkadot/types-known": 4.16.2
+    "@polkadot/util": ^6.10.1
+    "@polkadot/util-crypto": ^6.10.1
+  checksum: d4e057c107f9f2f34c5d2884e4f453e3a83a90a1461b32746841f8f923ca2d427f2167c8d0d2d4fa5130a7e2f07b8d7e85c661adfa4847fc0c080f125165fb6d
   languageName: node
   linkType: hard
 
@@ -991,42 +991,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:6.9.1, @polkadot/networks@npm:^6.0.5, @polkadot/networks@npm:^6.8.1, @polkadot/networks@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/networks@npm:6.9.1"
+"@polkadot/networks@npm:6.10.1, @polkadot/networks@npm:^6.0.5, @polkadot/networks@npm:^6.10.1, @polkadot/networks@npm:^6.8.1":
+  version: 6.10.1
+  resolution: "@polkadot/networks@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-  checksum: 6c1d2e8638e99619f8b324f7fac30a94f741389596550687d9003d5b4f5725347438883c8a65ee7ad42ef02987173a8c16180671fdc237cad58740f59f3a8c85
+    "@babel/runtime": ^7.14.6
+  checksum: ac113c3fe16624fab1299501c69bfa5d152a95dae4ac3e2d641f3ba89d2c74d6c7b95475b87cd5631661b231fc4fa6e7685e4384af68c54712a76d45d9d83bdf
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:4.15.1":
-  version: 4.15.1
-  resolution: "@polkadot/rpc-core@npm:4.15.1"
+"@polkadot/rpc-core@npm:4.16.2":
+  version: 4.16.2
+  resolution: "@polkadot/rpc-core@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/metadata": 4.15.1
-    "@polkadot/rpc-provider": 4.15.1
-    "@polkadot/types": 4.15.1
-    "@polkadot/util": ^6.9.1
-    "@polkadot/x-rxjs": ^6.9.1
-  checksum: 376ab1010dc9b511b35b2b7ee6e90231f6155d8f2c92db8a726d544b1bd520c3990c19a156227f63366cc86a1662e6c8d32c5ddc8cb12327c3ca607a03ea643a
+    "@babel/runtime": ^7.14.6
+    "@polkadot/metadata": 4.16.2
+    "@polkadot/rpc-provider": 4.16.2
+    "@polkadot/types": 4.16.2
+    "@polkadot/util": ^6.10.1
+    "@polkadot/x-rxjs": ^6.10.1
+  checksum: 9aa379ccd851bb4e7c68c167db11e0e1027d9cac44b6bcfed5f124092b5bc4c36d19240bc603470342712cb7ebc4a50d40809f62a51aaae305297e8b28879f1a
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:4.15.1":
-  version: 4.15.1
-  resolution: "@polkadot/rpc-provider@npm:4.15.1"
+"@polkadot/rpc-provider@npm:4.16.2":
+  version: 4.16.2
+  resolution: "@polkadot/rpc-provider@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/types": 4.15.1
-    "@polkadot/util": ^6.9.1
-    "@polkadot/util-crypto": ^6.9.1
-    "@polkadot/x-fetch": ^6.9.1
-    "@polkadot/x-global": ^6.9.1
-    "@polkadot/x-ws": ^6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/types": 4.16.2
+    "@polkadot/util": ^6.10.1
+    "@polkadot/util-crypto": ^6.10.1
+    "@polkadot/x-fetch": ^6.10.1
+    "@polkadot/x-global": ^6.10.1
+    "@polkadot/x-ws": ^6.10.1
     eventemitter3: ^4.0.7
-  checksum: 71e7ce13c575cc809a7f29bd39961ba68580ba6fcea15af79c2012801655029447f4df54ac63859d0733fdd86695f5f3ff3a1f714e6d137260c1a493bb5879da
+  checksum: ae5f5fd46bf0e0c18d7ba942cbde20409a3c2c52ded5060edb9b7b44cb90643b4e60d188d2aa6ffddb2c1cb8e3011815973b1b5721ecb54abbe3872a6a7d6e50
   languageName: node
   linkType: hard
 
@@ -1056,15 +1056,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:4.15.1":
-  version: 4.15.1
-  resolution: "@polkadot/types-known@npm:4.15.1"
+"@polkadot/types-known@npm:4.16.2":
+  version: 4.16.2
+  resolution: "@polkadot/types-known@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/networks": ^6.9.1
-    "@polkadot/types": 4.15.1
-    "@polkadot/util": ^6.9.1
-  checksum: 1dcab0b5beee9d26e75a5eea4cfda83a3af8bc9b880626c7412f6cc765516addcbdf717c4f45eaf08d7408ada8ab40148a9d812671c1c7d5e9d5f82237f20158
+    "@babel/runtime": ^7.14.6
+    "@polkadot/networks": ^6.10.1
+    "@polkadot/types": 4.16.2
+    "@polkadot/util": ^6.10.1
+  checksum: 70f48665ac3d33bc0242808442d5fe1e2aa0ab42521ca29f22413c5c28d0525db5534848bb8d153770001ce39ca43869adda734a8c0e1ecc2639e5c41b905d52
   languageName: node
   linkType: hard
 
@@ -1098,31 +1098,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:4.15.1, @polkadot/types@npm:^4.11.3-0, @polkadot/types@npm:^4.12.1, @polkadot/types@npm:^4.13.1":
-  version: 4.15.1
-  resolution: "@polkadot/types@npm:4.15.1"
+"@polkadot/types@npm:4.16.2, @polkadot/types@npm:^4.11.3-0, @polkadot/types@npm:^4.12.1, @polkadot/types@npm:^4.13.1":
+  version: 4.16.2
+  resolution: "@polkadot/types@npm:4.16.2"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/metadata": 4.15.1
-    "@polkadot/util": ^6.9.1
-    "@polkadot/util-crypto": ^6.9.1
-    "@polkadot/x-rxjs": ^6.9.1
-  checksum: ede27db095a4f31963ec4d8fa42dddf7fca2d2df61c37515035abc17b1d0cd22b9e3d7b6bda384b63fa7627c9ea959d6c25db9bc1c1584019df1455f3bef8433
+    "@babel/runtime": ^7.14.6
+    "@polkadot/metadata": 4.16.2
+    "@polkadot/util": ^6.10.1
+    "@polkadot/util-crypto": ^6.10.1
+    "@polkadot/x-rxjs": ^6.10.1
+  checksum: f8fc14bec499dd1b85a73cfaa5cb456b127c660f1f23463832ba98e6540b6a7aa82de32a2adea31194fcce2a1d3f994355807c04d68728f24a4f552b442313bf
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:6.9.1, @polkadot/util-crypto@npm:^6.0.5, @polkadot/util-crypto@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/util-crypto@npm:6.9.1"
+"@polkadot/util-crypto@npm:6.10.1, @polkadot/util-crypto@npm:^6.0.5, @polkadot/util-crypto@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/util-crypto@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/networks": 6.9.1
-    "@polkadot/util": 6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/networks": 6.10.1
+    "@polkadot/util": 6.10.1
     "@polkadot/wasm-crypto": ^4.0.2
-    "@polkadot/x-randomvalues": 6.9.1
+    "@polkadot/x-randomvalues": 6.10.1
     base-x: ^3.0.8
     base64-js: ^1.5.1
-    blakejs: ^1.1.0
+    blakejs: ^1.1.1
     bn.js: ^4.11.9
     create-hash: ^1.2.0
     elliptic: ^6.5.4
@@ -1132,8 +1132,8 @@ __metadata:
     tweetnacl: ^1.0.3
     xxhashjs: ^0.2.2
   peerDependencies:
-    "@polkadot/util": 6.9.1
-  checksum: e17d9cc560115ef5cb052da96050f9bc54d206a183f664af8e50b039920f1373dfbcf3f2769a3a27b93e20626f051e7bab61902c314c95cbad20bfbe40ff7192
+    "@polkadot/util": 6.10.1
+  checksum: e0acce8c81a038d9179ec7403d18d7b4d6e8446a90d78c57eaddfea5dacd637c10f8a7ba3ad86646df7c5819cd871a6424eb5d6ad7cf80635e317fdd50f23688
   languageName: node
   linkType: hard
 
@@ -1193,18 +1193,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:6.9.1, @polkadot/util@npm:^6.0.5, @polkadot/util@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/util@npm:6.9.1"
+"@polkadot/util@npm:6.10.1, @polkadot/util@npm:^6.0.5, @polkadot/util@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/util@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/x-textdecoder": 6.9.1
-    "@polkadot/x-textencoder": 6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-textdecoder": 6.10.1
+    "@polkadot/x-textencoder": 6.10.1
     "@types/bn.js": ^4.11.6
     bn.js: ^4.11.9
     camelcase: ^5.3.1
     ip-regex: ^4.3.0
-  checksum: 9dcb4b3a4aa3830cb4ada09d0e19964ad950910d2af4188ac87c4a61c262d0a150886edb3427f1c03b59977f64cc581c297cce12c183481afa0f151aedf07572
+  checksum: 57a58a51ce9784d8a879db45d4beef7fea0b4a039150c80cda21125fa2e91ab98a7b99e68e8e24f75682b420e1382cf63eadf956ae2ee013e454b741aeb143eb
   languageName: node
   linkType: hard
 
@@ -1272,15 +1272,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-fetch@npm:6.9.1"
+"@polkadot/x-fetch@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-fetch@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/x-global": 6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.10.1
     "@types/node-fetch": ^2.5.10
     node-fetch: ^2.6.1
-  checksum: 5a31d826736c9bba23796899bc659f558d52bbf4bacd2370cd7be00bfe13c07f64499a44565e3c39c8459e97cec8889a2dfd8fb9932448311ec8852b2f615ce2
+  checksum: f654e41b265b04340a83b385a707b425362684595ec448f6014b81c948e2e182f1d4e3fc18f4ce43cdb6a1b409122d97bac140225c6f1a5d21fb2a4bcc36ad32
   languageName: node
   linkType: hard
 
@@ -1306,14 +1306,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:6.9.1, @polkadot/x-global@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-global@npm:6.9.1"
+"@polkadot/x-global@npm:6.10.1, @polkadot/x-global@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-global@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
+    "@babel/runtime": ^7.14.6
     "@types/node-fetch": ^2.5.10
     node-fetch: ^2.6.1
-  checksum: 117a5aadac24a58d6fc11cca2bf880d1287a0f5822fbe455251bc8fbf600485b5c9f79c739e4ef37e33e24a05bbcb5096f3fca7d7d966d1381e3a505bfb6a955
+  checksum: 09419064c62f1906dabdc71269b7a14ac5210e1c9aabe92586cfc8465e7048b6bf5d306c5e8ebdc28c6242a7a33280f25156c99aa850e25f92f0d68a9823dcb0
   languageName: node
   linkType: hard
 
@@ -1327,13 +1327,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-randomvalues@npm:6.9.1"
+"@polkadot/x-randomvalues@npm:6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-randomvalues@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/x-global": 6.9.1
-  checksum: aef4c7624d60638ffa057b00605ac9905be9509772b05464c5a5a0f14ecaf6ae9132efe973e2112f714955562b18e9aac686bd1fcbcf96ad0bac64bb843f53c2
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.10.1
+  checksum: d91c87a53f5a2001475778d3b0e02a6b95d2a8f7c886f69c40574eafb6efaa70c928b5e5286766c6addd57dad9b9ea6ab14aa0cd838cbd523ddfa1a6cb95d181
   languageName: node
   linkType: hard
 
@@ -1347,13 +1347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-rxjs@npm:^6.0.5, @polkadot/x-rxjs@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-rxjs@npm:6.9.1"
+"@polkadot/x-rxjs@npm:^6.0.5, @polkadot/x-rxjs@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-rxjs@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
+    "@babel/runtime": ^7.14.6
     rxjs: ^6.6.7
-  checksum: bbffb118b0ec95e9e2c4c6de4b2b2081dbf1c4fdcd2f3049d8fd6d771317006f380e52fe65e3e622e6f3eb9b7eecf3a46abf8fdc4fa69d72c8efdac3804bbbf5
+  checksum: ebbe3bf4e22dc8e0177b8d5a5753074527d5d460f1e6464d7cf0d98406ee00d754076bb536334f6b23f701ffe441dbd01b10ee302f7f34a77a5fa26804390663
   languageName: node
   linkType: hard
 
@@ -1377,13 +1377,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-textdecoder@npm:6.9.1"
+"@polkadot/x-textdecoder@npm:6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-textdecoder@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/x-global": 6.9.1
-  checksum: 7503fb45868970380d1c77fed141ed0f30de7d48d4477a45abeed080e60e4efd922a3e9cf417002ab3a70b57c7c78e6219863efc997a7e9ff90b4c8a4d6e9349
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.10.1
+  checksum: c121f977c1af9e2343f954d114aac257e63733c72b7b94304ba5ddaa98eb0420a3c01ea177d437a4bd446e565e2ad6cf99a60d9fd3728293dec2dba7a5fc1486
   languageName: node
   linkType: hard
 
@@ -1407,25 +1407,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-textencoder@npm:6.9.1"
+"@polkadot/x-textencoder@npm:6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-textencoder@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/x-global": 6.9.1
-  checksum: 968453c8de796f637fd9e8662f16910d94fb8f87c8f44626b18697f2d5eacd6c0b4be86f8dfb3c615dddc29fc6364fbb18b267d945c1f9d0656b2afb14f6b527
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.10.1
+  checksum: 6b80cc8ecee36e957ed913511a876849810976575286a118e0f9c4362014f1374afd449ce596ef4d5c7e99aafc69fcaa39be9d0f6fb788924428fd9f8edf3c02
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^6.9.1":
-  version: 6.9.1
-  resolution: "@polkadot/x-ws@npm:6.9.1"
+"@polkadot/x-ws@npm:^6.10.1":
+  version: 6.10.1
+  resolution: "@polkadot/x-ws@npm:6.10.1"
   dependencies:
-    "@babel/runtime": ^7.14.5
-    "@polkadot/x-global": 6.9.1
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.10.1
     "@types/websocket": ^1.0.2
     websocket: ^1.0.34
-  checksum: e94fc365ab731a6d8b233c316fee6a0f84b700362b46f0fe5975e0394dec6fb13641b06cfdc933e345a6174ee802e3c1a3917907d485c3e29d892085f4f9d1fd
+  checksum: ad1548c9711fdc1e7131114d2ce4cf1694a98194a11fee9e60a28089ad86e3e75ca80c8416f2e7059cd7ab7e412db08921046ce14fd0d9370a6cedd03f6bb93e
   languageName: node
   linkType: hard
 
@@ -1523,9 +1523,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^4.15.1
+    "@polkadot/api": ^4.16.2
     "@polkadot/apps-config": ^0.93.1
-    "@polkadot/util-crypto": ^6.9.1
+    "@polkadot/util-crypto": ^6.10.1
     "@substrate/calc": ^0.2.0
     "@substrate/dev": ^0.5.4
     "@types/argparse": ^2.0.8
@@ -2421,10 +2421,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blakejs@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "blakejs@npm:1.1.0"
-  checksum: 007d68a909d94cea612294bbab0cb2c26440c3a59eb340dfca046f1913cf4aa917da56088ad762f13921883ccc81c6eed2924ceac27f4ebbf9b4d25981a85fcd
+"blakejs@npm:^1.1.0, blakejs@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "blakejs@npm:1.1.1"
+  checksum: 7f9f34cb7b9cc57588f2d438e47ff5284a2ae05370f826612625760816bb75c3a45fb520cd42a5d9fee251326cade24fb3d4d8a53151a057000dbb883af89c36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes: [#590](https://github.com/paritytech/substrate-api-sidecar/issues/590)

Update polkadot-js/api to 4.16.2 to fix for decoding of `electionProviderMultiPhase`.


