### PR TITLE
fix!: change the response for vesting-info

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1396,11 +1396,17 @@ components:
                 $ref: '#/components/schemas/Payouts'
     AccountVestingInfo:
       type: object
+      description: Sidecar version's <= v10.0.0 have a`vesting` return value that defaults to an object for
+        when there is no available vesting-info data. It also returns a `VestingSchedule` as an object. 
+        For Sidecar >=10.0.1, that value will now default as an array when there is no value, and `Vec<VestingSchedule>` 
+        is wrapped in an array now.
       properties:
         at:
           $ref: '#/components/schemas/BlockIdentifiers'
         vesting:
-          $ref: '#/components/schemas/VestingSchedule'
+          type: array
+          items: 
+            $ref: '#/components/schemas/VestingSchedule'
     AssetsBalance:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1397,9 +1397,9 @@ components:
     AccountVestingInfo:
       type: object
       description: Sidecar version's <= v10.0.0 have a`vesting` return value that defaults to an object for
-        when there is no available vesting-info data. It also returns a `VestingSchedule` as an object. 
-        For Sidecar >=10.0.1, that value will now default as an array when there is no value, and `Vec<VestingSchedule>` 
-        is wrapped in an array now.
+        when there is no available vesting-info data. It also returns a `VestingInfo` as an object. 
+        For Sidecar >=11.0.0, that value will now default as an array when there is no value, and `Vec<PalletsPalletVestingInfo>` 
+        is returned when there is.
       properties:
         at:
           $ref: '#/components/schemas/BlockIdentifiers'

--- a/src/services/accounts/AccountsVestingInfoService.spec.ts
+++ b/src/services/accounts/AccountsVestingInfoService.spec.ts
@@ -1,8 +1,10 @@
 import { ApiPromise } from '@polkadot/api';
 import { Hash } from '@polkadot/types/interfaces';
 
+import { createApiWithAugmentations, TypeFactory } from '../../test-helpers/typeFactory';
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { polkadotRegistry } from '../../test-helpers/registries';
+import { polkadotMetadataRpcV9110 } from '../../test-helpers/metadata/polkadotV9110Metadata';
 import {
 	blockHash789629,
 	defaultMockApi,
@@ -11,10 +13,21 @@ import {
 import response789629 from '../test-helpers/responses/accounts/vestingInfo789629.json';
 import { AccountsVestingInfoService } from './AccountsVestingInfoService';
 
+const typeFactorApiV9110 = createApiWithAugmentations(polkadotMetadataRpcV9110);
+const factory = new TypeFactory(typeFactorApiV9110);
+
 const vestingAt = (_hash: Hash, _address: string) =>
-	Promise.resolve().then(() =>
-		polkadotRegistry.createType('Option<VestingInfo>', null)
-	);
+	Promise.resolve().then(() => {
+		const vestingRes = {
+			"locked": "1749990000000000",
+			"perBlock": "166475460",
+			"startingBlock": "4961000"
+		}
+		const vestingInfo = typeFactorApiV9110.createType('PalletVestingVestingInfo', vestingRes);
+		const vecVestingInfo = factory.vecOf([vestingInfo]);
+
+		return factory.optionOf(vecVestingInfo);
+	});
 
 const mockApi = {
 	...defaultMockApi,
@@ -29,7 +42,7 @@ const accountsVestingInfoService = new AccountsVestingInfoService(mockApi);
 
 describe('AccountVestingInfoService', () => {
 	describe('fetchAccountVestingInfo', () => {
-		it('works when ApiPromise works (block 789629)', async () => {
+		it('works when ApiPromise works (block 789629) with V14 metadata', async () => {
 			expect(
 				sanitizeNumbers(
 					await accountsVestingInfoService.fetchAccountVestingInfo(
@@ -38,6 +51,29 @@ describe('AccountVestingInfoService', () => {
 					)
 				)
 			).toStrictEqual(response789629);
+		});
+
+		it('Vesting should return an empty array for None responses', async () => {
+			const tempVest = () => Promise.resolve().then(() => polkadotRegistry.createType('Option<VestingInfo>', null));
+			(mockApi.query.vesting.vesting.at as unknown) = tempVest;
+
+			const expectedResponse = {
+				at: {
+					hash: "0x7b713de604a99857f6c25eacc115a4f28d2611a23d9ddff99ab0e4f1c17a8578",
+					height: "789629"
+				},
+				vesting: []
+			}
+
+			expect(
+				sanitizeNumbers(
+					await accountsVestingInfoService.fetchAccountVestingInfo(
+						blockHash789629,
+						testAddress
+					)
+				)
+			).toStrictEqual(expectedResponse);
+			(mockApi.query.vesting.vesting.at as unknown) = vestingAt
 		});
 	});
 });

--- a/src/services/accounts/AccountsVestingInfoService.spec.ts
+++ b/src/services/accounts/AccountsVestingInfoService.spec.ts
@@ -36,10 +36,10 @@ const vestingAt = (_hash: Hash, _address: string) =>
 		return factory.optionOf(vecVestingInfo);
 	});
 
-const historicVestingAt = (_hash: Hash, _address: string) => 
-	Promise.resolve().then(() => 
+const historicVestingAt = (_hash: Hash, _address: string) =>
+	Promise.resolve().then(() =>
 		polkadotRegistry.createType('Option<VestingInfo>', vestingRes)
-	)
+	);
 
 const mockApi = {
 	...defaultMockApi,
@@ -102,6 +102,6 @@ describe('AccountVestingInfoService', () => {
 				)
 			).toStrictEqual(response789629);
 			(mockApi.query.vesting.vesting.at as unknown) = vestingAt;
-		})
+		});
 	});
 });

