### PR TITLE
fix: update blockWeights store for westend and kusama

### DIFF
--- a/src/chains-config/metadata-consts/kusamaConsts.ts
+++ b/src/chains-config/metadata-consts/kusamaConsts.ts
@@ -12,7 +12,7 @@ export const kusamaDefinitions: MetadataConsts[] = [
 	{
 		runtimeVersions: [
 			2027, 2028, 2029, 2030, 9000, 9010, 9030, 9040, 9050, 9070, 9080, 9090,
-			9100, 9110, 9111,
+			9100, 9110, 9111, 9122,
 		],
 		perClass,
 	},

--- a/src/chains-config/metadata-consts/westendConsts.ts
+++ b/src/chains-config/metadata-consts/westendConsts.ts
@@ -11,7 +11,7 @@ export const westendDefinitions: MetadataConsts[] = [
 	{
 		runtimeVersions: [
 			47, 48, 49, 50, 9000, 9010, 9030, 9033, 9050, 9070, 9080, 9090, 9100,
-			9110, 9111,
+			9110, 9111, 9120, 9121, 9122,
 		],
 		perClass,
 	},


### PR DESCRIPTION
Updates the blockWeights Store for both westend and kusama with the most up to date runtimes.