### PR TITLE
fix(deps): bump polkadot/api, cleanup resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ All the commits in this repo follow the [Conventional Commits spec](https://www.
     - @polkadot/util-crypto [release notes](https://github.com/polkadot-js/common/releases)
     - @substrate/calc [npm release page](https://www.npmjs.com/package/@substrate/calc)
 
-1. Next make sure the resolutions are up to date inside of the `package.json` to match polkadot-js [here](https://github.com/polkadot-js/apps/blob/master/package.json). This is a manual process, and the packages we want to update are only the ones with `@polkadot` appended to it. If any issues may surface, contact the maintainers. 
+1. Next make sure the resolutions are up to date inside of the `package.json` for all `@polkadot/*` packages, please refer to the releases of each polkadot package we update as a dependency, and reach out to the maintainers for any questions. 
 
 1. After updating the dependencies and resolutions (if applicable), the next step is making sure the release will work against all relevant runtimes for Polkadot, Kusama, and Westend. This can be handled by running `yarn test:init-e2e-tests`. If you would like to test on an individual chain, you may run the same command followed by its chain, ex: `yarn test:init-e2e-tests:polkadot`. Before moving forward ensure all tests pass, and if it warns of any missing types feel free to make an issue [here](https://github.com/paritytech/substrate-api-sidecar/issues).
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:test-release": "yarn start:test-release"
   },
   "dependencies": {
-    "@polkadot/api": "^6.0.5",
+    "@polkadot/api": "^6.1.2",
     "@polkadot/apps-config": "0.96.2-27",
     "@polkadot/util-crypto": "^7.4.1",
     "@polkadot/x-rxjs": "^6.11.1",
@@ -77,15 +77,11 @@
     "tsc-watch": "^4.4.0"
   },
   "resolutions": {
-    "@polkadot/api": "^6.0.5",
-    "@polkadot/api-contract": "^6.0.5",
-    "@polkadot/hw-ledger": "^7.4.1",
+    "@polkadot/api": "^6.1.2",
     "@polkadot/keyring": "^7.4.1",
     "@polkadot/networks": "^7.4.1",
-    "@polkadot/phishing": "^0.6.286",
-    "@polkadot/types": "^6.0.5",
-    "@polkadot/types-known": "^6.0.5",
-    "@polkadot/types-support": "^6.0.5",
+    "@polkadot/types": "^6.1.2",
+    "@polkadot/types-known": "^6.1.2",
     "@polkadot/util": "^7.4.1",
     "@polkadot/util-crypto": "^7.4.1",
     "@polkadot/wasm-crypto": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,37 +905,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:6.0.5":
-  version: 6.0.5
-  resolution: "@polkadot/api-derive@npm:6.0.5"
+"@polkadot/api-derive@npm:6.1.2":
+  version: 6.1.2
+  resolution: "@polkadot/api-derive@npm:6.1.2"
   dependencies:
     "@babel/runtime": ^7.15.4
-    "@polkadot/api": 6.0.5
-    "@polkadot/rpc-core": 6.0.5
-    "@polkadot/types": 6.0.5
+    "@polkadot/api": 6.1.2
+    "@polkadot/rpc-core": 6.1.2
+    "@polkadot/types": 6.1.2
     "@polkadot/util": ^7.4.1
     "@polkadot/util-crypto": ^7.4.1
     rxjs: ^7.3.0
-  checksum: 8a80c6f4b1e3af26926895c349c9da213cdaa5329cc85bd50fb6d36d9ff9960700ebd52864700bfbc812cabdfec497a2727dd77196aba900d1bdc2563073a47d
+  checksum: bdf9735c71761fad8090b2e3a3bf773ec38420d832a5955d5b545d7ed7c8bbefa5b2ab0825daa61581ad1af5d5da6bf50f0fbda9a1d56df278d0c69f23f2e220
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "@polkadot/api@npm:6.0.5"
+"@polkadot/api@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@polkadot/api@npm:6.1.2"
   dependencies:
     "@babel/runtime": ^7.15.4
-    "@polkadot/api-derive": 6.0.5
+    "@polkadot/api-derive": 6.1.2
     "@polkadot/keyring": ^7.4.1
-    "@polkadot/rpc-core": 6.0.5
-    "@polkadot/rpc-provider": 6.0.5
-    "@polkadot/types": 6.0.5
-    "@polkadot/types-known": 6.0.5
+    "@polkadot/rpc-core": 6.1.2
+    "@polkadot/rpc-provider": 6.1.2
+    "@polkadot/types": 6.1.2
+    "@polkadot/types-known": 6.1.2
     "@polkadot/util": ^7.4.1
     "@polkadot/util-crypto": ^7.4.1
     eventemitter3: ^4.0.7
     rxjs: ^7.3.0
-  checksum: a3e4c4b6793c95e959c8f9ccebf19a3c1a2c9dedccbbcbe69986e47286d5a7dcd14344746d7bcd8a63a1b4a484b3979a0a32f122f6fc5d5fe518c4edc73edfdd
+  checksum: a81c5ba93f547d983f8d99c8daee48f9104ea878e6bb8d46a1b2782ecb8ee1c3448983a98cce716fe9408921f25f2276887fa44976341c8a5260621fe8a33c12
   languageName: node
   linkType: hard
 
@@ -995,56 +995,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:6.0.5":
-  version: 6.0.5
-  resolution: "@polkadot/rpc-core@npm:6.0.5"
+"@polkadot/rpc-core@npm:6.1.2":
+  version: 6.1.2
+  resolution: "@polkadot/rpc-core@npm:6.1.2"
   dependencies:
     "@babel/runtime": ^7.15.4
-    "@polkadot/rpc-provider": 6.0.5
-    "@polkadot/types": 6.0.5
+    "@polkadot/rpc-provider": 6.1.2
+    "@polkadot/types": 6.1.2
     "@polkadot/util": ^7.4.1
     rxjs: ^7.3.0
-  checksum: 089944be094f7f0047405150836ba67cdd52bfd0f43784c4769c3a2cc36cd3a0e4d6074273a2b6ca026d3d41841fb0d0b33576c607fbc76f561fc1daa5c50295
+  checksum: 66d67f1a216c8cbd828bc24a8dc82f8881c97d91b5542c80493d1ff79b1a00f220e5f7502428d82fc4577b22635eee1b23bc50c342f7b61f8cbaae43f078d93d
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:6.0.5":
-  version: 6.0.5
-  resolution: "@polkadot/rpc-provider@npm:6.0.5"
+"@polkadot/rpc-provider@npm:6.1.2":
+  version: 6.1.2
+  resolution: "@polkadot/rpc-provider@npm:6.1.2"
   dependencies:
     "@babel/runtime": ^7.15.4
-    "@polkadot/types": 6.0.5
+    "@polkadot/types": 6.1.2
     "@polkadot/util": ^7.4.1
     "@polkadot/util-crypto": ^7.4.1
     "@polkadot/x-fetch": ^7.4.1
     "@polkadot/x-global": ^7.4.1
     "@polkadot/x-ws": ^7.4.1
     eventemitter3: ^4.0.7
-  checksum: 7452ecee13e36daeee18f854357a1031bd9f8842d4a581d205637c9a5688c44554c36c8c8f7240e29ce7a32564454621552e7826b54a98c6d6f3329ab84eca06
+  checksum: 9a08226a2c12edda78970a7bb5c2f111bae8374de65e9df4269a2b2f4baf1bb9cc739fa9152797ab1323c1f70217cab61351abc2f0c3ebe3235b06f3ba81935b
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "@polkadot/types-known@npm:6.0.5"
+"@polkadot/types-known@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@polkadot/types-known@npm:6.1.2"
   dependencies:
     "@babel/runtime": ^7.15.4
     "@polkadot/networks": ^7.4.1
-    "@polkadot/types": 6.0.5
+    "@polkadot/types": 6.1.2
     "@polkadot/util": ^7.4.1
-  checksum: 28156ce62ad08f69e6c33d7fe6e752f87dbfa0060bb386b22abfefee4b689e3a1ff75717c7318fca58fdfc54f911d699c794dd75ffccd27904d4bf7426f6e7ff
+  checksum: d5ccf31431ce4a278b5a07d7f9352c836b80046109ae66417fe208c1e6d0a53944ae8708abceb1e8ab98c7d7d7cd2a8adc67905b46cd055ea760e402e682a4ba
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:^6.0.5":
-  version: 6.0.5
-  resolution: "@polkadot/types@npm:6.0.5"
+"@polkadot/types@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@polkadot/types@npm:6.1.2"
   dependencies:
     "@babel/runtime": ^7.15.4
     "@polkadot/util": ^7.4.1
     "@polkadot/util-crypto": ^7.4.1
     rxjs: ^7.3.0
-  checksum: 250055879043ad5586bccd7dd3300550ef22b05ffe9c6a0e558bcbad04759097bce70668640881a3f734a4aa9d33115dcd6b46a193f48618d289ae64169b420b
+  checksum: 347578185768ba239d3c3890ee51d28a9a0fdc483b2f992ae1b30271a0f029bb3ae3257e867c8c81307241a7d670b99d909ad72ac2e057fa6a71b9f097a87c13
   languageName: node
   linkType: hard
 
@@ -1296,7 +1296,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^6.0.5
+    "@polkadot/api": ^6.1.2
     "@polkadot/apps-config": 0.96.2-27
     "@polkadot/util-crypto": ^7.4.1
     "@polkadot/x-rxjs": ^6.11.1


### PR DESCRIPTION
This PR cleans up the resolutions and bumps `@polkadot/api` to v6.1.2