--- a/src/services/accounts/AccountsVestingInfoService.spec.ts
+++ b/src/services/accounts/AccountsVestingInfoService.spec.ts
@@ -1,10 +1,13 @@
 import { ApiPromise } from '@polkadot/api';
 import { Hash } from '@polkadot/types/interfaces';
 
-import { createApiWithAugmentations, TypeFactory } from '../../test-helpers/typeFactory';
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
-import { polkadotRegistry } from '../../test-helpers/registries';
 import { polkadotMetadataRpcV9110 } from '../../test-helpers/metadata/polkadotV9110Metadata';
+import { polkadotRegistry } from '../../test-helpers/registries';
+import {
+	createApiWithAugmentations,
+	TypeFactory,
+} from '../../test-helpers/typeFactory';
 import {
 	blockHash789629,
 	defaultMockApi,
@@ -19,11 +22,14 @@ const factory = new TypeFactory(typeFactorApiV9110);
 const vestingAt = (_hash: Hash, _address: string) =>
 	Promise.resolve().then(() => {
 		const vestingRes = {
-			"locked": "1749990000000000",
-			"perBlock": "166475460",
-			"startingBlock": "4961000"
-		}
-		const vestingInfo = typeFactorApiV9110.createType('PalletVestingVestingInfo', vestingRes);
+			locked: '1749990000000000',
+			perBlock: '166475460',
+			startingBlock: '4961000',
+		};
+		const vestingInfo = typeFactorApiV9110.createType(
+			'PalletVestingVestingInfo',
+			vestingRes
+		);
 		const vecVestingInfo = factory.vecOf([vestingInfo]);
 
 		return factory.optionOf(vecVestingInfo);
@@ -54,16 +60,19 @@ describe('AccountVestingInfoService', () => {
 		});
 
 		it('Vesting should return an empty array for None responses', async () => {
-			const tempVest = () => Promise.resolve().then(() => polkadotRegistry.createType('Option<VestingInfo>', null));
+			const tempVest = () =>
+				Promise.resolve().then(() =>
+					polkadotRegistry.createType('Option<VestingInfo>', null)
+				);
 			(mockApi.query.vesting.vesting.at as unknown) = tempVest;
 
 			const expectedResponse = {
 				at: {
-					hash: "0x7b713de604a99857f6c25eacc115a4f28d2611a23d9ddff99ab0e4f1c17a8578",
-					height: "789629"
+					hash: '0x7b713de604a99857f6c25eacc115a4f28d2611a23d9ddff99ab0e4f1c17a8578',
+					height: '789629',
 				},
-				vesting: []
-			}
+				vesting: [],
+			};
 
 			expect(
 				sanitizeNumbers(
@@ -73,7 +82,7 @@ describe('AccountVestingInfoService', () => {
 					)
 				)
 			).toStrictEqual(expectedResponse);
-			(mockApi.query.vesting.vesting.at as unknown) = vestingAt
+			(mockApi.query.vesting.vesting.at as unknown) = vestingAt;
 		});
 	});
 });

