### PR TITLE
fix: expandMetadata for historic runtimes

### DIFF
--- a/src/chains-config/metadata-consts/kusamaConsts.ts
+++ b/src/chains-config/metadata-consts/kusamaConsts.ts
@@ -10,7 +10,10 @@ export const kusamaDefinitions: MetadataConsts[] = [
 		extrinsicBaseWeight,
 	},
 	{
-		runtimeVersions: [2027, 2028, 2029, 2030, 9010, 9030, 9040, 9050, 9070],
+		runtimeVersions: [
+			2027, 2028, 2029, 2030, 9000, 9010, 9030, 9040, 9050, 9070, 9080, 9090,
+			9100,
+		],
 		perClass,
 	},
 ];

--- a/src/chains-config/metadata-consts/polkadotConsts.ts
+++ b/src/chains-config/metadata-consts/polkadotConsts.ts
@@ -9,7 +9,9 @@ export const polkadotDefinitions: MetadataConsts[] = [
 		extrinsicBaseWeight,
 	},
 	{
-		runtimeVersions: [27, 28, 29, 30, 9050],
+		runtimeVersions: [
+			27, 28, 29, 30, 9000, 9010, 9030, 9033, 9050, 9070, 9080, 9090, 9100,
+		],
 		perClass,
 	},
 ];

--- a/src/chains-config/metadata-consts/westendConsts.ts
+++ b/src/chains-config/metadata-consts/westendConsts.ts
@@ -9,7 +9,9 @@ export const westendDefinitions: MetadataConsts[] = [
 		extrinsicBaseWeight,
 	},
 	{
-		runtimeVersions: [47, 48, 49, 50, 9010, 9030, 9033, 9050, 9070],
+		runtimeVersions: [
+			47, 48, 49, 50, 9000, 9010, 9030, 9033, 9050, 9070, 9080, 9090, 9100,
+		],
 		perClass,
 	},
 ];

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -18,9 +18,11 @@ import {
 	polkadotRegistry,
 	polkadotRegistryV29,
 } from '../../test-helpers/registries';
+import { createApiWithAugmentations } from '../../test-helpers/typeFactory';
 import { ExtBaseWeightValue, PerClassValue } from '../../types/chains-config';
 import { IBlock, IExtrinsic } from '../../types/responses/';
 import {
+	apiAt,
 	blockHash20000,
 	blockHash100000,
 	blockHash789629,
@@ -251,7 +253,13 @@ describe('BlocksService', () => {
 				Promise.resolve().then(() => polkadotMetadataV29);
 			const revertedMetadata = () =>
 				Promise.resolve().then(() => polkadotMetadata);
+			// Set this historic At to the tests current runtime
+			const historicAt = () =>
+				Promise.resolve().then(() =>
+					createApiWithAugmentations(polkadotMetadataV29.toHex())
+				);
 
+			(mockApi.at as unknown) = historicAt;
 			(mockApi.registry as unknown) = polkadotRegistryV29;
 			(mockApi.rpc.state.getMetadata as unknown) = changeMetadataToV29;
 
@@ -269,6 +277,7 @@ describe('BlocksService', () => {
 					.baseExtrinsic
 			).toBe(BigInt(512000000000001));
 
+			(mockApi.at as unknown) = apiAt;
 			(mockApi.registry as unknown) = polkadotRegistry;
 			(mockApi.rpc.state.getMetadata as unknown) = revertedMetadata;
 		});

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -558,7 +558,7 @@ export class BlocksService extends AbstractService {
 		blockHash: BlockHash
 	): Promise<WeightValue> {
 		const metadata = await api.rpc.state.getMetadata(blockHash);
-		const historicApi = await api.at(blockHash);
+		const historicApi = await api.at(blockHash) as ApiPromise;
 		const {
 			consts: { system },
 		} = expandMetadata(historicApi.registry, metadata);

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -558,9 +558,10 @@ export class BlocksService extends AbstractService {
 		blockHash: BlockHash
 	): Promise<WeightValue> {
 		const metadata = await api.rpc.state.getMetadata(blockHash);
+		const historicApi = await api.at(blockHash);
 		const {
 			consts: { system },
-		} = expandMetadata(api.registry, metadata);
+		} = expandMetadata(historicApi.registry, metadata);
 
 		let weightValue;
 		if ((system.blockWeights as unknown as BlockWeights)?.perClass) {

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -558,7 +558,7 @@ export class BlocksService extends AbstractService {
 		blockHash: BlockHash
 	): Promise<WeightValue> {
 		const metadata = await api.rpc.state.getMetadata(blockHash);
-		const historicApi = await api.at(blockHash) as ApiPromise;
+		const historicApi = (await api.at(blockHash)) as ApiPromise;
 		const {
 			consts: { system },
 		} = expandMetadata(historicApi.registry, metadata);

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -655,7 +655,7 @@ const assetApprovals = () =>
 		return rococoRegistry.createType('Option<AssetApproval>', assetObj);
 	});
 
-const apiAt = () =>
+export const apiAt = (): Promise<ApiPromise> =>
 	Promise.resolve().then(() => {
 		return createApiWithAugmentations(polkadotMetadata.toHex());
 	});


### PR DESCRIPTION
closes: [#690](https://github.com/paritytech/substrate-api-sidecar/issues/690)

This fixes a bug where when expanding metadata in order to capture the weights used in calculating we dont use the correct registry per historic block. This changes that to have a historicApi return the correct registry for the block. 
