### PR TITLE
test(e2e-tests): fix adjust values in e2e tests

### DIFF
--- a/e2e-tests/endpoints/polkadot/runtime/metadata/6877002.json
+++ b/e2e-tests/endpoints/polkadot/runtime/metadata/6877002.json
@@ -7981,7 +7981,7 @@
                         {
                             "name": "batched_calls_limit",
                             "type": "u32",
-                            "value": "0x0cc30000",
+                            "value": "0x0dd20000",
                             "docs": [
                                 " The limit on the number of batched calls."
                             ]

--- a/e2e-tests/endpoints/westend/blocks/5493461.json
+++ b/e2e-tests/endpoints/westend/blocks/5493461.json
@@ -40,6 +40,9 @@
             "tip": null,
             "hash": "0xe786c17e052a23715c95476cbcb346237e1cbed4194b7c07b9ac3e9bed97951e",
             "info": {},
+            "era": {
+                "immortalEra": "0x00"
+            },
             "events": [
                 {
                     "method": {
@@ -103,6 +106,9 @@
             "tip": null,
             "hash": "0xa5cfd214dc99977d6f2ee880c2f33e0e026c8e48e004b205e5f4e33ac9189f67",
             "info": {},
+            "era": {
+                "immortalEra": "0x00"
+            },
             "events": [
                 {
                     "method": {
@@ -145,6 +151,12 @@
                 "weight": "198207000",
                 "class": "Normal",
                 "partialFee": "15700001585"
+            },
+            "era": {
+                "mortalEra": [
+                    "64",
+                    "17"
+                ]
             },
             "events": [
                 {
@@ -218,6 +230,12 @@
                 "weight": "198207000",
                 "class": "Normal",
                 "partialFee": "15700001585"
+            },
+            "era": {
+                "mortalEra": [
+                    "64",
+                    "17"
+                ]
             },
             "events": [
                 {

--- a/e2e-tests/endpoints/westend/blocks/5495855.json
+++ b/e2e-tests/endpoints/westend/blocks/5495855.json
@@ -40,6 +40,9 @@
             "tip": null,
             "hash": "0x44795cd37ecdc669f008e112db799865530f8d6fbf28a264534b886c70f86f77",
             "info": {},
+            "era": {
+                "immortalEra": "0x00"
+            },
             "events": [
                 {
                     "method": {
@@ -113,6 +116,9 @@
             "tip": null,
             "hash": "0x45a15de490c1773ed5100c936509a483302f1deead366572623aae69712a573b",
             "info": {},
+            "era": {
+                "immortalEra": "0x00"
+            },
             "events": [
                 {
                     "method": {
@@ -155,6 +161,12 @@
                 "weight": "198207000",
                 "class": "Normal",
                 "partialFee": "15700001585"
+            },
+            "era": {
+                "mortalEra": [
+                    "64",
+                    "43"
+                ]
             },
             "events": [
                 {

--- a/e2e-tests/endpoints/westend/runtime/metadata/7417678.json
+++ b/e2e-tests/endpoints/westend/runtime/metadata/7417678.json
@@ -4098,7 +4098,7 @@
                         {
                             "name": "batched_calls_limit",
                             "type": "u32",
-                            "value": "0x3c230000",
+                            "value": "0x822d0000",
                             "docs": [
                                 " The limit on the number of batched calls."
                             ]


### PR DESCRIPTION
### `/runtime/metadata`

`batch_calls_limited` in polkadot and westend, has an adjusted value.

### `/blocks/5495855` && `/blocks/5493461`

Now that [ed389a4](https://github.com/paritytech/substrate-api-sidecar/commit/ed389a4baac99662321d2cf88f00669f9d6ce53d) and [4362347](https://github.com/paritytech/substrate-api-sidecar/commit/43623471913545d44ecea74e1411e4a1a740de53), we can update these two responses as they are no longer broken.