### PR TITLE
fix: remove polkadot config for paras controller

### DIFF
--- a/src/chains-config/polkadotControllers.ts
+++ b/src/chains-config/polkadotControllers.ts
@@ -17,7 +17,6 @@ export const polkadotControllers: ControllerConfig = {
 		'NodeVersion',
 		'PalletsStakingProgress',
 		'PalletsStorage',
-		'Paras',
 		'RuntimeCode',
 		'RuntimeMetadata',
 		'RuntimeSpec',


### PR DESCRIPTION
closes: [#640](https://github.com/paritytech/substrate-api-sidecar/issues/640)

Remove `Paras` controller from the polkadot chains-config until it's time to start testing parachains against polkadot before it's launched. I think this will cause less confusion for others, and is the most straight forward way to address the issue of anyone trying to use the endpoint. 