### PR TITLE
chore(release): 8.0.3: add missing Cargo.lock

### DIFF
--- a/calc/Cargo.lock
+++ b/calc/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "calc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "console_error_panic_hook",
  "console_log",


### PR DESCRIPTION
This was missed in the previous release PR, so adding it now.

Bumps calc to 0.2.1 in the Cargo.lock file