### PR TITLE
fix: update versioning in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ All the commits in this repo follow the [Conventional Commits spec](https://www.
 
 1. Update the version in the package.json (this is very important for releasing on NPM).
 
+1. Update the substrate-api-sidecar version in the docs by going into `docs/src/openapi-v1.yaml`, and changing the `version` field under `info` to the releases respected version. Then run `yarn build:docs`. 
+
 1. Update `CHANGELOG.md` by looking at merged PRs since the last release. Follow the format of previous releases. Only record dep updates if they reflect type definition updates as those affect the users API.
 
     Make sure to note if it is a high upgrade priority (e.g. it has type definitions for an upcoming runtime upgrade to a Parity maintained network).

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: GPL-3.0-or-later
     url: https://github.com/paritytech/substrate-api-sidecar/blob/master/LICENSE
-  version: 1.0.0-oas3
+  version: 9.1.9
 tags:
 - name: accounts
 - name: blocks


### PR DESCRIPTION
closes: [#670](https://github.com/paritytech/substrate-api-sidecar/issues/670)

Updates the version of substrate-api-sidecar inside of the docs, and also updates the release notes to update the docs.