### PR TITLE
fix: workflows for wasm-pack

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Install wasm-pack
       uses: jetli/wasm-pack-action@v0.3.0
+      with:
+        version: v0.10.0
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Install wasm-pack
       uses: jetli/wasm-pack-action@v0.3.0
+      with:
+        version: v0.10.0
     - uses: actions/checkout@v2
     - name: Lint
       run: |
@@ -25,6 +27,8 @@ jobs:
     steps:
     - name: Install wasm-pack
       uses: jetli/wasm-pack-action@v0.3.0
+      with:
+        version: v0.10.0
     - uses: actions/checkout@v2
     - name: Test
       run: |


### PR DESCRIPTION
The latest version of wasm-pack v0.10.1 is causing a break in the CI due to file paths, so I set the version to 0.10.0 which resolves our issue. 