### PR TITLE
docs: alphabetical order for schema types

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1257,25 +1257,30 @@ paths:
                 $ref: '#/components/schemas/BlocksTraceOperations'
 components:
   schemas:
-    BalanceLock:
+    AccountAssetsApproval:
       type: object
       properties:
-        id:
-          type: string
-          description: An identifier for this lock. Only one lock may be in existence
-            for each identifier.
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
         amount:
           type: string
-          description: The amount below which the free balance may not drop with this
-            lock in effect.
+          description: The amount of funds approved for the balance transfer from the owner
+            to some delegated target.
           format: unsignedInteger
-        reasons:
+        deposit:
           type: string
-          description: Reasons for withdrawing balance.
-          enum:
-          - Fee = 0
-          - Misc = 1
-          - All = 2
+          description: The amount reserved on the owner's account to hold this item in storage.
+          format: unsignedInteger
+    AccountAssetsBalances:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        assets:
+          type: array
+          description: An array of queried assets.
+          items:
+            $ref: '#/components/schemas/AssetsBalance'
     AccountBalanceInfo:
       type: object
       properties:
@@ -1316,16 +1321,70 @@ components:
             locks
           items:
             $ref: '#/components/schemas/BalanceLock'
-    AccountAssetsBalances:
+    AccountStakingInfo:
       type: object
       properties:
         at:
           $ref: '#/components/schemas/BlockIdentifiers'
