### PR TITLE
ci: build docs test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,3 +30,20 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn
     - run: yarn build
+  
+  build-docs:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn
+    - run: yarn build:docs


### PR DESCRIPTION
closes: [#673](https://github.com/paritytech/substrate-api-sidecar/issues/673)

Adds a CI test to build the docs to make sure there is no error. 

- [X] Add a test to build the docs 