### PR TITLE
fix: add `vrfDelay` as a `phase` return value for ongoing auctions to reflect VRFdelays in polkadot

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2338,12 +2338,15 @@ components:
         phase:
           type: string
           enum:
-          - opening
+          - starting
           - ending
+          - delay
           description: |
-            Whether the auction is in the `opening` or `ending` phase. The
-            `ending` phase is where the eventual winners are retroactively
-            picked from. `null` if there is no ongoing auction.
+            An auction can be in one of 4 phases. Both `starting` and `ending` denoting
+            an ongoing auction. `delay` is part of the VRFDelay inside of Substrate which is a Period 
+            `finishEnd` block number where contributions are no longer accepted. After this `delay` phase 
+            the auction is officially finalized and a winner is declared. If `null` is returned 
+            this means the auction has not started yet.
         auctionIndex:
           type: string
           format: unsignedInteger

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2338,8 +2338,8 @@ components:
         phase:
           type: string
           enum:
-          - starting
-          - ending
+          - startPeriod
+          - endPeriod
           - vrfDelay
           description: |
             An auction can be in one of 4 phases. Both `startingPeriod` () and `endingPeriod` indicate

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2340,13 +2340,13 @@ components:
           enum:
           - starting
           - ending
-          - delay
+          - vrfDelay
           description: |
-            An auction can be in one of 4 phases. Both `starting` and `ending` denoting
-            an ongoing auction. `delay` is part of the VRFDelay inside of Substrate which is a Period 
-            `finishEnd` block number where contributions are no longer accepted. After this `delay` phase 
-            the auction is officially finalized and a winner is declared. If `null` is returned 
-            this means the auction has not started yet.
+            An auction can be in one of 4 phases. Both `startingPeriod` () and `endingPeriod` indicate
+            an ongoing auction, while `vrfDelay` lines up with the `AuctionStatus::VrfDelay` . Finally, a value of `null`
+            indicates there is no ongoing auction. Keep in mind the that the `finishEnd` field is the block number the 
+            `endingPeriod` finishes and the `vrfDelay` period begins. The `vrfDelay` period is typically about an 
+            epoch long and no crowdloan contributions are accepted. 
         auctionIndex:
           type: string
           format: unsignedInteger

