### PR TITLE
fix: update the readme for the open api docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
 # Sidecar OpenApi UI
 
-Proposed OpenApi spec for [substrate-api-sidecar](https://github.com/paritytech/substrate-api-sidecar) v1.
+OpenApi spec for [substrate-api-sidecar](https://github.com/paritytech/substrate-api-sidecar).
+
+## Contributing:
+
+After updating the docs, ensure to run `yarn build:docs` from the root directory of this repository.
+
+This will make sure that the `dist` is updated with the current changes. Please verify the changes made work with an editor such as [swagger](https://editor.swagger.io/) by copying the `src/openapi-v1.yaml` file and pasting into the editor. 


### PR DESCRIPTION
closes: [#669](https://github.com/paritytech/substrate-api-sidecar/issues/669)

This updates the readme for the open api docs. 

