### PR TITLE
fix: optimize pallets-storage

### DIFF
--- a/src/controllers/pallets/PalletsStorageController.ts
+++ b/src/controllers/pallets/PalletsStorageController.ts
@@ -2,6 +2,7 @@ import { ApiPromise } from '@polkadot/api';
 import { stringCamelCase } from '@polkadot/util';
 import { RequestHandler } from 'express-serve-static-core';
 
+import { Log } from '../../logging/Log';
 import { PalletsStorageService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -45,6 +46,11 @@ export default class PalletsStorageController extends AbstractController<Pallets
 		const metadataArg = metadata === 'true';
 		const adjustMetadataV13Arg = adjustMetadataV13 === 'true';
 
+		this.deprecationWarning(
+			adjustMetadataV13Arg,
+			'The adjustMetadataV13 query parameter is subject to deprecation soon.'
+		);
+
 		const hash = await this.getHashFromAt(at);
 		const historicApi = await this.api.at(hash);
 
@@ -70,6 +76,11 @@ export default class PalletsStorageController extends AbstractController<Pallets
 		const onlyIdsArg = onlyIds === 'true';
 		const adjustMetadataV13Arg = adjustMetadataV13 === 'true';
 
+		this.deprecationWarning(
+			adjustMetadataV13Arg,
+			'The adjustMetadataV13 query parameter is subject to deprecation soon.'
+		);
+
 		const hash = await this.getHashFromAt(at);
 		const historicApi = await this.api.at(hash);
 
@@ -83,4 +94,10 @@ export default class PalletsStorageController extends AbstractController<Pallets
 			})
 		);
 	};
+
+	private deprecationWarning(arg: boolean, message: string) {
+		if (arg) {
+			Log.logger.warn(message);
+		}
+	}
 }

--- a/src/controllers/pallets/PalletsStorageController.ts
+++ b/src/controllers/pallets/PalletsStorageController.ts
@@ -20,10 +20,12 @@ import AbstractController from '../AbstractController';
  * See `docs/src/openapi-v1.yaml` for usage information.
  */
 export default class PalletsStorageController extends AbstractController<PalletsStorageService> {
+	private readonly deprecationMsg: string;
 	constructor(api: ApiPromise) {
 		super(api, '/pallets/:palletId/storage', new PalletsStorageService(api));
 
 		this.initRoutes();
+		this.deprecationMsg = 'The adjustMetadataV13 query parameter is deprecated and will be removed in v12 of sidecar';
 	}
 
 	protected initRoutes(): void {
@@ -46,10 +48,7 @@ export default class PalletsStorageController extends AbstractController<Pallets
 		const metadataArg = metadata === 'true';
 		const adjustMetadataV13Arg = adjustMetadataV13 === 'true';
 
-		this.deprecationWarning(
-			adjustMetadataV13Arg,
-			'The adjustMetadataV13 query parameter is subject to deprecation soon.'
-		);
+		adjustMetadataV13Arg && Log.logger.warn(this.deprecationMsg);
 
 		const hash = await this.getHashFromAt(at);
 		const historicApi = await this.api.at(hash);
@@ -76,10 +75,7 @@ export default class PalletsStorageController extends AbstractController<Pallets
 		const onlyIdsArg = onlyIds === 'true';
 		const adjustMetadataV13Arg = adjustMetadataV13 === 'true';
 
-		this.deprecationWarning(
-			adjustMetadataV13Arg,
-			'The adjustMetadataV13 query parameter is subject to deprecation soon.'
-		);
+		adjustMetadataV13Arg && Log.logger.warn(this.deprecationMsg);
 
 		const hash = await this.getHashFromAt(at);
 		const historicApi = await this.api.at(hash);
@@ -94,10 +90,4 @@ export default class PalletsStorageController extends AbstractController<Pallets
 			})
 		);
 	};
-
-	private deprecationWarning(arg: boolean, message: string) {
-		if (arg) {
-			Log.logger.warn(message);
-		}
-	}
 }

--- a/src/controllers/pallets/PalletsStorageController.ts
+++ b/src/controllers/pallets/PalletsStorageController.ts
@@ -25,7 +25,8 @@ export default class PalletsStorageController extends AbstractController<Pallets
 		super(api, '/pallets/:palletId/storage', new PalletsStorageService(api));
 
 		this.initRoutes();
-		this.deprecationMsg = 'The adjustMetadataV13 query parameter is deprecated and will be removed in v12 of sidecar';
+		this.deprecationMsg =
+			'The adjustMetadataV13 query parameter is deprecated and will be removed in v12 of sidecar';
 	}
 
 	protected initRoutes(): void {


### PR DESCRIPTION
This PR optimizes the `/pallets/{palletId}/storage/*` endpoints for V14 metadata by about a factor of 10. When using the `adjustMetadataV13` query parameter you will still experience slow load times. I also added a warning for the `adjustMetadataV13` query param when it's in use. The logged warning expresses that its subject to deprecation and will soon be removed. 

closes: [#730](https://github.com/paritytech/substrate-api-sidecar/issues/730)