--- a/src/services/paras/ParasService.spec.ts
+++ b/src/services/paras/ParasService.spec.ts
@@ -188,7 +188,7 @@ describe('ParasService', () => {
 				at: expectedAt,
 				beginEnd: '1000',
 				finishEnd: '21000',
-				phase: 'delay',
+				phase: 'vrfDelay',
 				auctionIndex: '4',
 				leasePeriods: ['39', '40', '41', '42'],
 				winning: [

--- a/src/services/paras/ParasService.spec.ts
+++ b/src/services/paras/ParasService.spec.ts
@@ -1,11 +1,14 @@
 import BN from 'bn.js';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
+import { polkadotRegistry } from '../../test-helpers/registries';
 import {
 	auctionsInfoAt,
+	blockHash20000,
 	blockHash789629,
 	emptyVectorLeases,
 	mockApi,
+	mockBlock789629,
 	noneAuctionsInfoAt,
 	slotsLeasesAt,
 } from '../test-helpers/mock';
@@ -170,7 +173,7 @@ describe('ParasService', () => {
 
 	describe('ParasService.auctionsCurrent', () => {
 		it('Should return the correct data during an ongoing auction', async () => {
-			const leasePeriodIndex = new BN(1000);
+			const leasePeriodIndex = new BN(39);
 			const leaseIndexArray =
 				parasService['enumerateLeaseSets'](leasePeriodIndex);
 			// Remove the first two entries with splice because we have them in the expectedResponse.
@@ -183,11 +186,11 @@ describe('ParasService', () => {
 
 			const expectedResponse = {
 				at: expectedAt,
-				beginEnd: '39',
-				finishEnd: '20039',
-				phase: 'ending',
+				beginEnd: '1000',
+				finishEnd: '21000',
+				phase: 'delay',
 				auctionIndex: '4',
-				leasePeriods: ['1000', '1001', '1002', '1003'],
+				leasePeriods: ['39', '40', '41', '42'],
 				winning: [
 					{
 						bid: {
@@ -195,7 +198,7 @@ describe('ParasService', () => {
 							amount: '1000000',
 							paraId: '199',
 						},
-						leaseSet: ['1000'],
+						leaseSet: ['39'],
 					},
 					{
 						bid: {
@@ -203,7 +206,7 @@ describe('ParasService', () => {
 							amount: '2000000',
 							paraId: '200',
 						},
-						leaseSet: ['1000', '1001'],
+						leaseSet: ['39', '40'],
 					},
 					...additionalWinningOptions,
 				],
@@ -212,6 +215,38 @@ describe('ParasService', () => {
 			const response = await parasService.auctionsCurrent(blockHash789629);
 
 			expect(sanitizeNumbers(response)).toMatchObject(expectedResponse);
+		});
+
+		/**
+		 * The goal of this test is to manipulate the number of the finalized block so that it is less than
+		 * the expected `finishHead`, but higher the `beginEnd` which would denote we are in the `ending` phase
+		 */
+		it('Should return the correct `ending` phase', async () => {
+			const overrideHeader = {
+				parentHash:
+					'0x3d489d71f8fd2e15259df5059a1497436e6b73497500a303b1a705993e25cb27',
+				number: 20000,
+				stateRoot:
+					'0xa0089595e48850a8a00081dd987a4735d0e8f94ac98af89030521f23f6cb8e31',
+				extrinsicsRoot:
+					'0x2d5d3fdb96b487d480b08b64ed69a65433c1713ae3579dd23704cb790aa3b2ae',
+				digest: {},
+			};
+			const header = polkadotRegistry.createType('Header', overrideHeader);
+
+			// Override the mockApi
+			(mockApi.rpc.chain.getHeader as unknown) = () =>
+				Promise.resolve().then(() => header);
+
+			const expectedResponse = 'ending';
+
+			const response = await parasService.auctionsCurrent(blockHash20000);
+
+			expect(response.phase).toBe(expectedResponse);
+
+			// Set the MockApi back to its original self
+			(mockApi.rpc.chain.getHeader as unknown) = () =>
+				Promise.resolve().then(() => mockBlock789629.header);
 		});
 
 		it('Should return the correct null values when `auctionInfo` is `None`', async () => {

--- a/src/services/paras/ParasService.spec.ts
+++ b/src/services/paras/ParasService.spec.ts
@@ -219,7 +219,8 @@ describe('ParasService', () => {
 
 		/**
 		 * The goal of this test is to manipulate the number of the finalized block so that it is less than
-		 * the expected `finishHead`, but higher the `beginEnd` which would denote we are in the `ending` phase
+		 * the expected `finishHead`, but higher the `beginEnd` which would denote we are in the `endPeriod` phase
+		 * of the current auction.
 		 */
 		it('Should return the correct `ending` phase', async () => {
 			const overrideHeader = {
@@ -238,7 +239,7 @@ describe('ParasService', () => {
 			(mockApi.rpc.chain.getHeader as unknown) = () =>
 				Promise.resolve().then(() => header);
 
-			const expectedResponse = 'ending';
+			const expectedResponse = 'endPeriod';
 
 			const response = await parasService.auctionsCurrent(blockHash20000);
 

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -238,7 +238,12 @@ export class ParasService extends AbstractService {
 			}
 
 			finishEnd = beginEnd.add(endingPeriod);
-			phase = beginEnd.gt(blockNumber) ? 'starting' : 'ending';
+
+			if (finishEnd.lt(blockNumber)) {
+				phase = 'delay';
+			} else {
+				phase = beginEnd.gt(blockNumber) ? 'starting' : 'ending';
+			}
 		} else {
 			leasePeriodIndex = null;
 			beginEnd = null;

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -240,7 +240,7 @@ export class ParasService extends AbstractService {
 			finishEnd = beginEnd.add(endingPeriod);
 
 			if (finishEnd.lt(blockNumber)) {
-				phase = 'delay';
+				phase = 'vrfDelay';
 			} else {
 				phase = beginEnd.gt(blockNumber) ? 'starting' : 'ending';
 			}

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -242,7 +242,7 @@ export class ParasService extends AbstractService {
 			if (finishEnd.lt(blockNumber)) {
 				phase = 'vrfDelay';
 			} else {
-				phase = beginEnd.gt(blockNumber) ? 'starting' : 'ending';
+				phase = beginEnd.gt(blockNumber) ? 'startPeriod' : 'endPeriod';
 			}
 		} else {
 			leasePeriodIndex = null;

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -472,8 +472,8 @@ export const auctionsInfoAt = (): Promise<Option<Vec<BlockNumber>>> =>
 		const beingEnd = rococoRegistry.createType('BlockNumber', 1000);
 		const leasePeriodIndex = rococoRegistry.createType('BlockNumber', 39);
 		const vectorAuctions = rococoTypeFactory.vecOf([
-			beingEnd,
 			leasePeriodIndex,
+			beingEnd,
 		]);
 		const optionAuctions = rococoTypeFactory.optionOf(vectorAuctions);
 

--- a/src/services/test-helpers/mock/mockBlock789629.ts
+++ b/src/services/test-helpers/mock/mockBlock789629.ts
@@ -19,6 +19,14 @@ export const blockHash789629 = polkadotRegistry.createType(
 );
 
 /**
+ * BlockHash for polkadot block #20000
+ */
+export const blockHash20000 = polkadotRegistry.createType(
+	'BlockHash',
+	'0x1c309003c5737bb473fa04dc3cce638122d5ffd64497e024835bce71587c4d46'
+);
+
+/**
  * Mock for polkadot forked block #789629.
  */
 export const mockForkedBlock789629 = polkadotRegistry.createType(

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import { IOption } from '../util';
 import { IAt } from './';
 
-export type AuctionPhase = 'starting' | 'ending';
+export type AuctionPhase = 'starting' | 'ending' | 'delay';
 
 export type ParaType = 'parachain' | 'parathread';
 

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import { IOption } from '../util';
 import { IAt } from './';
 
-export type AuctionPhase = 'starting' | 'ending' | 'delay';
+export type AuctionPhase = 'starting' | 'ending' | 'vrfDelay';
 
 export type ParaType = 'parachain' | 'parathread';
 

--- a/src/types/responses/Paras.ts
+++ b/src/types/responses/Paras.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import { IOption } from '../util';
 import { IAt } from './';
 
-export type AuctionPhase = 'starting' | 'ending' | 'vrfDelay';
+export type AuctionPhase = 'startPeriod' | 'endPeriod' | 'vrfDelay';
 
 export type ParaType = 'parachain' | 'parathread';
 


### PR DESCRIPTION
closes: [#588](https://github.com/paritytech/substrate-api-sidecar/issues/588)

## Breaking Change

### Summary

This PR aims to reflect the addition of the `AuctionStatus` enum in polkadot for parachains, specifically the `VRFDelay`. When an auction is past its `finishEnd` block the auction is then in a `vrfDelay` phase. 

### Changes

* I updated the tests to reflect this change, I also spotted a minor issue in the tests and reversed the output results to reflect a real world scenario with the auctions.

* Added logic inside of the `auctionsCurrent` method for `ParasService` that will add a `vrfDelay` phase as a potential result.

* I added the `vrfDelay` result to the `AuctionPhase` type, and changed `starting`=> `startPeriod`, `ending` => `endPeriod`. 

Overall there are 3 potential return values for a phase:

```
phase :
  startPeriod
  endPeriod
  vrfDelay
```

* Updated the docs