### PR TITLE
helm: increase liveness and rediness probe timeouts

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -45,10 +45,12 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
+            timeoutSeconds: 10
             httpGet:
               path: /
               port: http
           readinessProbe:
+            timeoutSeconds: 10
             httpGet:
               path: /
               port: http


### PR DESCRIPTION
Recently we have received some alerts for substrate-api-sidecar application in production environment.
looking at the events of the container I see:
```
  Warning  Unhealthy  39m                   kubelet  Readiness probe failed: Get "http://10.148.14.9:8080/": read tcp 10.148.14.1:46866->10.148.14.9:8080: read: connection reset by peer
  Normal   Killing    36m (x12 over 33h)    kubelet  Container substrate-api-sidecar failed liveness probe, will be restarted
  Normal   Started    35m (x13 over 4d20h)  kubelet  Started container substrate-api-sidecar
  Normal   Pulled     35m (x12 over 33h)    kubelet  Container image "docker.io/parity/substrate-api-sidecar:v9.1.7" already present on machine
  Normal   Created    35m (x13 over 4d20h)  kubelet  Created container substrate-api-sidecar
  Warning  Unhealthy  30m (x38 over 33h)    kubelet  Liveness probe failed: Get "http://10.148.14.9:8080/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  Warning  Unhealthy  30m (x60 over 33h)    kubelet  Readiness probe failed: Get "http://10.148.14.9:8080/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  ```

and here are the pods:
```
NAME                                READY   STATUS    RESTARTS   AGE
kusama-sidecar-5f77d86d5b-z9knm     1/1     Running   1          4d20h
polkadot-sidecar-7d867d545b-9cl8p   1/1     Running   13         4d20h
```

Kubernetes cannot pass readiness and liveness probes for the polkadot-sidecar container, it is either down those moments or too slow to respond in less than 1 second (default threshold). As a result, the Kubernetes tries to restart the polkadot-sidecar container to bring it up again when the liveness probe fails.
This mr will increase the timeout seconds from 1 to 10 to reduce false-positive alerts. Hope this fixes the issue with those alerts, if not the recent changes of the application should be reviewed to see what could cause temporary downtimes for the container.

P.S: The last deployment on the Kubernetes (based on the age of the pods) was 4days and 20hours ago.
