### PR TITLE
chore(release): 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [8.0.1](https://github.com/paritytech/substrate-api-sidecar/compare/v8.0.0..v8.0.1) (2021-07-01)
+## [8.0.1](https://github.com/paritytech/substrate-api-sidecar/compare/v8.0.0..v8.0.1) (2021-07-06)
 
 * Update @polkadot/api to get the latest substrate specific upgrades.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [8.0.1](https://github.com/paritytech/substrate-api-sidecar/compare/v8.0.0..v8.0.1) (2021-07-01)
+
+* Update @polkadot/api to get the latest substrate specific upgrades.
+
+* Update @polkadot/apps-config to get latest chain specific upgrades.
+
+
 ## [8.0.0](https://github.com/paritytech/substrate-api-sidecar/compare/v7.0.5..v8.0.0) (2021-07-01)
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0.0",
+  "version": "8.0.1",
   "name": "@substrate/api-sidecar",
   "description": "REST service that makes it easy to interact with blockchain nodes built using Substrate's FRAME framework.",
   "homepage": "https://github.com/paritytech/substrate-api-sidecar#readme",
@@ -43,9 +43,9 @@
     "test:init-e2e-tests": "python3 ./scripts/run_chain_tests.py"
   },
   "dependencies": {
-    "@polkadot/api": "^4.16.2",
-    "@polkadot/apps-config": "^0.93.1",
-    "@polkadot/util-crypto": "^6.10.1",
+    "@polkadot/api": "^4.17.1",
+    "@polkadot/apps-config": "^0.94.1",
+    "@polkadot/util-crypto": "^6.11.1",
     "@substrate/calc": "^0.2.0",
     "confmgr": "^1.0.6",
     "express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,7 +927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^6.11.1":
+"@polkadot/keyring@npm:^6.11.1, @polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1":
   version: 6.11.1
   resolution: "@polkadot/keyring@npm:6.11.1"
   dependencies:
@@ -938,20 +938,6 @@ __metadata:
     "@polkadot/util": 6.11.1
     "@polkadot/util-crypto": 6.11.1
   checksum: 00f1daf471ee36b036a82c076999200a55b3b6b652cf3d22c579ea44aea1a1fe22d364d0cd388f91b3e0c73cc8f98cf63b94b92c1c0d83ecbf68cefecf4cbb0b
-  languageName: node
-  linkType: hard
-
-"@polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1":
-  version: 6.10.1
-  resolution: "@polkadot/keyring@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/util": 6.10.1
-    "@polkadot/util-crypto": 6.10.1
-  peerDependencies:
-    "@polkadot/util": 6.10.1
-    "@polkadot/util-crypto": 6.10.1
-  checksum: ffd55b9d0ffbd51240698a29f5c6050abc26fe2982ffbd360ff2d5a627765eb5e6eab686b242c975f17f442ae4f9ef12ee2fab4e3d0b06cb93dfc992ac39f318
   languageName: node
   linkType: hard
 
@@ -982,19 +968,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/metadata@npm:4.16.2":
-  version: 4.16.2
-  resolution: "@polkadot/metadata@npm:4.16.2"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/types": 4.16.2
-    "@polkadot/types-known": 4.16.2
-    "@polkadot/util": ^6.10.1
-    "@polkadot/util-crypto": ^6.10.1
-  checksum: d4e057c107f9f2f34c5d2884e4f453e3a83a90a1461b32746841f8f923ca2d427f2167c8d0d2d4fa5130a7e2f07b8d7e85c661adfa4847fc0c080f125165fb6d
-  languageName: node
-  linkType: hard
-
 "@polkadot/metadata@npm:4.17.1":
   version: 4.17.1
   resolution: "@polkadot/metadata@npm:4.17.1"
@@ -1008,16 +981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:6.10.1, @polkadot/networks@npm:^6.0.5, @polkadot/networks@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/networks@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-  checksum: ac113c3fe16624fab1299501c69bfa5d152a95dae4ac3e2d641f3ba89d2c74d6c7b95475b87cd5631661b231fc4fa6e7685e4384af68c54712a76d45d9d83bdf
-  languageName: node
-  linkType: hard
-
-"@polkadot/networks@npm:6.11.1, @polkadot/networks@npm:^6.11.1, @polkadot/networks@npm:^6.9.1":
+"@polkadot/networks@npm:6.11.1, @polkadot/networks@npm:^6.0.5, @polkadot/networks@npm:^6.10.1, @polkadot/networks@npm:^6.11.1, @polkadot/networks@npm:^6.9.1":
   version: 6.11.1
   resolution: "@polkadot/networks@npm:6.11.1"
   dependencies:
@@ -1081,18 +1045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:4.16.2":
-  version: 4.16.2
-  resolution: "@polkadot/types-known@npm:4.16.2"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/networks": ^6.10.1
-    "@polkadot/types": 4.16.2
-    "@polkadot/util": ^6.10.1
-  checksum: 70f48665ac3d33bc0242808442d5fe1e2aa0ab42521ca29f22413c5c28d0525db5534848bb8d153770001ce39ca43869adda734a8c0e1ecc2639e5c41b905d52
-  languageName: node
-  linkType: hard
-
 "@polkadot/types-known@npm:4.17.1":
   version: 4.17.1
   resolution: "@polkadot/types-known@npm:4.17.1"
@@ -1133,20 +1085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:4.16.2, @polkadot/types@npm:^4.11.3-0, @polkadot/types@npm:^4.12.1, @polkadot/types@npm:^4.13.1":
-  version: 4.16.2
-  resolution: "@polkadot/types@npm:4.16.2"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/metadata": 4.16.2
-    "@polkadot/util": ^6.10.1
-    "@polkadot/util-crypto": ^6.10.1
-    "@polkadot/x-rxjs": ^6.10.1
-  checksum: f8fc14bec499dd1b85a73cfaa5cb456b127c660f1f23463832ba98e6540b6a7aa82de32a2adea31194fcce2a1d3f994355807c04d68728f24a4f552b442313bf
-  languageName: node
-  linkType: hard
-
-"@polkadot/types@npm:4.17.1":
+"@polkadot/types@npm:4.17.1, @polkadot/types@npm:^4.11.3-0, @polkadot/types@npm:^4.12.1, @polkadot/types@npm:^4.13.1":
   version: 4.17.1
   resolution: "@polkadot/types@npm:4.17.1"
   dependencies:
@@ -1159,33 +1098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:6.10.1, @polkadot/util-crypto@npm:^6.0.5, @polkadot/util-crypto@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/util-crypto@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/networks": 6.10.1
-    "@polkadot/util": 6.10.1
-    "@polkadot/wasm-crypto": ^4.0.2
-    "@polkadot/x-randomvalues": 6.10.1
-    base-x: ^3.0.8
-    base64-js: ^1.5.1
-    blakejs: ^1.1.1
-    bn.js: ^4.11.9
-    create-hash: ^1.2.0
-    elliptic: ^6.5.4
-    hash.js: ^1.1.7
-    js-sha3: ^0.8.0
-    scryptsy: ^2.1.0
-    tweetnacl: ^1.0.3
-    xxhashjs: ^0.2.2
-  peerDependencies:
-    "@polkadot/util": 6.10.1
-  checksum: e0acce8c81a038d9179ec7403d18d7b4d6e8446a90d78c57eaddfea5dacd637c10f8a7ba3ad86646df7c5819cd871a6424eb5d6ad7cf80635e317fdd50f23688
-  languageName: node
-  linkType: hard
-
-"@polkadot/util-crypto@npm:6.11.1, @polkadot/util-crypto@npm:^6.11.1, @polkadot/util-crypto@npm:^6.9.1":
+"@polkadot/util-crypto@npm:6.11.1, @polkadot/util-crypto@npm:^6.0.5, @polkadot/util-crypto@npm:^6.11.1, @polkadot/util-crypto@npm:^6.9.1":
   version: 6.11.1
   resolution: "@polkadot/util-crypto@npm:6.11.1"
   dependencies:
@@ -1226,22 +1139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:6.10.1, @polkadot/util@npm:^6.0.5, @polkadot/util@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/util@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/x-textdecoder": 6.10.1
-    "@polkadot/x-textencoder": 6.10.1
-    "@types/bn.js": ^4.11.6
-    bn.js: ^4.11.9
-    camelcase: ^5.3.1
-    ip-regex: ^4.3.0
-  checksum: 57a58a51ce9784d8a879db45d4beef7fea0b4a039150c80cda21125fa2e91ab98a7b99e68e8e24f75682b420e1382cf63eadf956ae2ee013e454b741aeb143eb
-  languageName: node
-  linkType: hard
-
-"@polkadot/util@npm:6.11.1, @polkadot/util@npm:^6.11.1, @polkadot/util@npm:^6.9.1":
+"@polkadot/util@npm:6.11.1, @polkadot/util@npm:^6.0.5, @polkadot/util@npm:^6.11.1, @polkadot/util@npm:^6.9.1":
   version: 6.11.1
   resolution: "@polkadot/util@npm:6.11.1"
   dependencies:
@@ -1311,33 +1209,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-global@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@types/node-fetch": ^2.5.10
-    node-fetch: ^2.6.1
-  checksum: 09419064c62f1906dabdc71269b7a14ac5210e1c9aabe92586cfc8465e7048b6bf5d306c5e8ebdc28c6242a7a33280f25156c99aa850e25f92f0d68a9823dcb0
-  languageName: node
-  linkType: hard
-
 "@polkadot/x-global@npm:6.11.1, @polkadot/x-global@npm:^6.11.1":
   version: 6.11.1
   resolution: "@polkadot/x-global@npm:6.11.1"
   dependencies:
     "@babel/runtime": ^7.14.6
   checksum: 6a94a9aa6c0426022fce3cd33973fd2ea5f084771e6dd2aa1751a1b6068a9a16c40f736e24203cb99bb1f556ec362b3bf0c37ae6d049f87cbab4308c799e1216
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-randomvalues@npm:6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-randomvalues@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/x-global": 6.10.1
-  checksum: d91c87a53f5a2001475778d3b0e02a6b95d2a8f7c886f69c40574eafb6efaa70c928b5e5286766c6addd57dad9b9ea6ab14aa0cd838cbd523ddfa1a6cb95d181
   languageName: node
   linkType: hard
 
@@ -1351,17 +1228,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-rxjs@npm:^6.0.5, @polkadot/x-rxjs@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-rxjs@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    rxjs: ^6.6.7
-  checksum: ebbe3bf4e22dc8e0177b8d5a5753074527d5d460f1e6464d7cf0d98406ee00d754076bb536334f6b23f701ffe441dbd01b10ee302f7f34a77a5fa26804390663
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-rxjs@npm:^6.11.1, @polkadot/x-rxjs@npm:^6.9.1":
+"@polkadot/x-rxjs@npm:^6.0.5, @polkadot/x-rxjs@npm:^6.11.1, @polkadot/x-rxjs@npm:^6.9.1":
   version: 6.11.1
   resolution: "@polkadot/x-rxjs@npm:6.11.1"
   dependencies:
@@ -1378,16 +1245,6 @@ __metadata:
     "@babel/runtime": ^7.13.9
     "@polkadot/x-global": 6.0.5
   checksum: eb56d68418d41452520b6e9d5147e594864de0e35edc78a88304610886a7297fbc62ed9292b81862647c7d7d579a7b3736b2899ca4b6eb111d823bd97e445ae2
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-textdecoder@npm:6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-textdecoder@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/x-global": 6.10.1
-  checksum: c121f977c1af9e2343f954d114aac257e63733c72b7b94304ba5ddaa98eb0420a3c01ea177d437a4bd446e565e2ad6cf99a60d9fd3728293dec2dba7a5fc1486
   languageName: node
   linkType: hard
 
@@ -1408,16 +1265,6 @@ __metadata:
     "@babel/runtime": ^7.13.9
     "@polkadot/x-global": 6.0.5
   checksum: 3b360312d28dcce37f3bb4bb89f69905eeba0e3e36e2c2d745d72d2f5a967937030e7fb5012765af925475d93b0bf04f89f3fc62021bb86e619da26fd4d3bdf0
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-textencoder@npm:6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-textencoder@npm:6.10.1"
-  dependencies:
-    "@babel/runtime": ^7.14.6
-    "@polkadot/x-global": 6.10.1
-  checksum: 6b80cc8ecee36e957ed913511a876849810976575286a118e0f9c4362014f1374afd449ce596ef4d5c7e99aafc69fcaa39be9d0f6fb788924428fd9f8edf3c02
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,7 +407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.13.7, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.13.9, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.9.6":
+"@babel/runtime@npm:^7.13.9, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.9.6":
   version: 7.14.6
   resolution: "@babel/runtime@npm:7.14.6"
   dependencies:
@@ -525,10 +525,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@equilab/definitions@npm:1.2.2":
-  version: 1.2.2
-  resolution: "@equilab/definitions@npm:1.2.2"
-  checksum: d6e46452ad884051a635cf9901539404a9a9c4b2c236f21ce7d07bce24a5eb0ad43f313039ed4a51cd7b61cc8dbc72ead563ccd030982491729baba1b286c5ba
+"@equilab/definitions@npm:1.2.5":
+  version: 1.2.5
+  resolution: "@equilab/definitions@npm:1.2.5"
+  checksum: 0699436e0d6c5ae8fd01d987a9af538e76c9df63eb32b8fe779cdbf11e85691e8aacbc6ca0bd613c9f556e804bf6620bf0d9d4e060e66b8de5dc0a3b94cad462
   languageName: node
   linkType: hard
 
@@ -549,7 +549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@interlay/polkabtc-types@npm:^0.7.3":
+"@interlay/polkabtc-types@npm:^0.7.4":
   version: 0.7.4
   resolution: "@interlay/polkabtc-types@npm:0.7.4"
   checksum: c03d43d77ca88eda1ba81fba7683b66542348eeff46663bd99ab43002f7b265d64719c7db387b70c66e3bdee1b14db59a3183ed74afe497ffa2f4beda77fa718
@@ -790,10 +790,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kiltprotocol/type-definitions@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "@kiltprotocol/type-definitions@npm:0.1.6"
-  checksum: 685d3a63959d9482116293eb38993e84825615a0a994eb75315fbe28ba4a6fe3d0d4b5db3947942c6aeaa2d2c44a75b0f64fbb961b8df8707d4dd2b2c7939090
+"@kiltprotocol/type-definitions@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "@kiltprotocol/type-definitions@npm:0.1.8"
+  checksum: 26bf3e45c0541d86d0c5d1614990f91b29e1045efafe5e9cc302ea69062eeee5811f7743148e8c41f90e9fc6732abafa177c66f745eb295f3dbc53b301eefe0c
   languageName: node
   linkType: hard
 
@@ -857,77 +857,91 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@phala/typedefs@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@phala/typedefs@npm:0.1.3"
-  checksum: 3e2dc30cb4ca41ec24755e7b2db1efcdb5a1e1cff4c9cd84a2654f44e6eabd9cf532094fb94c705699bc473a4e532fd3615f677127c8e3c7409afc89c8cb1958
+"@phala/typedefs@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@phala/typedefs@npm:0.1.5"
+  checksum: 7747e281f17023631a2eceb789c101f6e4c6f64c7155055e2b4be782a14537bb5639036d059e9d5e44658d081a0476e4e98869c1a4c4ae66502096ddbb8e31f7
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:4.16.2":
-  version: 4.16.2
-  resolution: "@polkadot/api-derive@npm:4.16.2"
+"@polkadot/api-derive@npm:4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/api-derive@npm:4.17.1"
   dependencies:
     "@babel/runtime": ^7.14.6
-    "@polkadot/api": 4.16.2
-    "@polkadot/rpc-core": 4.16.2
-    "@polkadot/types": 4.16.2
-    "@polkadot/util": ^6.10.1
-    "@polkadot/util-crypto": ^6.10.1
-    "@polkadot/x-rxjs": ^6.10.1
-  checksum: 3aea8b879d6dbaff492d66aa8db7c8d65ab0f470fa32d4349e1d3f282afb765cf70222e9eb56143b958b4b6d49f58d97a5a20809b8d8a94093301c241bcab668
+    "@polkadot/api": 4.17.1
+    "@polkadot/rpc-core": 4.17.1
+    "@polkadot/types": 4.17.1
+    "@polkadot/util": ^6.11.1
+    "@polkadot/util-crypto": ^6.11.1
+    "@polkadot/x-rxjs": ^6.11.1
+  checksum: 030393a5f2c7d5389e41e0e46492dbdd96c0bee2bfcf80da18f9b5b6fbf1d15f42f94a299a90a6ada89737d605facc0c913c5b37e3396d8d7c52f8b12489d9dd
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:4.16.2, @polkadot/api@npm:^4.16.2":
-  version: 4.16.2
-  resolution: "@polkadot/api@npm:4.16.2"
+"@polkadot/api@npm:4.17.1, @polkadot/api@npm:^4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/api@npm:4.17.1"
   dependencies:
     "@babel/runtime": ^7.14.6
-    "@polkadot/api-derive": 4.16.2
-    "@polkadot/keyring": ^6.10.1
-    "@polkadot/metadata": 4.16.2
-    "@polkadot/rpc-core": 4.16.2
-    "@polkadot/rpc-provider": 4.16.2
-    "@polkadot/types": 4.16.2
-    "@polkadot/types-known": 4.16.2
-    "@polkadot/util": ^6.10.1
-    "@polkadot/util-crypto": ^6.10.1
-    "@polkadot/x-rxjs": ^6.10.1
+    "@polkadot/api-derive": 4.17.1
+    "@polkadot/keyring": ^6.11.1
+    "@polkadot/metadata": 4.17.1
+    "@polkadot/rpc-core": 4.17.1
+    "@polkadot/rpc-provider": 4.17.1
+    "@polkadot/types": 4.17.1
+    "@polkadot/types-known": 4.17.1
+    "@polkadot/util": ^6.11.1
+    "@polkadot/util-crypto": ^6.11.1
+    "@polkadot/x-rxjs": ^6.11.1
     eventemitter3: ^4.0.7
-  checksum: df082c6297ce01cb6d42f963b7d6759c47f343b5485085666d5407888d1bdaf842f2ef882eee82f796494a0d1161931fe26ab7a4e384e5e09a7c7811562e2e89
+  checksum: 2e5a141d01f2480fbcdc7e14d416cad28f22f894601ce8f38911d424c4d9abaa9b39c0814f0a6222f8c0a90b45eb2614cb73940d79e680dac18660d6b0b1b174
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:^0.93.1":
-  version: 0.93.1
-  resolution: "@polkadot/apps-config@npm:0.93.1"
+"@polkadot/apps-config@npm:^0.94.1":
+  version: 0.94.1
+  resolution: "@polkadot/apps-config@npm:0.94.1"
   dependencies:
     "@acala-network/type-definitions": ^0.7.4-11
-    "@babel/runtime": ^7.14.0
+    "@babel/runtime": ^7.14.6
     "@crustio/type-definitions": 0.0.10
     "@darwinia/types": ^1.1.0-alpha.21
     "@digitalnative/type-definitions": ^1.1.9
     "@docknetwork/node-types": ^0.4.6
     "@edgeware/node-types": ^3.5.1-erup-4
-    "@equilab/definitions": 1.2.2
-    "@interlay/polkabtc-types": ^0.7.3
-    "@kiltprotocol/type-definitions": ^0.1.6
+    "@equilab/definitions": 1.2.5
+    "@interlay/polkabtc-types": ^0.7.4
+    "@kiltprotocol/type-definitions": ^0.1.8
     "@laminar/type-definitions": ^0.3.1
-    "@phala/typedefs": ^0.1.3
-    "@polkadot/networks": ^6.8.1
+    "@phala/typedefs": ^0.1.5
+    "@polkadot/networks": ^6.10.1
     "@polymathnetwork/polymesh-types": ^0.0.2
     "@snowfork/snowbridge-types": ^0.2.3
-    "@sora-substrate/type-definitions": ^1.3.17
-    "@subsocial/types": ^0.5.3
-    "@zeitgeistpm/type-defs": ^0.1.51
+    "@sora-substrate/type-definitions": ^1.3.30
+    "@subsocial/types": ^0.5.8
+    "@zeitgeistpm/type-defs": ^0.2.0
     moonbeam-types-bundle: 1.1.22
     pontem-types-bundle: ^1.0.5
-  checksum: b5e7f0e36df5172f8844ebf0b16cb63aa7f996e8cd557511702434c6ba0177c2c509a9e128b657baa0ca4d0c06a0599b0a8e3da4a0f6910d6e314a3a2576f02d
+  checksum: ff7546dcff7b3aac3e8e658fa2ff1a69b75f25327cc3fdb7b919ff849a92374a6e3243ada1421321d5099d53e76c315d099073090b38fcbdf3b983a33b8e4868
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^6.10.1, @polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1":
+"@polkadot/keyring@npm:^6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/keyring@npm:6.11.1"
+  dependencies:
+    "@babel/runtime": ^7.14.6
+    "@polkadot/util": 6.11.1
+    "@polkadot/util-crypto": 6.11.1
+  peerDependencies:
+    "@polkadot/util": 6.11.1
+    "@polkadot/util-crypto": 6.11.1
+  checksum: 00f1daf471ee36b036a82c076999200a55b3b6b652cf3d22c579ea44aea1a1fe22d364d0cd388f91b3e0c73cc8f98cf63b94b92c1c0d83ecbf68cefecf4cbb0b
+  languageName: node
+  linkType: hard
+
+"@polkadot/keyring@npm:^6.5.2-1, @polkadot/keyring@npm:^6.6.1":
   version: 6.10.1
   resolution: "@polkadot/keyring@npm:6.10.1"
   dependencies:
@@ -938,20 +952,6 @@ __metadata:
     "@polkadot/util": 6.10.1
     "@polkadot/util-crypto": 6.10.1
   checksum: ffd55b9d0ffbd51240698a29f5c6050abc26fe2982ffbd360ff2d5a627765eb5e6eab686b242c975f17f442ae4f9ef12ee2fab4e3d0b06cb93dfc992ac39f318
-  languageName: node
-  linkType: hard
-
-"@polkadot/metadata@npm:3.11.1":
-  version: 3.11.1
-  resolution: "@polkadot/metadata@npm:3.11.1"
-  dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/types": 3.11.1
-    "@polkadot/types-known": 3.11.1
-    "@polkadot/util": ^5.9.2
-    "@polkadot/util-crypto": ^5.9.2
-    bn.js: ^4.11.9
-  checksum: d776e0f390daeb4438ebb897433bc946d639196ded94f1ac12b73680ee5a9cb340507b1654f02585975ac64a6784e502d95bc33df23ff74bb1d9b44b06e94c4f
   languageName: node
   linkType: hard
 
@@ -969,6 +969,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/metadata@npm:4.15.1":
+  version: 4.15.1
+  resolution: "@polkadot/metadata@npm:4.15.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/types": 4.15.1
+    "@polkadot/types-known": 4.15.1
+    "@polkadot/util": ^6.9.1
+    "@polkadot/util-crypto": ^6.9.1
+  checksum: 496a450a1c8af6ae203662f569012bdcef51d5440a47db06e2714b3a4ef7fcf847e799124603c76542e14f1cffb588b36f7f03d1eb873024b4cb1192791adfb9
+  languageName: node
+  linkType: hard
+
 "@polkadot/metadata@npm:4.16.2":
   version: 4.16.2
   resolution: "@polkadot/metadata@npm:4.16.2"
@@ -982,16 +995,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:5.9.2, @polkadot/networks@npm:^5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/networks@npm:5.9.2"
+"@polkadot/metadata@npm:4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/metadata@npm:4.17.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-  checksum: 42a2022af8217a3bf77003d98e0ae3ff351005250bbeab504a612c7af719314eeccde93f0588aed64b1f8949cf924d51894d27836e9cc2c4a273cb8f1761db4a
+    "@babel/runtime": ^7.14.6
+    "@polkadot/types": 4.17.1
+    "@polkadot/types-known": 4.17.1
+    "@polkadot/util": ^6.11.1
+    "@polkadot/util-crypto": ^6.11.1
+  checksum: 56a6280f87dc1693fe536c142dd6696f93764c136c80ffc9d020173a5c9d068c96513394343280774f1d13c867ff4cfba4c01371138315be0663d8d1232cc9d2
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:6.10.1, @polkadot/networks@npm:^6.0.5, @polkadot/networks@npm:^6.10.1, @polkadot/networks@npm:^6.8.1":
+"@polkadot/networks@npm:6.10.1, @polkadot/networks@npm:^6.0.5, @polkadot/networks@npm:^6.10.1":
   version: 6.10.1
   resolution: "@polkadot/networks@npm:6.10.1"
   dependencies:
@@ -1000,46 +1017,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:4.16.2":
-  version: 4.16.2
-  resolution: "@polkadot/rpc-core@npm:4.16.2"
+"@polkadot/networks@npm:6.11.1, @polkadot/networks@npm:^6.11.1, @polkadot/networks@npm:^6.9.1":
+  version: 6.11.1
+  resolution: "@polkadot/networks@npm:6.11.1"
   dependencies:
     "@babel/runtime": ^7.14.6
-    "@polkadot/metadata": 4.16.2
-    "@polkadot/rpc-provider": 4.16.2
-    "@polkadot/types": 4.16.2
-    "@polkadot/util": ^6.10.1
-    "@polkadot/x-rxjs": ^6.10.1
-  checksum: 9aa379ccd851bb4e7c68c167db11e0e1027d9cac44b6bcfed5f124092b5bc4c36d19240bc603470342712cb7ebc4a50d40809f62a51aaae305297e8b28879f1a
+  checksum: b6de958395a31cca7c2ee6e4232287d20f31ccc005b99d8892618716d3e3a4d1af81999f71d935ae69a0ea82abc85a557157bdc6de48f84f4a7d42bb7e1217ec
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:4.16.2":
-  version: 4.16.2
-  resolution: "@polkadot/rpc-provider@npm:4.16.2"
+"@polkadot/rpc-core@npm:4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/rpc-core@npm:4.17.1"
   dependencies:
     "@babel/runtime": ^7.14.6
-    "@polkadot/types": 4.16.2
-    "@polkadot/util": ^6.10.1
-    "@polkadot/util-crypto": ^6.10.1
-    "@polkadot/x-fetch": ^6.10.1
-    "@polkadot/x-global": ^6.10.1
-    "@polkadot/x-ws": ^6.10.1
+    "@polkadot/metadata": 4.17.1
+    "@polkadot/rpc-provider": 4.17.1
+    "@polkadot/types": 4.17.1
+    "@polkadot/util": ^6.11.1
+    "@polkadot/x-rxjs": ^6.11.1
+  checksum: f2a644427e2a67bdb7becf0a73c0c7d4a3eb839143dbdd672327ffb16ecf8a6daa7ec7a504321131b75c81bd1ce2019809cb404251afd373368f1ffdb1d63628
+  languageName: node
+  linkType: hard
+
+"@polkadot/rpc-provider@npm:4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/rpc-provider@npm:4.17.1"
+  dependencies:
+    "@babel/runtime": ^7.14.6
+    "@polkadot/types": 4.17.1
+    "@polkadot/util": ^6.11.1
+    "@polkadot/util-crypto": ^6.11.1
+    "@polkadot/x-fetch": ^6.11.1
+    "@polkadot/x-global": ^6.11.1
+    "@polkadot/x-ws": ^6.11.1
     eventemitter3: ^4.0.7
-  checksum: ae5f5fd46bf0e0c18d7ba942cbde20409a3c2c52ded5060edb9b7b44cb90643b4e60d188d2aa6ffddb2c1cb8e3011815973b1b5721ecb54abbe3872a6a7d6e50
-  languageName: node
-  linkType: hard
-
-"@polkadot/types-known@npm:3.11.1":
-  version: 3.11.1
-  resolution: "@polkadot/types-known@npm:3.11.1"
-  dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/networks": ^5.9.2
-    "@polkadot/types": 3.11.1
-    "@polkadot/util": ^5.9.2
-    bn.js: ^4.11.9
-  checksum: 52bcb902a0bb9bcfb47e57cd5a26fefa1d8010de1a618500217a65a2ea97d07486877eb77579262e09e66f95e4831fe669a10cac3fcc6e0d8035bce759dc5011
+  checksum: 24fb402b1d9a4d95e4ddbf2c41d785e51ee8222cedeb20b97ea26da0fda82f9a54ec84c10a8078ad4876aea80e686882c24707e33b6fb8bbe3c2b8317e27b99c
   languageName: node
   linkType: hard
 
@@ -1056,6 +1069,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/types-known@npm:4.15.1":
+  version: 4.15.1
+  resolution: "@polkadot/types-known@npm:4.15.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/networks": ^6.9.1
+    "@polkadot/types": 4.15.1
+    "@polkadot/util": ^6.9.1
+  checksum: 1dcab0b5beee9d26e75a5eea4cfda83a3af8bc9b880626c7412f6cc765516addcbdf717c4f45eaf08d7408ada8ab40148a9d812671c1c7d5e9d5f82237f20158
+  languageName: node
+  linkType: hard
+
 "@polkadot/types-known@npm:4.16.2":
   version: 4.16.2
   resolution: "@polkadot/types-known@npm:4.16.2"
@@ -1068,18 +1093,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:3.11.1, @polkadot/types@npm:~3.11.1":
-  version: 3.11.1
-  resolution: "@polkadot/types@npm:3.11.1"
+"@polkadot/types-known@npm:4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/types-known@npm:4.17.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/metadata": 3.11.1
-    "@polkadot/util": ^5.9.2
-    "@polkadot/util-crypto": ^5.9.2
-    "@polkadot/x-rxjs": ^5.9.2
-    "@types/bn.js": ^4.11.6
-    bn.js: ^4.11.9
-  checksum: 7af682222081f1664a8616380ca6be92adf6c97b814a73f0b7fc8b573fb4839640491be728bfe3b75f7c7b4d61a42fe375659d82a07887907a62f68bc76a2526
+    "@babel/runtime": ^7.14.6
+    "@polkadot/networks": ^6.11.1
+    "@polkadot/types": 4.17.1
+    "@polkadot/util": ^6.11.1
+  checksum: 7f75965ff02f291294a176bf680a0776683a606454c6c6311412ecad20a04147e0f542a180fed56fa72eaab808c6a22653686cdfa71cb8359c6d49f376320fc3
   languageName: node
   linkType: hard
 
@@ -1098,6 +1120,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/types@npm:4.15.1, @polkadot/types@npm:~4.15.1":
+  version: 4.15.1
+  resolution: "@polkadot/types@npm:4.15.1"
+  dependencies:
+    "@babel/runtime": ^7.14.5
+    "@polkadot/metadata": 4.15.1
+    "@polkadot/util": ^6.9.1
+    "@polkadot/util-crypto": ^6.9.1
+    "@polkadot/x-rxjs": ^6.9.1
+  checksum: ede27db095a4f31963ec4d8fa42dddf7fca2d2df61c37515035abc17b1d0cd22b9e3d7b6bda384b63fa7627c9ea959d6c25db9bc1c1584019df1455f3bef8433
+  languageName: node
+  linkType: hard
+
 "@polkadot/types@npm:4.16.2, @polkadot/types@npm:^4.11.3-0, @polkadot/types@npm:^4.12.1, @polkadot/types@npm:^4.13.1":
   version: 4.16.2
   resolution: "@polkadot/types@npm:4.16.2"
@@ -1108,6 +1143,19 @@ __metadata:
     "@polkadot/util-crypto": ^6.10.1
     "@polkadot/x-rxjs": ^6.10.1
   checksum: f8fc14bec499dd1b85a73cfaa5cb456b127c660f1f23463832ba98e6540b6a7aa82de32a2adea31194fcce2a1d3f994355807c04d68728f24a4f552b442313bf
+  languageName: node
+  linkType: hard
+
+"@polkadot/types@npm:4.17.1":
+  version: 4.17.1
+  resolution: "@polkadot/types@npm:4.17.1"
+  dependencies:
+    "@babel/runtime": ^7.14.6
+    "@polkadot/metadata": 4.17.1
+    "@polkadot/util": ^6.11.1
+    "@polkadot/util-crypto": ^6.11.1
+    "@polkadot/x-rxjs": ^6.11.1
+  checksum: e4925e5421779101646abdeafc105bf16b0660cf0e84f17748cda4b0e177695e9830b6e4a4f710aef371b17687eb1778c4a8b709cd0e0a6f38eac16982f9e42c
   languageName: node
   linkType: hard
 
@@ -1137,18 +1185,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:^5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/util-crypto@npm:5.9.2"
+"@polkadot/util-crypto@npm:6.11.1, @polkadot/util-crypto@npm:^6.11.1, @polkadot/util-crypto@npm:^6.9.1":
+  version: 6.11.1
+  resolution: "@polkadot/util-crypto@npm:6.11.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/networks": 5.9.2
-    "@polkadot/util": 5.9.2
-    "@polkadot/wasm-crypto": ^3.2.4
-    "@polkadot/x-randomvalues": 5.9.2
+    "@babel/runtime": ^7.14.6
+    "@polkadot/networks": 6.11.1
+    "@polkadot/util": 6.11.1
+    "@polkadot/wasm-crypto": ^4.0.2
+    "@polkadot/x-randomvalues": 6.11.1
     base-x: ^3.0.8
     base64-js: ^1.5.1
-    blakejs: ^1.1.0
+    blakejs: ^1.1.1
     bn.js: ^4.11.9
     create-hash: ^1.2.0
     elliptic: ^6.5.4
@@ -1158,23 +1206,8 @@ __metadata:
     tweetnacl: ^1.0.3
     xxhashjs: ^0.2.2
   peerDependencies:
-    "@polkadot/util": 5.9.2
-  checksum: b8283aaa82b9910e09bbbc4daf3b9de0f24099bc1fd03d36b7e1450c81b56f60112777670ca722f8f43dd189dc4c70cad6182078214fd1036ae57284670e4883
-  languageName: node
-  linkType: hard
-
-"@polkadot/util@npm:5.9.2, @polkadot/util@npm:^5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/util@npm:5.9.2"
-  dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/x-textdecoder": 5.9.2
-    "@polkadot/x-textencoder": 5.9.2
-    "@types/bn.js": ^4.11.6
-    bn.js: ^4.11.9
-    camelcase: ^5.3.1
-    ip-regex: ^4.3.0
-  checksum: a4662b170fbdf41188024f8438d9bd434158aaf25cb8f7e0c0c25ede384f64ffa48224a9a4eb14a3f1c026ec5061cf9b4ce4e850f9222518deb42ab5d6efb091
+    "@polkadot/util": 6.11.1
+  checksum: ce050dda04352000773abd97e4fd499a095642865fce980c3691a10812375735ae95b61b2612123d4a0382aaf3bfbd80fd416e63832c83a0571b45d8bbdb5072
   languageName: node
   linkType: hard
 
@@ -1208,12 +1241,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:3.2.4"
+"@polkadot/util@npm:6.11.1, @polkadot/util@npm:^6.11.1, @polkadot/util@npm:^6.9.1":
+  version: 6.11.1
+  resolution: "@polkadot/util@npm:6.11.1"
   dependencies:
-    "@babel/runtime": ^7.13.7
-  checksum: b6909a042c975e739ca5b725e809ab5ca8c35e34da980ad1e81d4e4f0d6e1e5e9dba140b63c3264f6e59df5428346c0a92b089588e909cf934c85011741956d0
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-textdecoder": 6.11.1
+    "@polkadot/x-textencoder": 6.11.1
+    "@types/bn.js": ^4.11.6
+    bn.js: ^4.11.9
+    camelcase: ^5.3.1
+    ip-regex: ^4.3.0
+  checksum: 044c5a809aa2310a64521317ca4c9d7e53dd476ad158666648050f9eb3ea745c1e6980d4ee4f5e2cbd2c4c489f77b2475567f386656c6782fdbe2d922c471aff
   languageName: node
   linkType: hard
 
@@ -1226,35 +1265,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "@polkadot/wasm-crypto-wasm@npm:3.2.4"
-  dependencies:
-    "@babel/runtime": ^7.13.7
-  checksum: 7963e8c6a16e4c42733fcc85d6dcddb44452427be968059c2b6cacfdb65a4b23a329f7a568fbf7a6b210106b71097f4be329050a75780717de2d47d37d5a5201
-  languageName: node
-  linkType: hard
-
 "@polkadot/wasm-crypto-wasm@npm:^4.0.2":
   version: 4.0.2
   resolution: "@polkadot/wasm-crypto-wasm@npm:4.0.2"
   dependencies:
     "@babel/runtime": ^7.13.9
   checksum: d149e025a4bc97753adac39f11ec994d3a9a4b0ac37148d5e7c64c41fc6f2cc9c0e4ebb349b043f2dceddbb2ea432b67a11c37fd2547b81aed091680461265cb
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "@polkadot/wasm-crypto@npm:3.2.4"
-  dependencies:
-    "@babel/runtime": ^7.13.7
-    "@polkadot/wasm-crypto-asmjs": ^3.2.4
-    "@polkadot/wasm-crypto-wasm": ^3.2.4
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 23a93e6fd9638dcd4f5116a4b9d94dea9e7e7e5dd4f98a96c52d352d7afa159f0717240c252dada49c8b9d74cea04656d5dfae70551926ca616cc08baa41167e
   languageName: node
   linkType: hard
 
@@ -1272,26 +1288,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-fetch@npm:6.10.1"
+"@polkadot/x-fetch@npm:^6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-fetch@npm:6.11.1"
   dependencies:
     "@babel/runtime": ^7.14.6
-    "@polkadot/x-global": 6.10.1
+    "@polkadot/x-global": 6.11.1
     "@types/node-fetch": ^2.5.10
     node-fetch: ^2.6.1
-  checksum: f654e41b265b04340a83b385a707b425362684595ec448f6014b81c948e2e182f1d4e3fc18f4ce43cdb6a1b409122d97bac140225c6f1a5d21fb2a4bcc36ad32
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-global@npm:5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/x-global@npm:5.9.2"
-  dependencies:
-    "@babel/runtime": ^7.13.8
-    "@types/node-fetch": ^2.5.8
-    node-fetch: ^2.6.1
-  checksum: 5b36492c847169375c146b60dc35f37e5b7feba5ce164d1fcc78806d1f3e4f1d7ce84b59a345a7035e9d58fab617ea7e5101553717519e330490ac0f21404498
+  checksum: 818ec28321729084b6170b37921a6ec0401464b4ee5fc661e02a23b34a324345c019325a2a2945d2a9f015f9ac761cc2110023d0ed9f714613d61a673c6ec3a3
   languageName: node
   linkType: hard
 
@@ -1306,7 +1311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:6.10.1, @polkadot/x-global@npm:^6.10.1":
+"@polkadot/x-global@npm:6.10.1":
   version: 6.10.1
   resolution: "@polkadot/x-global@npm:6.10.1"
   dependencies:
@@ -1317,13 +1322,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/x-randomvalues@npm:5.9.2"
+"@polkadot/x-global@npm:6.11.1, @polkadot/x-global@npm:^6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-global@npm:6.11.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/x-global": 5.9.2
-  checksum: 1004af57c79ed62ac5457f6f3748aa410ec0c93314e87a71d9e9f09b35729f8b52398d7f0fdf1ac45c202b57db8ff06fd7147a40892f367e26a48347415ae124
+    "@babel/runtime": ^7.14.6
+  checksum: 6a94a9aa6c0426022fce3cd33973fd2ea5f084771e6dd2aa1751a1b6068a9a16c40f736e24203cb99bb1f556ec362b3bf0c37ae6d049f87cbab4308c799e1216
   languageName: node
   linkType: hard
 
@@ -1337,13 +1341,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-rxjs@npm:^5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/x-rxjs@npm:5.9.2"
+"@polkadot/x-randomvalues@npm:6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-randomvalues@npm:6.11.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-    rxjs: ^6.6.6
-  checksum: 4c5d2cf4b6ec8abd57fa14c909b226aeec8289c96e0a24c447d4c9fa565321be0c711f31417a567ede509f18bda1d42522cb0efd94549bd50f06541b63b6971d
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.11.1
+  checksum: f13127b29dbc76a13169181461685a93070151e20dffe464be59345a14f391925219d472405ac8beefc62a35f9eb6cafc9ab3aeae6816eb756c4dfc5ee99e43e
   languageName: node
   linkType: hard
 
@@ -1357,13 +1361,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/x-textdecoder@npm:5.9.2"
+"@polkadot/x-rxjs@npm:^6.11.1, @polkadot/x-rxjs@npm:^6.9.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-rxjs@npm:6.11.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/x-global": 5.9.2
-  checksum: 3644a73b13ef98d0026f87ee140a5debcc6d6a4cb965d1f1ccf214d2c154e06c8053c2453179eed599d771782bba15cb28311d9a2b7f30895b2d0a578b9af307
+    "@babel/runtime": ^7.14.6
+    rxjs: ^6.6.7
+  checksum: 127df5125b706c1cbb16ba8945a9a023c5b8e9ccb6fb7718dc01a92003b81754315b03e1f1724d559dc450b1738fcc75e6fe936a7563d8a43cf89f42005820a6
   languageName: node
   linkType: hard
 
@@ -1387,13 +1391,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:5.9.2":
-  version: 5.9.2
-  resolution: "@polkadot/x-textencoder@npm:5.9.2"
+"@polkadot/x-textdecoder@npm:6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-textdecoder@npm:6.11.1"
   dependencies:
-    "@babel/runtime": ^7.13.8
-    "@polkadot/x-global": 5.9.2
-  checksum: f96a47217110d165894bc098276b685114bfc8ffe10696760f73d24eb259ff9f94acd6719cf4b8c8c6ff74e3f164fb8bf29694bad59767e17e595d62f38bb2d7
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.11.1
+  checksum: 75e5090cf94e207e7454b68a4f554010ddb935565456549ad348daed724a09f4eb1f94f47028739cbf6aadbdea84359bc2f3f304cb03f513f3fa05cc904d67b5
   languageName: node
   linkType: hard
 
@@ -1417,15 +1421,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^6.10.1":
-  version: 6.10.1
-  resolution: "@polkadot/x-ws@npm:6.10.1"
+"@polkadot/x-textencoder@npm:6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-textencoder@npm:6.11.1"
   dependencies:
     "@babel/runtime": ^7.14.6
-    "@polkadot/x-global": 6.10.1
-    "@types/websocket": ^1.0.2
+    "@polkadot/x-global": 6.11.1
+  checksum: 7ae8cdd688ad1ac645587ddcb2511697245f0ce11cc3d1516f323fc9c5c68ccab14d820379721ab24e50b49ee900fcafcaecb456d348b30c7b450e65de6340ea
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-ws@npm:^6.11.1":
+  version: 6.11.1
+  resolution: "@polkadot/x-ws@npm:6.11.1"
+  dependencies:
+    "@babel/runtime": ^7.14.6
+    "@polkadot/x-global": 6.11.1
+    "@types/websocket": ^1.0.3
     websocket: ^1.0.34
-  checksum: ad1548c9711fdc1e7131114d2ce4cf1694a98194a11fee9e60a28089ad86e3e75ca80c8416f2e7059cd7ab7e412db08921046ce14fd0d9370a6cedd03f6bb93e
+  checksum: 87815ff4b0226940c213d641800e5b3031c7a514017f4156b56866dec6287fce853e49be47f0f4116f0c7a39e2b2f244041614b814a2268355a8bd9458a13ca0
   languageName: node
   linkType: hard
 
@@ -1481,23 +1495,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:^1.3.17":
-  version: 1.3.17
-  resolution: "@sora-substrate/type-definitions@npm:1.3.17"
+"@sora-substrate/type-definitions@npm:^1.3.30":
+  version: 1.3.33
+  resolution: "@sora-substrate/type-definitions@npm:1.3.33"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.8.2-9
-  checksum: 310569be20477a6baf6f8dbb93b89355804e47f5b2912878f8b8b6354eaff63f134193cb0fa49157438f92e9d9eacbad075288165722119617329a1d8d2b1988
+  checksum: 04bf3611b17e4ee8f9bc60d80f58a7917d117894a310359156340f2d180817478de1e4ef5f98fadb675a2b452094c626f62aa90d2793799b2b4c9999788f0044
   languageName: node
   linkType: hard
 
-"@subsocial/types@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "@subsocial/types@npm:0.5.3"
+"@subsocial/types@npm:^0.5.8":
+  version: 0.5.8
+  resolution: "@subsocial/types@npm:0.5.8"
   dependencies:
-    "@polkadot/types": ~3.11.1
+    "@polkadot/types": ~4.15.1
     "@subsocial/utils": ^0.4.39
     cids: ^0.7.1
-  checksum: 17e2720187a2d26167a80fbc15279c770bc343bf1e02b09f09a5d136d157a8e34158c76f89f76df2d79b4ebc6482a321dc53eac0dae876491788c7f186a7450f
+  checksum: a6e2152bca88ea9b5cb00ab0b6c92145da69f1d79f44e69e07ae17fef5af8d7498403af506f1cda97e0cc1fed9159b8c71c6eddc237d510e857f4d55a0bdc8cd
   languageName: node
   linkType: hard
 
@@ -1523,9 +1537,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^4.16.2
-    "@polkadot/apps-config": ^0.93.1
-    "@polkadot/util-crypto": ^6.10.1
+    "@polkadot/api": ^4.17.1
+    "@polkadot/apps-config": ^0.94.1
+    "@polkadot/util-crypto": ^6.11.1
     "@substrate/calc": ^0.2.0
     "@substrate/dev": ^0.5.4
     "@types/argparse": ^2.0.8
@@ -1853,12 +1867,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/websocket@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@types/websocket@npm:1.0.2"
+"@types/websocket@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@types/websocket@npm:1.0.3"
   dependencies:
     "@types/node": "*"
-  checksum: d826bdc282b78ef5ad60610dbb87674034c21978d86f00f5a8bff5096ff2ad5d1720c7e0eea0cc9c35987f214b20b7c5af6ae8b353ab2be07c1ba2c31cab284b
+  checksum: 320735c03832277a090c44aa2a645f38678ec5aadd3dbdbe74b213b8c2c9dd44ce7eb44c8440d5e061a7c28f8b3d3da2cec40db1ec431d78f4d2ec898ee48480
   languageName: node
   linkType: hard
 
@@ -1996,10 +2010,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zeitgeistpm/type-defs@npm:^0.1.51":
-  version: 0.1.51
-  resolution: "@zeitgeistpm/type-defs@npm:0.1.51"
-  checksum: e00b7a9c4614b3295bdb5b0a08db2048aa8b992c65bcca1e10069f80c11a0b58af5fb43ae9e4c9a57530ec88db7ac959e1decce1959d40ee72bcdd73b4bbcf04
+"@zeitgeistpm/type-defs@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@zeitgeistpm/type-defs@npm:0.2.0"
+  checksum: 781c7f1ed53f50d0c9bc53fc1628ae1eb628f0f95f31deafced156fc5bca0f81bd6cc9cc4ed87f177c049ede7a501697dcd79c34c58b2f1798fbbe228720a147
   languageName: node
   linkType: hard
 
@@ -2421,7 +2435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blakejs@npm:^1.1.0, blakejs@npm:^1.1.1":
+"blakejs@npm:^1.1.1":
   version: 1.1.1
   resolution: "blakejs@npm:1.1.1"
   checksum: 7f9f34cb7b9cc57588f2d438e47ff5284a2ae05370f826612625760816bb75c3a45fb520cd42a5d9fee251326cade24fb3d4d8a53151a057000dbb883af89c36
@@ -7464,7 +7478,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.6.6, rxjs@npm:^6.6.7":
+"rxjs@npm:^6.6.7":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:


### PR DESCRIPTION
Weekly Sidecar release v8.0.1.

Updates the chain specific types via polkadot-js. 