--- a/src/services/accounts/AccountsVestingInfoService.ts
+++ b/src/services/accounts/AccountsVestingInfoService.ts
@@ -26,13 +26,18 @@ export class AccountsVestingInfoService extends AbstractService {
 			height: number.unwrap().toString(10),
 		};
 
-		return {
-			at,
-			vesting: vesting.isNone
-				? []
-				: Array.isArray(vesting.unwrap())
-				? vesting.unwrap()
-				: [vesting.unwrap()],
-		};
+		if (vesting.isNone) {
+			return {
+				at,
+				vesting: [],
+			};
+		} else {
+			const unwrapVesting = vesting.unwrap();
+
+			return {
+				at,
+				vesting: Array.isArray(unwrapVesting) ? unwrapVesting : [unwrapVesting],
+			};
+		}
 	}
 }

--- a/src/services/accounts/AccountsVestingInfoService.ts
+++ b/src/services/accounts/AccountsVestingInfoService.ts
@@ -28,7 +28,11 @@ export class AccountsVestingInfoService extends AbstractService {
 
 		return {
 			at,
-			vesting: vesting.isNone ? {} : vesting.unwrap(),
+			vesting: vesting.isNone
+				? []
+				: Array.isArray(vesting.unwrap())
+				? vesting.unwrap()
+				: [vesting.unwrap()],
 		};
 	}
 }

--- a/src/services/test-helpers/responses/accounts/vestingInfo789629.json
+++ b/src/services/test-helpers/responses/accounts/vestingInfo789629.json
@@ -3,5 +3,9 @@
     "hash": "0x7b713de604a99857f6c25eacc115a4f28d2611a23d9ddff99ab0e4f1c17a8578",
     "height": "789629"
   },
-  "vesting": {}
+  "vesting": [{
+    "locked": "1749990000000000",
+    "perBlock": "166475460",
+    "startingBlock": "4961000"
+  }]
 }


### PR DESCRIPTION
## BREAKING CHANGE

With runtime v9110, the vesting-info response now returns an array for `vesting`, with the `VestingInfo` type now being `Vec<PalletVestingVestingInfo>`. Sidecar previously returned responses under the `vesting` key as objects, therefore when there was no information the response was an empty object. 

This is now changed as the response will default to an empty array when there is no vesting-info on the account, and the past responses that were objects, will now be wrapped in an array. 

### Examples:

Before: 
```
{
  "at": {
    "hash": "0x89f4608b568a05a89737bc826a32f8677f2646a5773312d7dee3a667458e5a98",
    "height": "6000000"
  },
  "vesting": {
      "locked": "1749990000000000",
      "perBlock": "166475460",
      "startingBlock": "4961000"
    }
}
```

After
```
{
  "at": {
    "hash": "0x89f4608b568a05a89737bc826a32f8677f2646a5773312d7dee3a667458e5a98",
    "height": "6000000"
  },
  "vesting": [
    {
      "locked": "1749990000000000",
      "perBlock": "166475460",
      "startingBlock": "4961000"
    }
  ]
}
```