### PR TITLE
docs(ChainType): fix docs for chaintype return value

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1639,6 +1639,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Operation'
+    ChainType:
+      type: object
+      description: Type of the chain. It will return one of the following enum variants as a key. Live, Development, Local, or Custom. Each variant will have a value as null except when the ChainType is Custom, it will return a string. 
+      properties:
+        live: 
+          type: boolean
+          nullable: true
+          default: null
+        development:
+          type: boolean
+          nullable: true
+          default: null
+        local: 
+          type: boolean
+          nullable: true
+          default: null
+        custom:
+          type: string
+      example: "{\"live\": null}"
     DigestItem:
       type: object
       properties:
@@ -2259,12 +2278,7 @@ components:
           description: The version of the authorship interface. An authoring node
             will not attempt to author blocks unless this is equal to its native runtime.
         chainType:
-          type: string
-          description: Type of the chain.
-          enum:
-          - Development
-          - Local
-          - Live
+          $ref: '#/components/schemas/ChainType'
         implVersion:
           type: string
           description: Version of the implementation specification. Non-consensus-breaking

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1644,15 +1644,15 @@ components:
       description: Type of the chain. It will return one of the following enum variants as a key. Live, Development, Local, or Custom. Each variant will have a value as null except when the ChainType is Custom, it will return a string. 
       properties:
         live: 
-          type: boolean
+          type: string
           nullable: true
           default: null
         development:
-          type: boolean
+          type: string
           nullable: true
           default: null
         local: 
-          type: boolean
+          type: string
           nullable: true
           default: null
         custom:


### PR DESCRIPTION
closes: [#624]

I updated the docs to reflect the actual return value of ChainType via polkadot-js. 

The route this is associated with is `/runtime/spec`.

The enum ChainType has 4 variants:

```
- Live => null
- Development => null
- Local => null
- Custom => string
```

The old docs reflected that the return value is a string, but instead an object is returned with the key as one of the variants, and the value as null except when the variant custom is used, in which case a string will be the value. 