-        assets:
+        rewardDestination:
+          type: string
+          description: The account to which rewards will be paid. Can be 'Staked' (Stash
+            account, adding to the amount at stake), 'Stash' (Stash address, not
+            adding to the amount at stake), or 'Controller' (Controller address).
+          format: ss58
+          enum:
+          - Staked
+          - Stash
+          - Controller
+        controller:
+          type: string
+          description: Controller address for the given Stash.
+          format: ss58
+        numSlashingSpans:
+          type: string
+          description: Number of slashing spans on Stash account; `null` if provided address
+            is not a Controller.
+          format: unsignedInteger
+        nominations:
+          $ref: '#/components/schemas/Nominations'
+        stakingLedger:
+          $ref: '#/components/schemas/StakingLedger'
+      description: >-
+        Note: Runtime versions of Kusama less than 1062 will either have `lastReward` in place of
+        `claimedRewards`, or no field at all. This is related to changes in reward distribution. See: [Lazy Payouts](https://github.com/paritytech/substrate/pull/4474), [Simple Payouts](https://github.com/paritytech/substrate/pull/5406)
+    AccountStakingPayouts:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        erasPayouts:
           type: array
-          description: An array of queried assets.
           items:
-            $ref: '#/components/schemas/AssetsBalance'
+            type: object
+            properties:
+              era:
+                type: string
+                format: unsignedInteger
+                description: Era this information is associated with.
+              totalEraRewardPoints:
+                type: string
+                format: unsignedInteger
+                description: Total reward points for the era. Equals the sum of
+                  reward points for all the validators in the set.
+              totalEraPayout:
+                type: string
+                format: unsignedInteger
+                description: Total payout for the era. Validators split the payout
+                  based on the portion of `totalEraRewardPoints` they have.
+              payouts:
+                $ref: '#/components/schemas/Payouts'
+    AccountVestingInfo:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        vesting:
+          $ref: '#/components/schemas/VestingSchedule'
     AssetsBalance:
       type: object
       properties:
@@ -1347,29 +1406,6 @@ components:
             `true`, then non-zero balances may be stored without a `consumer` reference (and thus
             an ED in the Balances pallet or whatever else is used to control user-account state
             growth).
-    AccountAssetsApproval:
-      type: object
-      properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        amount:
-          type: string
-          description: The amount of funds approved for the balance transfer from the owner
-            to some delegated target.
-          format: unsignedInteger
-        deposit:
-          type: string
-          description: The amount reserved on the owner's account to hold this item in storage.
-          format: unsignedInteger
-    PalletsAssetsInfo:
-      type: object
-      properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        assetInfo:
-          $ref: '#/components/schemas/AssetInfo'
-        assetMetadata: 
-          $ref: '#/components/schemas/AssetMetadata'
     AssetInfo:
       type: object
       properties:
@@ -1443,170 +1479,113 @@ components:
         isFrozen: 
           type: boolean
           description: Whether the asset metadata may be changed by a non Force origin.
-    StakingLedger:
+    BalanceLock:
       type: object
       properties:
-        stash:
+        id:
           type: string
-          description: The _Stash_ account whose balance is actually locked and at stake.
-          format: ss58
-        total:
+          description: An identifier for this lock. Only one lock may be in existence
+            for each identifier.
+        amount:
           type: string
-          description: The total amount of the _Stash_'s balance that we are currently accounting
-            for. Simply `active + unlocking`.
+          description: The amount below which the free balance may not drop with this
+            lock in effect.
           format: unsignedInteger
-        active:
+        reasons:
           type: string
-          description: The total amount of the _Stash_'s balance that will be at stake
-            in any forthcoming eras.
-          format: unsignedInteger
-        unlocking:
-          type: string
-          description: Any balance that is becoming free, which may eventually be
-            transferred out of the _Stash_ (assuming it doesn't get slashed first).
-            Represented as an array of objects, each with an `era` at which `value`
-            will be unlocked.
-          format: unsignedInteger
-        claimedRewards:
-          type: array
-          description: Array of eras for which the stakers behind a validator have
-            claimed rewards. Only updated for _validators._
-          items:
-            type: string
-            format: unsignedInteger
-      description: The staking ledger.
-    Nominations:
-      type: object
-      properties:
-        targets:
-          type: array
-          items:
-            type: string
-          description: The targets of the nomination.
-        submittedIn:
-          type: string
-          format: unsignedInteger
-          description: >-
-             The era the nominations were submitted. (Except for initial
-             nominations which are considered submitted at era 0.)
-        suppressed:
-          type: boolean
-          description: Whether the nominations have been suppressed.
-    AccountStakingInfo:
-      type: object
-      properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        rewardDestination:
-          type: string
-          description: The account to which rewards will be paid. Can be 'Staked' (Stash
-            account, adding to the amount at stake), 'Stash' (Stash address, not
-            adding to the amount at stake), or 'Controller' (Controller address).
-          format: ss58
+          description: Reasons for withdrawing balance.
           enum:
-          - Staked
-          - Stash
-          - Controller
-        controller:
-          type: string
-          description: Controller address for the given Stash.
-          format: ss58
-        numSlashingSpans:
-          type: string
-          description: Number of slashing spans on Stash account; `null` if provided address
-            is not a Controller.
-          format: unsignedInteger
-        nominations:
-          $ref: '#/components/schemas/Nominations'
-        stakingLedger:
-          $ref: '#/components/schemas/StakingLedger'
-      description: >-
-        Note: Runtime versions of Kusama less than 1062 will either have `lastReward` in place of
-        `claimedRewards`, or no field at all. This is related to changes in reward distribution. See: [Lazy Payouts](https://github.com/paritytech/substrate/pull/4474), [Simple Payouts](https://github.com/paritytech/substrate/pull/5406)
-    Payouts:
-      type: array
-      items:
-        type: object
-        properties:
-          validatorId:
-            type: string
-            description: AccountId of the validator the payout is coming from.
-          nominatorStakingPayout:
-            type: string
-            format: unsignedInteger
-            description: Payout for the reward destination associated with the
-              accountId the query was made for.
-          claimed:
-            type: boolean
-            description: Whether or not the reward has been claimed.
-          totalValidatorRewardPoints:
-            type: string
-            format: unsignedInteger
-            description: Number of reward points earned by the validator.
-          validatorCommission:
-            type: string
-            format: unsignedInteger
-            description: The percentage of the total payout that the validator takes as commission,
-              expressed as a Perbill.
-          totalValidatorExposure:
-            type: string
-            format: unsignedInteger
-            description: The sum of the validator's and its nominators' stake.
-          nominatorExposure:
-            type: string
-            format: unsignedInteger
-            description: The amount of stake the nominator has behind the validator.
-        description: Payout for a nominating _Stash_ address and
-          information about the validator they were nominating.
-    AccountStakingPayouts:
+          - Fee = 0
+          - Misc = 1
+          - All = 2
+    Block:
       type: object
       properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        erasPayouts:
+        hash:
+          type: string
+          description: The block's hash.
+          format: hex
+        number:
+          type: string
+          description: The block's height.
+          format: unsignedInteger
+        parentHash:
+          type: string
+          description: The hash of the parent block.
+          format: hex
+        stateRoot:
+          type: string
+          description: The state root after executing this block.
+          format: hex
+        extrinsicRoot:
+          type: string
+          description: The Merkle root of the extrinsics.
+          format: hex
+        authorId:
+          type: string
+          description: The account ID of the block author (may be undefined for some
+            chains).
+          format: ss58
+        logs:
           type: array
           items:
-            type: object
-            properties:
-              era:
-                type: string
-                format: unsignedInteger
-                description: Era this information is associated with.
-              totalEraRewardPoints:
-                type: string
-                format: unsignedInteger
-                description: Total reward points for the era. Equals the sum of
-                  reward points for all the validators in the set.
-              totalEraPayout:
-                type: string
-                format: unsignedInteger
-                description: Total payout for the era. Validators split the payout
-                  based on the portion of `totalEraRewardPoints` they have.
-              payouts:
-                $ref: '#/components/schemas/Payouts'
-    VestingSchedule:
+            $ref: '#/components/schemas/DigestItem'
+          description: Array of `DigestItem`s associated with the block.
+        onInitialize:
+          $ref: '#/components/schemas/BlockInitialize'
+        extrinsics:
+          type: array
+          description: Array of extrinsics (inherents and transactions) within the
+            block.
+          items:
+            $ref: '#/components/schemas/Extrinsic'
+        onFinalize:
+          $ref: '#/components/schemas/BlockFinalize'
+        finalized:
+          type: boolean
+          description: >-
+            A boolean identifying whether the block is finalized or not. 
+            Note: on chains that do not have deterministic finality this field is omitted.
+      description: >-
+        Note: Block finalization does not correspond to consensus, i.e. whether
+        the block is in the canonical chain. It denotes the finalization of block
+        _construction._
+    BlockFinalize:
       type: object
       properties:
-        locked:
-          type: string
-          description: Number of tokens locked at start.
-          format: unsignedInteger
-        perBlock:
-          type: string
-          description: Number of tokens that gets unlocked every block after `startingBlock`.
-          format: unsignedInteger
-        startingBlock:
-          type: string
-          description: Starting block for unlocking (vesting).
-          format: unsignedInteger
-      description: Vesting schedule for an account.
-    AccountVestingInfo:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/SanitizedEvent'
+      description: Object with an array of `SanitizedEvent`s that occurred during
+        block construction finalization with the `method` and `data` for each.
+    BlockHeader:
       type: object
       properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        vesting:
-          $ref: '#/components/schemas/VestingSchedule'
+        parentHash:
+          type: string
+          description: The hash of the parent block.
+          format: hex
+        number:
+          type: string
+          description: The block's height.
+          format: unsignedInteger
+        stateRoot:
+          type: string
+          description: The state root after executing this block.
+          format: hex
+        extrinsicRoot:
+          type: string
+          description: The Merkle root of the extrinsics.
+          format: hex
+        digest:
+          type: object
+          properties: 
+            logs:
+              type: array
+              items:
+                $ref: '#/components/schemas/DigestItem'
+              description: Array of `DigestItem`s associated with the block.
     BlockIdentifiers:
       type: object
       properties:
@@ -1619,6 +1598,47 @@ components:
           description: The block's height.
           format: unsignedInteger
       description: Block number and hash at which the call was made.
+    BlockInitialize:
+      type: object
+      properties:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/SanitizedEvent'
+      description: Object with an array of `SanitizedEvent`s that occurred during
+        block initialization with the `method` and `data` for each.
+    BlocksTrace:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        blockHash:
+          type: string
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/TraceEvent'
+        parentHash:
+          type: string
+        spans:
+          type: array
+          items:
+            $ref: '#/components/schemas/TraceSpan'
+        storageKeys:
+          type: string
+          description: Hex encoded storage keys used to filter events.
+        tracingTargets:
+          type: string
+          description: Targets used to filter spans and events.
+    BlocksTraceOperations:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        operations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
     DigestItem:
       type: object
       properties:
@@ -1631,43 +1651,37 @@ components:
           type: array
           items:
             type: string
-    SanitizedEvent:
+    ElectionStatus:
       type: object
       properties:
-        method:
+        status:
+          type: object
+          description: >-
+            [Deprecated](Works for polkadot runtimes before v0.8.30).
+
+            Era election status: either `Close: null` or `Open: <BlockNumber>`.
+            A status of `Close` indicates that the submission window for solutions
+            from off-chain Phragmen is not open. A status of `Open` indicates that the
+            submission window for off-chain Phragmen solutions has been open since
+            BlockNumber. N.B. when the submission window is open, certain
+            extrinsics are not allowed because they would mutate the state that the
+            off-chain Phragmen calculation relies on for calculating results.
+        toggleEstimate:
           type: string
-        data:
-          type: array
-          items:
-            type: string
-    Signature:
-      type: object
-      properties:
-        signature:
-          type: string
-          format: hex
-        signer:
-          type: string
-          format: ss58
-      description: Object with `signature` and `signer`, or `null` if unsigned.
-    RuntimeDispatchInfo:
-      type: object
-      properties:
-        weight:
-          type: string
-          description: Extrinsic weight.
-        class:
-          type: string
-          description: Extrinsic class.
-          enum:
-          - Normal
-          - Operational
-          - Mandatory
-        partialFee:
-          type: string
-          description: The _inclusion fee_ of a transaction, i.e. the minimum fee required for a transaction. Includes weight and encoded length fees, but does not have access to any signed extensions, e.g. the `tip`.
+          description: Upper bound estimate of the block height at which the `status`
+            will switch.
           format: unsignedInteger
-      description: RuntimeDispatchInfo for the transaction. Includes the `partialFee`.
+      description: Information about the off-chain election. Not included in response when
+        `forceEra.isForceNone`.
+    Error:
+      type: object
+      properties:
+        code:
+          type: number
+        message:
+          type: string
+        stack:
+          type: string
     ExtrinsicMethod:
       type: object
       properties:
@@ -1727,117 +1741,38 @@ components:
         extrinsic:
           $ref: '#/components/schemas/Extrinsic'
       description: A single extrinsic at a given block.
-    BlockInitialize:
+    FundInfo:
       type: object
       properties:
-        events:
-          type: array
-          items:
-            $ref: '#/components/schemas/SanitizedEvent'
-      description: Object with an array of `SanitizedEvent`s that occurred during
-        block initialization with the `method` and `data` for each.
-    BlockFinalize:
-      type: object
-      properties:
-        events:
-          type: array
-          items:
-            $ref: '#/components/schemas/SanitizedEvent'
-      description: Object with an array of `SanitizedEvent`s that occurred during
-        block construction finalization with the `method` and `data` for each.
-    Block:
-      type: object
-      properties:
-        hash:
+        depositor:
           type: string
-          description: The block's hash.
-          format: hex
-        number:
+        verifier:
           type: string
-          description: The block's height.
+        deposit:
+          type: string
           format: unsignedInteger
-        parentHash:
+        raised:
           type: string
-          description: The hash of the parent block.
-          format: hex
-        stateRoot:
-          type: string
-          description: The state root after executing this block.
-          format: hex
-        extrinsicRoot:
-          type: string
-          description: The Merkle root of the extrinsics.
-          format: hex
-        authorId:
-          type: string
-          description: The account ID of the block author (may be undefined for some
-            chains).
-          format: ss58
-        logs:
-          type: array
-          items:
-            $ref: '#/components/schemas/DigestItem'
-          description: Array of `DigestItem`s associated with the block.
-        onInitialize:
-          $ref: '#/components/schemas/BlockInitialize'
-        extrinsics:
-          type: array
-          description: Array of extrinsics (inherents and transactions) within the
-            block.
-          items:
-            $ref: '#/components/schemas/Extrinsic'
-        onFinalize:
-          $ref: '#/components/schemas/BlockFinalize'
-        finalized:
-          type: boolean
-          description: >-
-            A boolean identifying whether the block is finalized or not. 
-            Note: on chains that do not have deterministic finality this field is omitted.
-      description: >-
-        Note: Block finalization does not correspond to consensus, i.e. whether
-        the block is in the canonical chain. It denotes the finalization of block
-        _construction._
-    NodeVersion:
-      type: object
-      properties:
-        clientVersion:
-          type: string
-          description: Node's binary version.
-        clientImplName:
-          type: string
-          description: Node's implementation name.
-        chain:
-          type: string
-          description: Node's chain name.
-      description: Version information of the node.
-    NodeRole:
-      type: string
-      description: Role of this node. (N.B. Sentry nodes are being deprecated.)
-      enum:
-      - Full
-      - LightClient
-      - Authority
-      - Sentry
-    PeerInfo:
-      type: object
-      properties:
-        peerId:
-          type: string
-          description: Peer ID.
-        roles:
-          type: string
-          description: Roles the peer is running
-        protocolVersion:
-          type: string
-          description: Peer's protocol version.
           format: unsignedInteger
-        bestHash:
+        end:
           type: string
-          description: Hash of the best block on the peer's canon chain.
-          format: hex
-        bestNumber:
+          format: unsignedInteger
+        cap:
           type: string
-          description: Height of the best block on the peer's canon chain.
+          format: unsignedInteger
+        lastConstribution:
+          type: string
+          enum:
+          - preEnding
+          - ending
+        firstPeriod:
+          type: string
+          format: unsignedInteger
+        lastPeriod:
+          type: string
+          format: unsignedInteger
+        trieIndex:
+          type: string
           format: unsignedInteger
     NodeNetwork:
       type: object
@@ -1870,374 +1805,146 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PeerInfo'
-    RuntimeSpec:
+    NodeRole:
+      type: string
+      description: Role of this node. (N.B. Sentry nodes are being deprecated.)
+      enum:
+      - Full
+      - LightClient
+      - Authority
+      - Sentry
+    NodeVersion:
       type: object
       properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        authoringVersion:
+        clientVersion:
           type: string
-          description: The version of the authorship interface. An authoring node
-            will not attempt to author blocks unless this is equal to its native runtime.
-        chainType:
+          description: Node's binary version.
+        clientImplName:
           type: string
-          description: Type of the chain.
-          enum:
-          - Development
-          - Local
-          - Live
-        implVersion:
+          description: Node's implementation name.
+        chain:
           type: string
-          description: Version of the implementation specification. Non-consensus-breaking
-            optimizations are about the only changes that could be made which would
-            result in only the `impl_version` changing. The `impl_version` is set to 0
-            when `spec_version` is incremented.
-        specName:
-          type: string
-          description: Identifies the different Substrate runtimes.
-        specVersion:
-          type: string
-          description: Version of the runtime specification.
-        transactionVersion:
-          type: string
-          description: All existing dispatches are fully compatible when this number
-            doesn't change. This number must change when an existing dispatchable
-            (module ID, dispatch ID) is changed, either through an alteration in its
-            user-level semantics, a parameter added/removed/changed, a dispatchable
-            being removed, a module being removed, or a dispatchable/module changing
-            its index.
-        properties:
-          type: object
-          description: Arbitrary properties defined in the chain spec.
-      description: Version information related to the runtime.
-    UnappliedSlash:
+          description: Node's chain name.
+      description: Version information of the node.
+    Nominations:
       type: object
       properties:
-        validator:
-          type: string
-          description: Stash account ID of the offending validator.
-          format: ss58
-        own:
-          type: string
-          description: The amount the validator will be slashed.
-          format: unsignedInteger
-        others:
+        targets:
           type: array
-          description: Array of tuples(`[accountId, amount]`) representing all the
-            stashes of other slashed stakers and the amount they will be slashed.
           items:
             type: string
-            format: tuple[ss58, unsignedInteger]
-        reporters:
-          type: array
-          description: Array of account IDs of the reporters of the offense.
-          items:
-            type: string
-            format: ss58
-        payout:
+          description: The targets of the nomination.
+        submittedIn:
           type: string
-          description: Amount of bounty payout to reporters.
           format: unsignedInteger
-    ElectionStatus:
-      type: object
-      properties:
-        status:
-          type: object
           description: >-
-            [Deprecated](Works for polkadot runtimes before v0.8.30).
-
-            Era election status: either `Close: null` or `Open: <BlockNumber>`.
-            A status of `Close` indicates that the submission window for solutions
-            from off-chain Phragmen is not open. A status of `Open` indicates that the
-            submission window for off-chain Phragmen solutions has been open since
-            BlockNumber. N.B. when the submission window is open, certain
-            extrinsics are not allowed because they would mutate the state that the
-            off-chain Phragmen calculation relies on for calculating results.
-        toggleEstimate:
-          type: string
-          description: Upper bound estimate of the block height at which the `status`
-            will switch.
-          format: unsignedInteger
-      description: Information about the off-chain election. Not included in response when
-        `forceEra.isForceNone`.
-    StakingProgress:
+             The era the nominations were submitted. (Except for initial
+             nominations which are considered submitted at era 0.)
+        suppressed:
+          type: boolean
+          description: Whether the nominations have been suppressed.
+    OnboardingAs:
+      type: string
+      enum:
+      - parachain
+      - parathread
+      description: |
+        This property only shows up when `paraLifecycle=onboarding`. It
+        describes if a particular para is onboarding as a `parachain` or a
+        `parathread`.
+    Operation:
       type: object
       properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        activeEra:
+        phase:
+          $ref: '#/components/schemas/OperationPhase'
+        parentSpanId:
+          $ref: '#/components/schemas/SpanId'
+        primarySpanId:
+          $ref: '#/components/schemas/SpanId'
+        eventIndex:
+          type: string
+          format: unsignedInteger
+          description: Index of the underlying trace event.
+        address:
           type: string
           description: |
-            `EraIndex` of the era being rewarded.
-          format: unsignedInteger
-        forceEra:
-          type: string
-          description: Current status of era forcing.
-          enum:
-          - ForceNone
-          - NotForcing
-          - ForceAlways
-          - ForceNew
-        nextActiveEraEstimate:
-          type: string
-          description: Upper bound estimate of the block height at which the next
-            active era will start. Not included in response when `forceEra.isForceNone`.
-          format: unsignedInteger
-        nextSessionEstimate:
-          type: string
-          description: Upper bound estimate of the block height at which the next
-            session will start.
-          format: unsignedInteger
-        unappliedSlashes:
-          type: array
-          items:
-            $ref: '#/components/schemas/UnappliedSlash'
-          description: Array of upcoming `UnappliedSlash` indexed by era.
-        electionStatus:
-          $ref: '#/components/schemas/ElectionStatus'
-        idealValidatorCount:
-          type: string
-          description: Upper bound of validator set size; considered the ideal size.
-            Not included in response when `forceEra.isForceNone`.
-          format: unsignedInteger
-        validatorSet:
-          type: array
-          description: Stash account IDs of the validators for the current session.
-            Not included in response when `forceEra.isForceNone`.
-          items:
-            type: string
-            format: ss58
-    TransactionDryRun:
+           Account this operation affects. Note - this will be an object like
+           `{ id: address }` if the network uses `MultiAddress`
+        storage:
+          type: object
+          properties:
+            pallet:
+              type: string
+            item:
+              type: string
+            field1:
+              type: string
+              description: |
+                A field of the storage item. (i.e `system::Account::get(address).data`)
+            field2:
+              type: string
+              description: |
+                A field of the struct described by field1 (i.e
+                `system::Account::get(address).data.free`)
+        amount:
+          $ref: '#/components/schemas/OperationAmount'
+    OperationAmount:
       type: object
       properties:
-        resultType:
+        values:
           type: string
-          enum:
-          - DispatchOutcome
-          - TransactionValidityError
-          description: Either `DispatchOutcome` if the transaction is valid or `TransactionValidityError` if the result is invalid.
-        result:
-          type: string
-          enum:
-          - Ok
-          - CannotLookup
-          - NoUnsignedValidator
-          - Custom(u8)
-          - Call
-          - Payment
-          - Future
-          - Stale
-          - BadProof
-          - AncientBirthBlock
-          - ExhaustsResources
-          - BadMandatory
-          - MandatoryDispatch
-          description: 'If there was an error it will be the cause of the error. If the
-            transaction executed correctly it will be `Ok: []`'
-        validityErrorType:
-          type: string
-          enum:
-          - InvalidTransaction
-          - UnknownTransaction
-      description: >-
-        References:
-        - `UnknownTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.UnknownTransaction.html
-        - `InvalidTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.InvalidTransaction.html
-    Transaction:
+          format: unsignedInteger
+        currency:
+          $ref: '#/components/schemas/OperationAmountCurrency'
+    OperationAmountCurrency:
       type: object
       properties:
-        tx:
+        symbol:
           type: string
-          format: hex
-    TransactionMaterial:
+          example: KSM
+    OperationPhase:
+      type: object
+      properties:
+        variant:
+          type: string
+          enum:
+          - onInitialize
+          - initialChecks
+          - applyExtrinsic
+          - onFinalize
+          - finalChecks
+          description: Phase of block execution pipeline.
+        extrinsicIndex:
+          type: string
+          format: unsignedInteger
+          description: |
+            If phase variant is `applyExtrinsic` this will be the index of
+            the extrinsic. Otherwise this field will not be present.
+    PalletsAssetsInfo:
       type: object
       properties:
         at:
           $ref: '#/components/schemas/BlockIdentifiers'
-        genesisHash:
-          type: string
-          description: The hash of the chain's genesis block.
-          format: blockHash
-        chainName:
-          type: string
-          description: The chain's name.
-        specName:
-          type: string
-          description: The chain's spec.
-        specVersion:
-          type: string
-          description: The spec version. Always increased in a runtime upgrade.
-        txVersion:
-          type: string
-          description: The transaction version. Common `txVersion` numbers indicate
-            that the transaction encoding format and method indices are the same.
-            Needed for decoding in an offline environment. Adding new transactions
-            does not change `txVersion`.
-        metadata:
-          type: string
-          description: The chain's metadata in hex format.
-          format: hex
-      description: >-
-        Note: `chainName`, `specName`, and `specVersion` are used to define a type registry with a set
-        of signed extensions and types. For Polkadot and Kusama, `chainName` is not used in defining
-        this registry, but in other Substrate-based chains that re-launch their network without
-        changing the `specName`, the `chainName` would be needed to create the correct registry.
-        Substrate Reference:
-        - `RuntimeVersion`: https://crates.parity.io/sp_version/struct.RuntimeVersion.html
-        - `SignedExtension`: https://crates.parity.io/sp_runtime/traits/trait.SignedExtension.html
-        -  FRAME Support: https://crates.parity.io/frame_support/metadata/index.html
-    TransactionSuccess:
+        assetInfo:
+          $ref: '#/components/schemas/AssetInfo'
+        assetMetadata: 
+          $ref: '#/components/schemas/AssetMetadata'
+    PalletStorage:
       type: object
       properties:
-        hash:
+        pallet:
           type: string
-          description: The hash of the encoded transaction.
-    TransactionFailedToParse:
-      type: object
-      properties:
-        code:
-          type: number
-        error:
+          description: Name of the pallet.
+          example: "democracy"
+        palletIndex:
           type: string
-          description: >-
-            `Failed to parse a tx.`
-        transaction:
-          type: string
-          format: hex
-        cause:
-          type: string
-        stack:
-          type: string
-      description: Error message when Sidecar fails to parse the transaction.
-    TransactionFailedToSubmit:
-      type: object
-      properties:
-        code:
-          type: number
-        error:
-          type: string
-          description: Failed to submit transaction.
-        transaction:
-          type: string
-          format: hex
-        cause:
-          type: string
-        stack:
-          type: string
-      description: >-
-        Error message when the node rejects the submitted transaction.
-    TransactionFailure:
-      oneOf:
-        - $ref: '#/components/schemas/TransactionFailedToSubmit'
-        - $ref: '#/components/schemas/TransactionFailedToParse'
-    TransactionFeeEstimateFailure:
-      type: object
-      properties:
-        code:
-          type: number
-        at:
-            type: object
-            properties:
-              hash:
-                type: string
-        error:
-          type: string
-          description:  Error description.
-        transaction:
-          type: string
-          format: hex
-        block:
-          type: string
-          description: Block hash of the block fee estimation was attempted at.
-        cause:
-          type: string
-          description: Error message from the client.
-        stack:
-          type: string
-    TransactionFeeEstimate:
-      type: object
-      properties:
-        weight:
-          type: string
-          description: Extrinsic weight.
-        class:
-          type: string
-          description: Extrinsic class.
-          enum:
-          - Normal
-          - Operational
-          - Mandatory
-        partialFee:
-          type: string
-          description: Expected inclusion fee for the transaction. Note that the fee
-            rate changes up to 30% in a 24 hour period and this will not be the exact
-            fee.
-          format: unsignedInteger
-      description: >-
-        Note: `partialFee` does not include any tips that you may add to increase a transaction's
-        priority. See [compute_fee](https://crates.parity.io/pallet_transaction_payment/struct.Module.html#method.compute_fee).
-    TransactionPool:
-      type: object
-      properties:
-        pool:
+          description: Index of the pallet for looking up storage.
+          example: "15"
+        items:
           type: array
           items:
-            type: object
-            properties:
-                hash:
-                  type: string
-                  format: hex
-                  description: H256 hash of the extrinsic.
-                encodedExtrinsic:
-                  type: string
-                  format: hex
-                  description: Scale encoded extrinsic.
-    RuntimeCode:
-      type: object
-      properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        code:
-          type: string
-          format: hex
-    Error:
-      type: object
-      properties:
-        code:
-          type: number
-        message:
-          type: string
-        stack:
-          type: string
-    PalletStorageType:
-      type: object
-      description: Info about the data structure used for storage.
-      example:
-          Map:
-              hasher: "Twox64Concat"
-              key:
-                example: "ReferendumIndex"
-              value: "ReferendumInfo"
-              linked: false
-    PalletStorageItemMetadata:
-      type: object
-      properties:
-        name:
-          type: string
-          example: "ReferendumInfoOf"
-          description: The storage item's name (which is the same as the storage item's ID).
-        modifier:
-          type: string
-          example: "Optional"
-        type:
-          $ref: '#/components/schemas/PalletStorageType'
-        fallback:
-          type: string
-          example: "0x00"
-        docs:
-          type: string
-          example: " Information concerning any given referendum.\n\n TWOX-NOTE: SAFE as indexes are not under an attacker’s control."
-      description: Metadata of a storage item from a FRAME pallet.
+            $ref: '#/components/schemas/PalletStorageItemMetadata'
+          description: Array containing metadata for each storage entry of the pallet.
     PalletStorageItem:
       type: object
       properties:
@@ -2278,44 +1985,35 @@ components:
                 turnout: "34485320658000000"
         metadata:
           $ref: '#/components/schemas/PalletStorageItemMetadata'
-    PalletStorage:
+    PalletStorageItemMetadata:
       type: object
       properties:
-        pallet:
+        name:
           type: string
-          description: Name of the pallet.
-          example: "democracy"
-        palletIndex:
+          example: "ReferendumInfoOf"
+          description: The storage item's name (which is the same as the storage item's ID).
+        modifier:
           type: string
-          description: Index of the pallet for looking up storage.
-          example: "15"
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/PalletStorageItemMetadata'
-          description: Array containing metadata for each storage entry of the pallet.
-    ParaLifecycle:
-      type: string
-      enum:
-      - onboarding
-      - parathread
-      - parachain
-      - upgradingParathread
-      - downgradingParachain
-      - offboardingParathread
-      - offboardingParachain
-      description: |
-        The possible states of a para, to take into account delayed lifecycle
-        changes.
-    OnboardingAs:
-      type: string
-      enum:
-      - parachain
-      - parathread
-      description: |
-        This property only shows up when `paraLifecycle=onboarding`. It
-        describes if a particular para is onboarding as a `parachain` or a
-        `parathread`.
+          example: "Optional"
+        type:
+          $ref: '#/components/schemas/PalletStorageType'
+        fallback:
+          type: string
+          example: "0x00"
+        docs:
+          type: string
+          example: " Information concerning any given referendum.\n\n TWOX-NOTE: SAFE as indexes are not under an attacker’s control."
+      description: Metadata of a storage item from a FRAME pallet.
+    PalletStorageType:
+      type: object
+      description: Info about the data structure used for storage.
+      example:
+          Map:
+              hasher: "Twox64Concat"
+              key:
+                example: "ReferendumIndex"
+              value: "ReferendumInfo"
+              linked: false
     Para:
       type: object
       properties:
@@ -2335,48 +2033,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Para'
-    ParasLeasesCurrent:
-      type: object
-      properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        leasePeriodIndex:
-          type: string
-          format: unsignedInteger
-          description: Current lease period index.
-        endOfLeasePeriod:
-          type: string
-          format: unsignedInteger
-          description: Last block (number) of the current lease period.
-        currentLeaseHolders:
-          type: array
-          items:
-            type: string
-            format: unsignedInteger
-          description: List of `paraId`s that currently hold a lease.
-    WinningData:
-      type: object
-      properties:
-        bid:
-          type: object
-          properties:
-            accountId:
-              type: string
-            paraId:
-              type: string
-              format: unsignedInteger
-            amount:
-              type: string
-              format: unsignedInteger
-        leaseSet:
-          type: array
-          items:
-            type: string
-            format: unsignedInteger
-      description: |
-        A currently winning bid and the set of lease periods the bid is for. The
-        `amount` of the bid is per lease period. The `bid` property will be `null`
-        if no bid has been made for the corresponding `leaseSet`.
     ParasAuctionsCurrent:
       type: object
       properties:
@@ -2424,39 +2080,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WinningData'
-    FundInfo:
-      type: object
-      properties:
-        depositor:
-          type: string
-        verifier:
-          type: string
-        deposit:
-          type: string
-          format: unsignedInteger
-        raised:
-          type: string
-          format: unsignedInteger
-        end:
-          type: string
-          format: unsignedInteger
-        cap:
-          type: string
-          format: unsignedInteger
-        lastConstribution:
-          type: string
-          enum:
-          - preEnding
-          - ending
-        firstPeriod:
-          type: string
-          format: unsignedInteger
-        lastPeriod:
-          type: string
-          format: unsignedInteger
-        trieIndex:
-          type: string
-          format: unsignedInteger
     ParasCrowdloans:
       type: object
       properties:
@@ -2487,6 +2110,25 @@ components:
             type: string
             format: unsignedInteger
           description: Lease periods the crowdloan can bid on.
+    ParasLeasesCurrent:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        leasePeriodIndex:
+          type: string
+          format: unsignedInteger
+          description: Current lease period index.
+        endOfLeasePeriod:
+          type: string
+          format: unsignedInteger
+          description: Last block (number) of the current lease period.
+        currentLeaseHolders:
+          type: array
+          items:
+            type: string
+            format: unsignedInteger
+          description: List of `paraId`s that currently hold a lease.
     ParasLeaseInfo:
       type: object
       properties:
@@ -2512,21 +2154,262 @@ components:
           description: |
             List of lease periods for which the `paraId` holds a lease along with
             the deposit held and the associated `accountId`.
-    TraceSpan:
+    ParaLifecycle:
+      type: string
+      enum:
+      - onboarding
+      - parathread
+      - parachain
+      - upgradingParathread
+      - downgradingParachain
+      - offboardingParathread
+      - offboardingParachain
+      description: |
+        The possible states of a para, to take into account delayed lifecycle
+        changes.
+    Payouts:
+      type: array
+      items:
+        type: object
+        properties:
+          validatorId:
+            type: string
+            description: AccountId of the validator the payout is coming from.
+          nominatorStakingPayout:
+            type: string
+            format: unsignedInteger
+            description: Payout for the reward destination associated with the
+              accountId the query was made for.
+          claimed:
+            type: boolean
+            description: Whether or not the reward has been claimed.
+          totalValidatorRewardPoints:
+            type: string
+            format: unsignedInteger
+            description: Number of reward points earned by the validator.
+          validatorCommission:
+            type: string
+            format: unsignedInteger
+            description: The percentage of the total payout that the validator takes as commission,
+              expressed as a Perbill.
+          totalValidatorExposure:
+            type: string
+            format: unsignedInteger
+            description: The sum of the validator's and its nominators' stake.
+          nominatorExposure:
+            type: string
+            format: unsignedInteger
+            description: The amount of stake the nominator has behind the validator.
+        description: Payout for a nominating _Stash_ address and
+          information about the validator they were nominating.
+    PeerInfo:
       type: object
       properties:
+        peerId:
+          type: string
+          description: Peer ID.
+        roles:
+          type: string
+          description: Roles the peer is running
+        protocolVersion:
+          type: string
+          description: Peer's protocol version.
+          format: unsignedInteger
+        bestHash:
+          type: string
+          description: Hash of the best block on the peer's canon chain.
+          format: hex
+        bestNumber:
+          type: string
+          description: Height of the best block on the peer's canon chain.
+          format: unsignedInteger
+    RuntimeCode:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        code:
+          type: string
+          format: hex
+    RuntimeDispatchInfo:
+      type: object
+      properties:
+        weight:
+          type: string
+          description: Extrinsic weight.
+        class:
+          type: string
+          description: Extrinsic class.
+          enum:
+          - Normal
+          - Operational
+          - Mandatory
+        partialFee:
+          type: string
+          description: The _inclusion fee_ of a transaction, i.e. the minimum fee required for a transaction. Includes weight and encoded length fees, but does not have access to any signed extensions, e.g. the `tip`.
+          format: unsignedInteger
+      description: RuntimeDispatchInfo for the transaction. Includes the `partialFee`.
+    RuntimeSpec:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        authoringVersion:
+          type: string
+          description: The version of the authorship interface. An authoring node
+            will not attempt to author blocks unless this is equal to its native runtime.
+        chainType:
+          type: string
+          description: Type of the chain.
+          enum:
+          - Development
+          - Local
+          - Live
+        implVersion:
+          type: string
+          description: Version of the implementation specification. Non-consensus-breaking
+            optimizations are about the only changes that could be made which would
+            result in only the `impl_version` changing. The `impl_version` is set to 0
+            when `spec_version` is incremented.
+        specName:
+          type: string
+          description: Identifies the different Substrate runtimes.
+        specVersion:
+          type: string
+          description: Version of the runtime specification.
+        transactionVersion:
+          type: string
+          description: All existing dispatches are fully compatible when this number
+            doesn't change. This number must change when an existing dispatchable
+            (module ID, dispatch ID) is changed, either through an alteration in its
+            user-level semantics, a parameter added/removed/changed, a dispatchable
+            being removed, a module being removed, or a dispatchable/module changing
+            its index.
+        properties:
+          type: object
+          description: Arbitrary properties defined in the chain spec.
+      description: Version information related to the runtime.
+    SanitizedEvent:
+      type: object
+      properties:
+        method:
+          type: string
+        data:
+          type: array
+          items:
+            type: string
+    Signature:
+      type: object
+      properties:
+        signature:
+          type: string
+          format: hex
+        signer:
+          type: string
+          format: ss58
+      description: Object with `signature` and `signer`, or `null` if unsigned.
+    SpanId:
+      type: object
+      properties:
+        name:
+          type: string
+        target:
+          type: string
         id:
           type: string
           format: unsignedInteger
-        name:
+    StakingLedger:
+      type: object
+      properties:
+        stash:
           type: string
+          description: The _Stash_ account whose balance is actually locked and at stake.
+          format: ss58
+        total:
+          type: string
+          description: The total amount of the _Stash_'s balance that we are currently accounting
+            for. Simply `active + unlocking`.
+          format: unsignedInteger
+        active:
+          type: string
+          description: The total amount of the _Stash_'s balance that will be at stake
+            in any forthcoming eras.
+          format: unsignedInteger
+        unlocking:
+          type: string
+          description: Any balance that is becoming free, which may eventually be
+            transferred out of the _Stash_ (assuming it doesn't get slashed first).
+            Represented as an array of objects, each with an `era` at which `value`
+            will be unlocked.
+          format: unsignedInteger
+        claimedRewards:
+          type: array
+          description: Array of eras for which the stakers behind a validator have
+            claimed rewards. Only updated for _validators._
+          items:
+            type: string
+            format: unsignedInteger
+      description: The staking ledger.
+    StakingProgress:
+      type: object
+      properties:
+        at:
+          $ref: '#/components/schemas/BlockIdentifiers'
+        activeEra:
+          type: string
+          description: |
+            `EraIndex` of the era being rewarded.
+          format: unsignedInteger
+        forceEra:
+          type: string
+          description: Current status of era forcing.
+          enum:
+          - ForceNone
+          - NotForcing
+          - ForceAlways
+          - ForceNew
+        nextActiveEraEstimate:
+          type: string
+          description: Upper bound estimate of the block height at which the next
+            active era will start. Not included in response when `forceEra.isForceNone`.
+          format: unsignedInteger
+        nextSessionEstimate:
+          type: string
+          description: Upper bound estimate of the block height at which the next
+            session will start.
+          format: unsignedInteger
+        unappliedSlashes:
+          type: array
+          items:
+            $ref: '#/components/schemas/UnappliedSlash'
+          description: Array of upcoming `UnappliedSlash` indexed by era.
+        electionStatus:
+          $ref: '#/components/schemas/ElectionStatus'
+        idealValidatorCount:
+          type: string
+          description: Upper bound of validator set size; considered the ideal size.
+            Not included in response when `forceEra.isForceNone`.
+          format: unsignedInteger
+        validatorSet:
+          type: array
+          description: Stash account IDs of the validators for the current session.
+            Not included in response when `forceEra.isForceNone`.
+          items:
+            type: string
+            format: ss58
+    TraceEvent:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+              stringValues:
+                $ref: '#/components/schemas/TraceEventDataStringValues'
         parentId:
           type: string
           format: unsignedInteger
         target:
-            type: string
-        wasm:
-          type: boolean
+          type: string
     TraceEventDataStringValues:
       type: object
       properties:
@@ -2542,156 +2425,273 @@ components:
           format: hex
           description: Hex scale encoded storage value.
       description: Note these exact values will only be present for storage events.
-    TraceEvent:
+    TraceSpan:
       type: object
       properties:
-        data:
-          type: object
-          properties:
-              stringValues:
-                $ref: '#/components/schemas/TraceEventDataStringValues'
+        id:
+          type: string
+          format: unsignedInteger
+        name:
+          type: string
         parentId:
           type: string
           format: unsignedInteger
         target:
-          type: string
-    BlocksTrace:
+            type: string
+        wasm:
+          type: boolean
+    Transaction:
       type: object
       properties:
-        at:
-          $ref: '#/components/schemas/BlockIdentifiers'
-        blockHash:
+        tx:
           type: string
-        events:
-          type: array
-          items:
-            $ref: '#/components/schemas/TraceEvent'
-        parentHash:
-          type: string
-        spans:
-          type: array
-          items:
-            $ref: '#/components/schemas/TraceSpan'
-        storageKeys:
-          type: string
-          description: Hex encoded storage keys used to filter events.
-        tracingTargets:
-          type: string
-          description: Targets used to filter spans and events.
-    SpanId:
+          format: hex
+    TransactionDryRun:
       type: object
       properties:
-        name:
-          type: string
-        target:
-          type: string
-        id:
-          type: string
-          format: unsignedInteger
-    OperationAmountCurrency:
-      type: object
-      properties:
-        symbol:
-          type: string
-          example: KSM
-    OperationAmount:
-      type: object
-      properties:
-        values:
-          type: string
-          format: unsignedInteger
-        currency:
-          $ref: '#/components/schemas/OperationAmountCurrency'
-    OperationPhase:
-      type: object
-      properties:
-        variant:
+        resultType:
           type: string
           enum:
-          - onInitialize
-          - initialChecks
-          - applyExtrinsic
-          - onFinalize
-          - finalChecks
-          description: Phase of block execution pipeline.
-        extrinsicIndex:
+          - DispatchOutcome
+          - TransactionValidityError
+          description: Either `DispatchOutcome` if the transaction is valid or `TransactionValidityError` if the result is invalid.
+        result:
           type: string
-          format: unsignedInteger
-          description: |
-            If phase variant is `applyExtrinsic` this will be the index of
-            the extrinsic. Otherwise this field will not be present.
-    Operation:
+          enum:
+          - Ok
+          - CannotLookup
+          - NoUnsignedValidator
+          - Custom(u8)
+          - Call
+          - Payment
+          - Future
+          - Stale
+          - BadProof
+          - AncientBirthBlock
+          - ExhaustsResources
+          - BadMandatory
+          - MandatoryDispatch
+          description: 'If there was an error it will be the cause of the error. If the
+            transaction executed correctly it will be `Ok: []`'
+        validityErrorType:
+          type: string
+          enum:
+          - InvalidTransaction
+          - UnknownTransaction
+      description: >-
+        References:
+        - `UnknownTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.UnknownTransaction.html
+        - `InvalidTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.InvalidTransaction.html
+    TransactionFailedToParse:
       type: object
       properties:
-        phase:
-          $ref: '#/components/schemas/OperationPhase'
-        parentSpanId:
-          $ref: '#/components/schemas/SpanId'
-        primarySpanId:
-          $ref: '#/components/schemas/SpanId'
-        eventIndex:
+        code:
+          type: number
+        error:
           type: string
+          description: >-
+            `Failed to parse a tx.`
+        transaction:
+          type: string
+          format: hex
+        cause:
+          type: string
+        stack:
+          type: string
+      description: Error message when Sidecar fails to parse the transaction.
+    TransactionFailedToSubmit:
+      type: object
+      properties:
+        code:
+          type: number
+        error:
+          type: string
+          description: Failed to submit transaction.
+        transaction:
+          type: string
+          format: hex
+        cause:
+          type: string
+        stack:
+          type: string
+      description: >-
+        Error message when the node rejects the submitted transaction.
+    TransactionFailure:
+      oneOf:
+        - $ref: '#/components/schemas/TransactionFailedToSubmit'
+        - $ref: '#/components/schemas/TransactionFailedToParse'
+    TransactionFeeEstimate:
+      type: object
+      properties:
+        weight:
+          type: string
+          description: Extrinsic weight.
+        class:
+          type: string
+          description: Extrinsic class.
+          enum:
+          - Normal
+          - Operational
+          - Mandatory
+        partialFee:
+          type: string
+          description: Expected inclusion fee for the transaction. Note that the fee
+            rate changes up to 30% in a 24 hour period and this will not be the exact
+            fee.
           format: unsignedInteger
-          description: Index of the underlying trace event.
-        address:
+      description: >-
+        Note: `partialFee` does not include any tips that you may add to increase a transaction's
+        priority. See [compute_fee](https://crates.parity.io/pallet_transaction_payment/struct.Module.html#method.compute_fee).
+    TransactionFeeEstimateFailure:
+      type: object
+      properties:
+        code:
+          type: number
+        at:
+            type: object
+            properties:
+              hash:
+                type: string
+        error:
           type: string
-          description: |
-           Account this operation affects. Note - this will be an object like
-           `{ id: address }` if the network uses `MultiAddress`
-        storage:
-          type: object
-          properties:
-            pallet:
-              type: string
-            item:
-              type: string
-            field1:
-              type: string
-              description: |
-                A field of the storage item. (i.e `system::Account::get(address).data`)
-            field2:
-              type: string
-              description: |
-                A field of the struct described by field1 (i.e
-                `system::Account::get(address).data.free`)
-        amount:
-          $ref: '#/components/schemas/OperationAmount'
-    BlocksTraceOperations:
+          description:  Error description.
+        transaction:
+          type: string
+          format: hex
+        block:
+          type: string
+          description: Block hash of the block fee estimation was attempted at.
+        cause:
+          type: string
+          description: Error message from the client.
+        stack:
+          type: string
+    TransactionMaterial:
       type: object
       properties:
         at:
           $ref: '#/components/schemas/BlockIdentifiers'
-        operations:
-          type: array
-          items:
-            $ref: '#/components/schemas/Operation'
-    BlockHeader:
+        genesisHash:
+          type: string
+          description: The hash of the chain's genesis block.
+          format: blockHash
+        chainName:
+          type: string
+          description: The chain's name.
+        specName:
+          type: string
+          description: The chain's spec.
+        specVersion:
+          type: string
+          description: The spec version. Always increased in a runtime upgrade.
+        txVersion:
+          type: string
+          description: The transaction version. Common `txVersion` numbers indicate
+            that the transaction encoding format and method indices are the same.
+            Needed for decoding in an offline environment. Adding new transactions
+            does not change `txVersion`.
+        metadata:
+          type: string
+          description: The chain's metadata in hex format.
+          format: hex
+      description: >-
+        Note: `chainName`, `specName`, and `specVersion` are used to define a type registry with a set
+        of signed extensions and types. For Polkadot and Kusama, `chainName` is not used in defining
+        this registry, but in other Substrate-based chains that re-launch their network without
+        changing the `specName`, the `chainName` would be needed to create the correct registry.
+        Substrate Reference:
+        - `RuntimeVersion`: https://crates.parity.io/sp_version/struct.RuntimeVersion.html
+        - `SignedExtension`: https://crates.parity.io/sp_runtime/traits/trait.SignedExtension.html
+        -  FRAME Support: https://crates.parity.io/frame_support/metadata/index.html
+    TransactionPool:
       type: object
       properties:
-        parentHash:
+        pool:
+          type: array
+          items:
+            type: object
+            properties:
+                hash:
+                  type: string
+                  format: hex
+                  description: H256 hash of the extrinsic.
+                encodedExtrinsic:
+                  type: string
+                  format: hex
+                  description: Scale encoded extrinsic.
+    TransactionSuccess:
+      type: object
+      properties:
+        hash:
           type: string
-          description: The hash of the parent block.
-          format: hex
-        number:
+          description: The hash of the encoded transaction.
+    UnappliedSlash:
+      type: object
+      properties:
+        validator:
           type: string
-          description: The block's height.
+          description: Stash account ID of the offending validator.
+          format: ss58
+        own:
+          type: string
+          description: The amount the validator will be slashed.
           format: unsignedInteger
-        stateRoot:
+        others:
+          type: array
+          description: Array of tuples(`[accountId, amount]`) representing all the
+            stashes of other slashed stakers and the amount they will be slashed.
+          items:
+            type: string
+            format: tuple[ss58, unsignedInteger]
+        reporters:
+          type: array
+          description: Array of account IDs of the reporters of the offense.
+          items:
+            type: string
+            format: ss58
+        payout:
           type: string
-          description: The state root after executing this block.
-          format: hex
-        extrinsicRoot:
+          description: Amount of bounty payout to reporters.
+          format: unsignedInteger
+    VestingSchedule:
+      type: object
+      properties:
+        locked:
           type: string
-          description: The Merkle root of the extrinsics.
-          format: hex
-        digest:
+          description: Number of tokens locked at start.
+          format: unsignedInteger
+        perBlock:
+          type: string
+          description: Number of tokens that gets unlocked every block after `startingBlock`.
+          format: unsignedInteger
+        startingBlock:
+          type: string
+          description: Starting block for unlocking (vesting).
+          format: unsignedInteger
+      description: Vesting schedule for an account.
+    WinningData:
+      type: object
+      properties:
+        bid:
           type: object
-          properties: 
-            logs:
-              type: array
-              items:
-                $ref: '#/components/schemas/DigestItem'
-              description: Array of `DigestItem`s associated with the block.
+          properties:
+            accountId:
+              type: string
+            paraId:
+              type: string
+              format: unsignedInteger
+            amount:
+              type: string
+              format: unsignedInteger
+        leaseSet:
+          type: array
+          items:
+            type: string
+            format: unsignedInteger
+      description: |
+        A currently winning bid and the set of lease periods the bid is for. The
+        `amount` of the bid is per lease period. The `bid` property will be `null`
+        if no bid has been made for the corresponding `leaseSet`.
   requestBodies:
     Transaction:
       content:


### PR DESCRIPTION
Update the schema of the swagger ui docs to be in alphabetical order. Unfortunately the schema portion doesnt have built in alphabetical order support, and a plugin is needed in order to facilitate that, therefore I just switched it all over manually. I think manually switching it over is nice anyways, it will make it easier to organize when updating the docs if need be. 