### PR TITLE
ci: npm release check

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -62,6 +62,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Initialize test release
     - run: yarn test:test-release
     

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,12 +49,11 @@ jobs:
     - run: yarn build:docs
 
   build-npm-release:
-    - description: | 
-      This test is to make sure sidecar can release a binary without any errors.
-      This script does not publish a release, but instead uses yarn to create a tarball and 
-      install it locally. Once installed a binary is attached to sidecars node_modules, and that 
-      binary is then tested against. For more in depth information reference the docs at 
-      `../../scripts/README.md`.
+      # This test is to make sure sidecar can release a binary without any errors.
+      # This script does not publish a release, but instead uses yarn to create a tarball and 
+      # install it locally. Once installed a binary is attached to sidecars node_modules, and that 
+      # binary is then tested against. For more in depth information reference the docs at 
+      # `../../scripts/README.md`.
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,3 +47,21 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn
     - run: yarn build:docs
+
+  build-npm-release:
+
+    runs-on: ubuntu-latest
+
+    strategy: 
+      matrix:
+        node-version: [14.x]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Initialize test release
+    - run: yarn test:test-release
+    

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,6 +49,12 @@ jobs:
     - run: yarn build:docs
 
   build-npm-release:
+    - description: | 
+      This test is to make sure sidecar can release a binary without any errors.
+      This script does not publish a release, but instead uses yarn to create a tarball and 
+      install it locally. Once installed a binary is attached to sidecars node_modules, and that 
+      binary is then tested against. For more in depth information reference the docs at 
+      `../../scripts/README.md`.
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -62,5 +62,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: yarn
     - run: yarn test:test-release
     

--- a/package.json
+++ b/package.json
@@ -45,8 +45,10 @@
     "test:init-e2e-tests:kusama": "yarn start:e2e-scripts --chain kusama",
     "test:init-e2e-tests:westend": "yarn start:e2e-scripts --chain westend",
     "start:e2e-scripts": "yarn build:scripts && node scripts/build/runChainTests.js",
