### PR TITLE
fix(security): ua-parser-js resolution for docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,6 @@
   },
   "resolutions": {
     "prismjs": "^1.23.0",
-    "us-parser-js": "<= 0.7.28"
+    "ua-parser-js": "<= 0.7.21"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6865,7 +6865,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^0.7.18":
+"ua-parser-js@npm:<= 0.7.21":
   version: 0.7.21
   resolution: "ua-parser-js@npm:0.7.21"
   checksum: 5c1f523e784442ee03d859981fccd642c3825c50365148c3803e151ba19419cef0ec1c47af9ebde1cb7be211ed194d255f7e5ba659a9f1f77d3c674da7b454da


### PR DESCRIPTION
rel: [#536](https://github.com/faisalman/ua-parser-js/issues/536)

Set a resolution for ua-parser-js, this makes sure no affected/malicious version of ua-parser-js is downloaded inside of sidecar. 

Sidecar is not affected by the following hack of ua-parser, but we also want to ensure safety and make sure no downstream deps can install the malicious versions.