### PR TITLE
fix: historical queries for account balances

### DIFF
--- a/src/services/accounts/AccountsBalanceInfoService.spec.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/require-await */
 import { AccountInfo, Address, Hash } from '@polkadot/types/interfaces';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
@@ -19,24 +20,13 @@ const accountsBalanceInfoService = new AccountsBalanceInfoService(mockApi);
 const historicalMockApi = {
 	query: {
 		balances: {
-			freeBalance: () =>
-				Promise.resolve().then(() => {
-					return polkadotRegistry.createType('Balance', 123456789);
-				}),
-			reservedBalance: () =>
-				Promise.resolve().then(() => {
-					return polkadotRegistry.createType('Balance', 1);
-				}),
-			locks: () =>
-				Promise.resolve().then(() => {
-					return polkadotRegistry.createType('Vec<BalanceLock>', []);
-				}),
+			freeBalance: async () =>
+				polkadotRegistry.createType('Balance', 123456789),
+			reservedBalance: async () => polkadotRegistry.createType('Balance', 1),
+			locks: async () => polkadotRegistry.createType('Vec<BalanceLock>', []),
 		},
 		system: {
-			accountNonce: () =>
-				Promise.resolve().then(() => {
-					return polkadotRegistry.createType('Index', 1);
-				}),
+			accountNonce: async () => polkadotRegistry.createType('Index', 1),
 		},
 	},
 };
@@ -171,10 +161,8 @@ describe('AccountsBalanceInfoService', () => {
 
 				expect(sanitizeNumbers(result)).toStrictEqual(expectedResponse);
 
-				mockApi.at = () =>
-					Promise.resolve().then(() => {
-						return createApiWithAugmentations(polkadotMetadata.toHex());
-					});
+				mockApi.at = async () =>
+					createApiWithAugmentations(polkadotMetadata.toHex());
 			});
 		});
 	});

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -28,16 +28,16 @@ export class AccountsBalanceInfoService extends AbstractService {
 		const { api } = this;
 
 		// Retrieve the api for the given hash
-		const a = await api.at(hash);
+		const historicalApi = await api.at(hash);
 
 		// Check if this is a historical block that needs a seperate api
-		if (a.query.balances.freeBalance) {
+		if (historicalApi.query.balances.freeBalance) {
 			const [header, free, locks, reserved, nonce] = await Promise.all([
 				api.rpc.chain.getHeader(hash),
-				a.query.balances.freeBalance(address) as Promise<Balance>,
-				a.query.balances.locks(address),
-				a.query.balances.reservedBalance(address) as Promise<Balance>,
-				a.query.system.accountNonce(address) as Promise<Index>,
+				historicalApi.query.balances.freeBalance(address) as Promise<Balance>,
+				historicalApi.query.balances.locks(address),
+				historicalApi.query.balances.reservedBalance(address) as Promise<Balance>,
+				historicalApi.query.system.accountNonce(address) as Promise<Index>,
 			]);
 
 			// Values dont exist for these historic runtimes

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -60,7 +60,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				height: header.number.toNumber().toString(10),
 			};
 
-			if (locks && free && reserved && nonce) {
+			if (free) {
 				return {
 					at,
 					nonce,

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -43,24 +43,28 @@ export class AccountsBalanceInfoService extends AbstractService {
 			]);
 
 			// Values dont exist for these historic runtimes
-			const miscFrozen = 0 as unknown as Balance,
-				feeFrozen = 0 as unknown as Balance;
+			const miscFrozen = api.registry.createType('Balance', 0),
+				feeFrozen = api.registry.createType('Balance', 0);
 
 			const at = {
 				hash,
 				height: header.number.toNumber().toString(10),
 			};
 
-			return {
-				at,
-				nonce,
-				tokenSymbol: token,
-				free,
-				reserved,
-				miscFrozen,
-				feeFrozen,
-				locks,
-			};
+			if (locks && free && reserved && nonce) {
+				return {
+					at,
+					nonce,
+					tokenSymbol: token,
+					free,
+					reserved,
+					miscFrozen,
+					feeFrozen,
+					locks,
+				};
+			} else {
+				throw new BadRequest('Account not found');
+			}
 		}
 
 		let locks, header, accountInfo, accountData;

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -36,7 +36,9 @@ export class AccountsBalanceInfoService extends AbstractService {
 				api.rpc.chain.getHeader(hash),
 				historicalApi.query.balances.freeBalance(address) as Promise<Balance>,
 				historicalApi.query.balances.locks(address),
-				historicalApi.query.balances.reservedBalance(address) as Promise<Balance>,
+				historicalApi.query.balances.reservedBalance(
+					address
+				) as Promise<Balance>,
 				historicalApi.query.system.accountNonce(address) as Promise<Index>,
 			]);
 

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -74,9 +74,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 			} else {
 				throw new BadRequest('Account not found');
 			}
-		} else if (
-			!Object.keys(historicalApi.query.system.account).includes('at')
-		) {
+		} else if (!historicalApi.query.system.account.at) {
 			const [header, accountInfo, locks] = await Promise.all([
 				api.rpc.chain.getHeader(hash),
 				historicalApi.query.system.account(address),

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -654,11 +654,17 @@ const assetApprovals = () =>
 		return rococoRegistry.createType('Option<AssetApproval>', assetObj);
 	});
 
+const apiAt = () =>
+	Promise.resolve().then(() => {
+		return createApiWithAugmentations(polkadotMetadata.toHex());
+	});
+
 /**
  * Mock polkadot-js ApiPromise. Values are largely meant to be accurate for block
  * #789629, which is what most Service unit tests are based on.
  */
 export const mockApi = {
+	at: apiAt,
 	runtimeVersion,
 	createType: polkadotRegistry.createType.bind(polkadotRegistry),
 	registry: polkadotRegistry,


### PR DESCRIPTION
closes: [#634](https://github.com/paritytech/substrate-api-sidecar/issues/634)

This fixes historical queries for `/accounts/{accountId}/balance-info`.