-    "build:scripts": "cd scripts && substrate-exec-tsc",
-    "lint:scripts": "cd scripts && substrate-dev-run-lint"
+    "build:scripts": "substrate-exec-rimraf scripts/build/ && cd scripts && substrate-exec-tsc",
+    "lint:scripts": "cd scripts && substrate-dev-run-lint",
+    "start:test-release": "yarn build:scripts && node scripts/build/runYarnPack.js",
+    "test:test-release": "yarn start:test-release"
   },
   "dependencies": {
     "@polkadot/api": "^6.0.5",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,4 +19,18 @@ a collection of different blocks, across different runtimes. It does this for Po
 
 ### Summary
 
-This scripts purpose is to do a dry-run npm release, and check if sidecar builds correctly. It uses `yarn pack` in order to create a tarball. That tarball is then used to create a binary inside of the repo, and that binary is then run. After the test the dependency tree is cleaned and the tarball deleted.
+This script's purpose is to do a dry-run npm release, and check if sidecar builds correctly. It uses `yarn pack` in order to create a tarball called `package.tgz` inside of our root directory. This tarball is a copy of what our release would be within the npm registry. We target that tarball using `yarn add ${__dirname}<path_to_file>/package.tgz` and add it as a dependency. Yarn will read the package.json of sidecar, and publish it as `@substrate/api-sidecar`. Once sidecar is fully installed a binary will be attached in `./node_modules/.bin/substrate-api-sidecar`, we then run that binary to check for any issues. After the test the dependency tree is cleaned and the tarball deleted.
+
+In order to start this script locally, run from the root directory of this repository:
+
+```bash
+$ yarn 
+$ yarn test:test-release
+```
+
+If the cleanup has any issues, you may run from the root directory of this repository:
+
+```bash
+$ yarn remove @substrate/api-sidecar
+$ rm -rf ./package.tgz
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,3 +13,10 @@
 
 This script calls the local e2e-tests helper library in order to test the current branch or development environment against
 a collection of different blocks, across different runtimes. It does this for Polkadot, Kusama, and Westend.
+
+
+## Script `runYarnPack.ts`
+
+### Summary
+
+This scripts purpose is to do a dry-run npm release, and check if sidecar builds correctly. It uses `yarn pack` in order to create a tarball. That tarball is then used to create a binary inside of the repo, and that binary is then run. After the test the dependency tree is cleaned and the tarball deleted.

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -1,21 +1,27 @@
 import { IChainConfig } from './types';
 
-const defaultSasStartOpts = {
+const defaultJestOpts = {
+	proc: 'jest',
+	resolver: 'PASS',
+};
+
+export const defaultSasStartOpts = {
 	proc: 'sidecar',
 	resolver: 'Check the root endpoint',
 	resolverStartupErr: 'error: uncaughtException: listen EADDRINUSE:',
 	args: ['start'],
 };
 
-const defaultJestOpts = {
-	proc: 'jest',
-	resolver: 'PASS',
-};
-
 export const defaultSasBuildOpts = {
 	proc: 'sidecar',
 	resolver: 'Build Finished',
 	args: ['build'],
+};
+
+export const defaultSasPackOpts = {
+	proc: 'sidecar-pack',
+	resolver: 'YN0000: Done in',
+	args: ['pack'],
 };
 
 export const config: Record<string, IChainConfig> = {

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -22,7 +22,8 @@ const cleanup = async () => {
 	const sidecarUnInstallPack = await launchProcess('yarn', procs, sasUnInstallPackOpts);
 
 	if (sidecarUnInstallPack === Failed) {
-		console.error('UnInstalling sidecar package failed');
+		console.error('UnInstalling sidecar package failed..');
+		console.error('Please uninstall the package using `yarn remove @substrate/api-sidecar`.');
 		killAll(procs);
 	}
 
@@ -38,13 +39,14 @@ const cleanup = async () => {
     const deleteTarball = await launchProcess('rm', procs, sasDeleteTarballOpts);
 
 	if (deleteTarball === Failed) {
-		console.error('Error deleting tarball');
+		console.error('Error deleting tarball.');
+		console.error('In order to delete tarball run: `rm -rf ./package.tgz` from the root directory of the repository.');
 		killAll(procs);
 	}
 };
 
 /**
- * This scripts focus is to create a dry-run npm release and check if sidecar
+ * This script creates a dry-run npm release and checks if sidecar
  * launches succesfully.
  */
 const main = async () => {

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -99,7 +99,7 @@ const main = async () => {
 	const sasStartPackOpts = {
 		proc: 'sidecar',
 		resolver: 'Check the root endpoint',
-		resolverStartupErr: 'error: uncaughtException: listen EADDRINUSE:',
+		resolverStartupErr: 'Error',
 		args: [],
 	};
 	const sidecarStart = await launchProcess(

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -1,5 +1,5 @@
 import { defaultSasBuildOpts, defaultSasPackOpts } from './config';
-import { killAll, launchProcess } from './sidecarScriptApi';
+import { killAll, launchProcess, setWsUrl } from './sidecarScriptApi';
 import { ProcsType, StatusCode } from './types';
 
 const procs: ProcsType = {};
@@ -94,6 +94,7 @@ const main = async () => {
 	/**
 	 * Start sidecar and see if it works
 	 */
+    setWsUrl('wss://kusama-rpc.polkadot.io');
 	console.log('Initializing Sidecar');
 	const sasStartPackOpts = {
 		proc: 'sidecar',

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -19,7 +19,7 @@ const cleanup = async () => {
 		resolver: 'YN0000: Done',
 		args: ['remove', '@substrate/api-sidecar'],
 	};
-	const sidecarUnInstallPack = await launchProcess(sasUnInstallPackOpts, procs);
+	const sidecarUnInstallPack = await launchProcess('yarn', procs, sasUnInstallPackOpts);
 
 	if (sidecarUnInstallPack === Failed) {
 		console.error('UnInstalling sidecar package failed');
@@ -35,7 +35,7 @@ const cleanup = async () => {
 		resolver: '',
 		args: ['-rf', `${__dirname}/../../package.tgz`],
 	};
-	const deleteTarball = await launchProcess(sasDeleteTarballOpts, procs, 'rm');
+    const deleteTarball = await launchProcess('rm', procs, sasDeleteTarballOpts);
 
 	if (deleteTarball === Failed) {
 		console.error('Error deleting tarball');
@@ -54,7 +54,7 @@ const main = async () => {
 	 * Build sidecar
 	 */
 	console.log('Building Sidecar');
-	const sidecarBuild = await launchProcess(defaultSasBuildOpts, procs);
+	const sidecarBuild = await launchProcess('yarn', procs, defaultSasBuildOpts);
 
 	if (sidecarBuild === Failed) {
 		console.error('Sidecar failed to build, exiting...');
@@ -66,7 +66,7 @@ const main = async () => {
 	 * Build Tarball via yarn pack
 	 */
 	console.log('Building Local Npm release of Sidecar.');
-	const sidecarPack = await launchProcess(defaultSasPackOpts, procs);
+	const sidecarPack = await launchProcess('yarn', procs, defaultSasPackOpts);
 
 	if (sidecarPack === Failed) {
 		console.error('Sidecar failed to build an local npm tarball.');
@@ -83,7 +83,7 @@ const main = async () => {
 		resolver: 'YN0000: Done',
 		args: ['add', `${__dirname}/../../package.tgz`],
 	};
-	const sidecarInstallPack = await launchProcess(sasInstallPackOpts, procs);
+	const sidecarInstallPack = await launchProcess('yarn', procs, sasInstallPackOpts);
 
 	if (sidecarInstallPack === Failed) {
 		console.error('Installing the binary failed..');
@@ -103,9 +103,9 @@ const main = async () => {
 		args: [],
 	};
 	const sidecarStart = await launchProcess(
-		sasStartPackOpts,
+		`${__dirname}/../../node_modules/.bin/substrate-api-sidecar`,
 		procs,
-		`${__dirname}/../../node_modules/.bin/substrate-api-sidecar`
+        sasStartPackOpts
 	);
 
 	if (sidecarStart === Success) {

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -121,4 +121,22 @@ const main = async () => {
 	}
 };
 
+/**
+ * Signal interrupt
+ */
+process.on('SIGINT', function () {
+    console.log('Caught interrupt signal');
+    killAll(procs);
+    process.exit();
+});
+
+/**
+ * Signal hangup terminal
+ */
+process.on('SIGHUP', function () {
+    console.log('Caught terminal termination');
+    killAll(procs);
+    process.exit();
+});
+
 main().finally(() => process.exit());

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -1,0 +1,123 @@
+import { defaultSasBuildOpts, defaultSasPackOpts } from './config';
+import { killAll, launchProcess } from './sidecarScriptApi';
+import { ProcsType, StatusCode } from './types';
+
+const procs: ProcsType = {};
+
+/**
+ * Cleans up the remaining deps and files that should be temps
+ */
+const cleanup = async () => {
+	const { Failed } = StatusCode;
+
+	/**
+	 * Cleanup dep tree
+	 */
+	console.log('Uninstalling Sidecar..');
+	const sasUnInstallPackOpts = {
+		proc: 'sidecar-install-pack',
+		resolver: 'YN0000: Done',
+		args: ['remove', '@substrate/api-sidecar'],
+	};
+	const sidecarUnInstallPack = await launchProcess(sasUnInstallPackOpts, procs);
+
+	if (sidecarUnInstallPack === Failed) {
+		console.error('UnInstalling sidecar package failed');
+		killAll(procs);
+	}
+
+	/**
+	 * Delete tarball
+	 */
+	console.log('Deleting Tarball');
+	const sasDeleteTarballOpts = {
+		proc: 'delete-tarball',
+		resolver: '',
+		args: ['-rf', `${__dirname}/../../package.tgz`],
+	};
+	const deleteTarball = await launchProcess(sasDeleteTarballOpts, procs, 'rm');
+
+	if (deleteTarball === Failed) {
+		console.error('Error deleting tarball');
+		killAll(procs);
+	}
+};
+
+/**
+ * This scripts focus is to create a dry-run npm release and check if sidecar
+ * launches succesfully.
+ */
+const main = async () => {
+	const { Failed, Success } = StatusCode;
+
+	/**
+	 * Build sidecar
+	 */
+	console.log('Building Sidecar');
+	const sidecarBuild = await launchProcess(defaultSasBuildOpts, procs);
+
+	if (sidecarBuild === Failed) {
+		console.error('Sidecar failed to build, exiting...');
+		killAll(procs);
+		process.exit(1);
+	}
+
+	/**
+	 * Build Tarball via yarn pack
+	 */
+	console.log('Building Local Npm release of Sidecar.');
+	const sidecarPack = await launchProcess(defaultSasPackOpts, procs);
+
+	if (sidecarPack === Failed) {
+		console.error('Sidecar failed to build an local npm tarball.');
+		killAll(procs);
+		process.exit(1);
+	}
+
+	/**
+	 * Install tarball
+	 */
+	console.log('Installing Sidecar as a package');
+	const sasInstallPackOpts = {
+		proc: 'sidecar-install-pack',
+		resolver: 'YN0000: Done',
+		args: ['add', `${__dirname}/../../package.tgz`],
+	};
+	const sidecarInstallPack = await launchProcess(sasInstallPackOpts, procs);
+
+	if (sidecarInstallPack === Failed) {
+		console.error('Installing the binary failed..');
+		killAll(procs);
+		process.exit(1);
+	}
+
+	/**
+	 * Start sidecar and see if it works
+	 */
+	console.log('Initializing Sidecar');
+	const sasStartPackOpts = {
+		proc: 'sidecar',
+		resolver: 'Check the root endpoint',
+		resolverStartupErr: 'error: uncaughtException: listen EADDRINUSE:',
+		args: [],
+	};
+	const sidecarStart = await launchProcess(
+		sasStartPackOpts,
+		procs,
+		`${__dirname}/../../node_modules/.bin/substrate-api-sidecar`
+	);
+
+	if (sidecarStart === Success) {
+		console.log('Successful Release Build of Sidecar');
+		killAll(procs);
+		await cleanup();
+		process.exit(0);
+	} else {
+		console.error('Release Build failed for Sidecar');
+		killAll(procs);
+		await cleanup();
+		process.exit(1);
+	}
+};
+
+main().finally(() => process.exit());

--- a/scripts/runYarnPack.ts
+++ b/scripts/runYarnPack.ts
@@ -29,7 +29,7 @@ const cleanup = async () => {
 	/**
 	 * Delete tarball
 	 */
-	console.log('Deleting Tarball');
+	console.log('Deleting tarball');
 	const sasDeleteTarballOpts = {
 		proc: 'delete-tarball',
 		resolver: '',

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -2,6 +2,10 @@ import { spawn } from 'child_process';
 
 import { IProcOpts, ProcsType, StatusCode } from './types';
 
+export const setWsUrl = (url: string): void => {
+    process.env.SAS_SUBSTRATE_WS_URL = url;
+};
+
 /**
  * Kill all processes
  *

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -2,6 +2,11 @@ import { spawn } from 'child_process';
 
 import { IProcOpts, ProcsType, StatusCode } from './types';
 
+/**
+ * Sets the url that sidecar will use in the env
+ * 
+ * @param url ws url used in sidecar
+ */
 export const setWsUrl = (url: string): void => {
     process.env.SAS_SUBSTRATE_WS_URL = url;
 };
@@ -48,6 +53,8 @@ export const killAll = (procs: ProcsType): void => {
  * }
  *
  * @param IProcOpts
+ * @param procs Object of saved processes 
+ * @param cmd Optional Command will default to 'yarn'
  */
 export const launchProcess = (
 	{ proc, resolver, resolverStartupErr, args }: IProcOpts,

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -45,21 +45,20 @@ export const killAll = (procs: ProcsType): void => {
 /**
  * Launch any given process. It accepts an options object.
  *
+ * @param cmd Optional Command will default to 'yarn'
+ * @param procs Object of saved processes 
+ * @param IProcOpts
  * {
  *   proc => the name of the process to be saved in our cache
  *   resolver => If the stdout contains the resolver it will resolve the process
  *   resolverStartupErr => If the stderr contains the resolver it will resolve the process
  *   args => an array of args to be attached to the `yarn` command.
  * }
- *
- * @param IProcOpts
- * @param procs Object of saved processes 
- * @param cmd Optional Command will default to 'yarn'
  */
 export const launchProcess = (
-	{ proc, resolver, resolverStartupErr, args }: IProcOpts,
+	cmd: string = 'yarn',
 	procs: ProcsType,
-	cmd?: string
+	{ proc, resolver, resolverStartupErr, args }: IProcOpts,
 ): Promise<StatusCode> => {
 	return new Promise<StatusCode>((resolve, reject) => {
 		const { Success, Failed } = StatusCode;
@@ -69,7 +68,7 @@ export const launchProcess = (
 		procs[proc] = spawn(command, args, { detached: true });
 
 		procs[proc].stdout.on('data', (data: Buffer) => {
-			console.log(data.toString());
+			console.log(data.toString().trim());
 
 			if (data.toString().includes(resolver)) {
 				resolve(Success);
@@ -77,7 +76,7 @@ export const launchProcess = (
 		});
 
 		procs[proc].stderr.on('data', (data: Buffer) => {
-			console.error(data.toString());
+			console.error(data.toString().trim());
 
 			if (resolverStartupErr && data.toString().includes(resolverStartupErr)) {
 				resolve(Failed);

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -1,0 +1,85 @@
+import { spawn } from 'child_process';
+
+import { IProcOpts, ProcsType, StatusCode } from './types';
+
+/**
+ * Kill all processes
+ *
+ * @param procs
+ */
+export const killAll = (procs: ProcsType): void => {
+	console.log('Killing all processes...');
+	for (const key of Object.keys(procs)) {
+		if (!procs[key].killed) {
+			try {
+				console.log(`Killing ${key}`);
+				// Kill child and all its descendants.
+				process.kill(-procs[key].pid, 'SIGTERM');
+				process.kill(-procs[key].pid, 'SIGKILL');
+			} catch (e) {
+				/**
+				 * The error we are catching here silently, is when `-procs[key].pid` takes
+				 * the range of all pid's inside of the subprocess group created with
+				 * `spawn`, and one of the process's is either already closed or doesn't exist anymore.
+				 *
+				 * ex: `Error: kill ESRCH`
+				 *
+				 * This is a very specific use case of an empty catch block and is used
+				 * outside of the scope of the API therefore justifiable, and should be used cautiously
+				 * elsewhere.
+				 */
+			}
+		}
+	}
+};
+
+/**
+ * Launch any given process. It accepts an options object.
+ *
+ * {
+ *   proc => the name of the process to be saved in our cache
+ *   resolver => If the stdout contains the resolver it will resolve the process
+ *   resolverStartupErr => If the stderr contains the resolver it will resolve the process
+ *   args => an array of args to be attached to the `yarn` command.
+ * }
+ *
+ * @param IProcOpts
+ */
+export const launchProcess = (
+	{ proc, resolver, resolverStartupErr, args }: IProcOpts,
+	procs: ProcsType,
+	cmd?: string
+): Promise<StatusCode> => {
+	return new Promise<StatusCode>((resolve, reject) => {
+		const { Success, Failed } = StatusCode;
+
+		const command = cmd || 'yarn';
+
+		procs[proc] = spawn(command, args, { detached: true });
+
+		procs[proc].stdout.on('data', (data: Buffer) => {
+			console.log(data.toString());
+
+			if (data.toString().includes(resolver)) {
+				resolve(Success);
+			}
+		});
+
+		procs[proc].stderr.on('data', (data: Buffer) => {
+			console.error(data.toString());
+
+			if (resolverStartupErr && data.toString().includes(resolverStartupErr)) {
+				resolve(Failed);
+			}
+		});
+
+		procs[proc].on('close', () => {
+			resolve(Success);
+		});
+
+		procs[proc].on('error', (err) => {
+			console.log(err);
+			reject(Failed);
+		});
+	});
+};

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -56,7 +56,7 @@ export const killAll = (procs: ProcsType): void => {
  * }
  */
 export const launchProcess = (
-	cmd: string = 'yarn',
+	cmd: string,
 	procs: ProcsType,
 	{ proc, resolver, resolverStartupErr, args }: IProcOpts,
 ): Promise<StatusCode> => {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,3 +1,7 @@
+import { ChildProcessWithoutNullStreams } from 'child_process';
+
+export type ProcsType = { [key: string]: ChildProcessWithoutNullStreams };
+
 export enum StatusCode {
 	Success = '0',
 	Failed = '1',


### PR DESCRIPTION
Replaces: [#682](https://github.com/paritytech/substrate-api-sidecar/pull/682)

This PR is focused on adding a CI test to check if the npm release will work with a dry-run. The CI will run a script in sidecar called `runYarnPack.ts`. This scripts creates a Tarball, which is then used to install sidecar as a dep, the sidecar binary is then called and tested to see if it returns a successful response. After the test is over, it cleans its dep tree, and any additional files that are not native to the repo.

This PR will be followed by a part 2 where the newly abstracted script API will be applied to `runChainTests.ts`. I chose to not refactor that script in this PR in order to keep the PR's organized.