### PR TITLE
fix: finalization for `/blocks/head`

### DIFF
--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -115,8 +115,8 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			hash = (await this.api.rpc.chain.getHeader()).hash;
 		} else if (finalized === 'false') {
 			// We query the finalized head to know where the latest finalized block
-			// is. It is a way to confirm whether the queried block is less than or greater
-			// than the finalized head.
+			// is. It is a way to confirm whether the queried block is less than or
+			// equal to the finalized head.
 			omitFinalizedTag = false;
 			queryFinalizedHead = true;
 			hash = (await this.api.rpc.chain.getHeader()).hash;

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -115,7 +115,10 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		const extrinsicDocsArg = extrinsicDocs === 'true';
 
 		const { hash, queryFinalizedHead, omitFinalizedTag } =
-			await this.parseFinalizationOpts(this.options.finalizes, finalized as string);
+			await this.parseFinalizationOpts(
+				this.options.finalizes,
+				finalized as string
+			);
 
 		const options = {
 			eventDocs: eventDocsArg,

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -114,6 +114,9 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			queryFinalizedHead = false;
 			hash = (await this.api.rpc.chain.getHeader()).hash;
 		} else if (finalized === 'false') {
+			// We query the finalized head to know where the latest finalized block
+			// is. It is a way to confirm whether the queried block is less than or greater
+			// than the finalized head. 
 			omitFinalizedTag = false;
 			queryFinalizedHead = true;
 			hash = (await this.api.rpc.chain.getHeader()).hash;

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -114,9 +114,8 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		const eventDocsArg = eventDocs === 'true';
 		const extrinsicDocsArg = extrinsicDocs === 'true';
 
-		const paramFinalized = finalized === 'true' ? true : false;
 		const { hash, queryFinalizedHead, omitFinalizedTag } =
-			await this.parseFinalizationOpts(this.options.finalizes, paramFinalized);
+			await this.parseFinalizationOpts(this.options.finalizes, finalized as string);
 
 		const options = {
 			eventDocs: eventDocsArg,
@@ -215,7 +214,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 	 */
 	private parseFinalizationOpts = async (
 		optFinalizes: boolean,
-		paramFinalized: boolean
+		paramFinalized: string
 	): Promise<IFinalizationOpts> => {
 		let hash, queryFinalizedHead, omitFinalizedTag;
 		if (!optFinalizes) {
@@ -223,7 +222,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			omitFinalizedTag = true;
 			queryFinalizedHead = false;
 			hash = (await this.api.rpc.chain.getHeader()).hash;
-		} else if (!paramFinalized) {
+		} else if (paramFinalized === 'false') {
 			omitFinalizedTag = false;
 			queryFinalizedHead = true;
 			hash = (await this.api.rpc.chain.getHeader()).hash;

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -116,7 +116,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		} else if (finalized === 'false') {
 			// We query the finalized head to know where the latest finalized block
 			// is. It is a way to confirm whether the queried block is less than or greater
-			// than the finalized head. 
+			// than the finalized head.
 			omitFinalizedTag = false;
 			queryFinalizedHead = true;
 			hash = (await this.api.rpc.chain.getHeader()).hash;


### PR DESCRIPTION
This fixes the default behavior for querying the finalized head. The query param and its expected behavior still works. The only issue is the `/blocks/head` endpoint is not returning the finalized head by default, which means you have to tag the finalized param onto the query. This fixes the slight bug introduced in this PR [#615](https://github.com/paritytech/substrate-api-sidecar/pull/615).