### PR TITLE
fix(StakingInfo): add historicApi to staking-info

### DIFF
--- a/src/services/accounts/AccountsStakingInfoService.spec.ts
+++ b/src/services/accounts/AccountsStakingInfoService.spec.ts
@@ -53,7 +53,7 @@ const historicApi = {
 			slashingSpans: slashingSpansAt,
 		},
 	},
-} as unknown as ApiDecoration<'promise'>
+} as unknown as ApiDecoration<'promise'>;
 
 const mockApi = {
 	...defaultMockApi,

--- a/src/services/accounts/AccountsStakingInfoService.spec.ts
+++ b/src/services/accounts/AccountsStakingInfoService.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { ApiPromise } from '@polkadot/api';
+import { ApiDecoration } from '@polkadot/api/types';
 import { Option } from '@polkadot/types';
 import { AccountId, Hash, StakingLedger } from '@polkadot/types/interfaces';
 import { BadRequest, InternalServerError } from 'http-errors';
@@ -43,16 +44,20 @@ const payeeAt = (_hash: Hash, _address: string) =>
 const slashingSpansAt = (_hash: Hash, _address: string) =>
 	Promise.resolve().then(() => polkadotRegistry.createType('SlashingSpans'));
 
-const mockApi = {
-	...defaultMockApi,
+const historicApi = {
 	query: {
 		staking: {
-			bonded: { at: bondedAt },
-			ledger: { at: ledgerAt },
-			payee: { at: payeeAt },
-			slashingSpans: { at: slashingSpansAt },
+			bonded: bondedAt,
+			ledger: ledgerAt,
+			payee: payeeAt,
+			slashingSpans: slashingSpansAt,
 		},
 	},
+} as unknown as ApiDecoration<'promise'>
+
+const mockApi = {
+	...defaultMockApi,
+	at: (_hash: Hash) => historicApi,
 } as unknown as ApiPromise;
 
 const accountStakingInfoService = new AccountsStakingInfoService(mockApi);
@@ -71,7 +76,7 @@ describe('AccountsStakingInfoService', () => {
 		});
 
 		it('throws a 400 when the given address is not a stash', async () => {
-			(mockApi.query.staking.bonded as any).at = () =>
+			(historicApi.query.staking.bonded as any) = () =>
 				Promise.resolve().then(() =>
 					polkadotRegistry.createType('Option<AccountId>', null)
 				);
@@ -85,11 +90,11 @@ describe('AccountsStakingInfoService', () => {
 				new BadRequest('The address NotStash is not a stash address.')
 			);
 
-			(mockApi.query.staking.bonded as any).at = bondedAt;
+			(historicApi.query.staking.bonded as any) = bondedAt;
 		});
 
 		it('throws a 404 when the staking ledger cannot be found', async () => {
-			(mockApi.query.staking.ledger as any).at = () =>
+			(historicApi.query.staking.ledger as any) = () =>
 				Promise.resolve().then(() =>
 					polkadotRegistry.createType('Option<StakingLedger>', null)
 				);
@@ -105,7 +110,7 @@ describe('AccountsStakingInfoService', () => {
 				)
 			);
 
-			(mockApi.query.staking.ledger as any).at = ledgerAt;
+			(historicApi.query.staking.ledger as any) = ledgerAt;
 		});
 	});
 });

--- a/src/services/accounts/AccountsStakingInfoService.ts
+++ b/src/services/accounts/AccountsStakingInfoService.ts
@@ -16,10 +16,11 @@ export class AccountsStakingInfoService extends AbstractService {
 		stash: string
 	): Promise<IAccountStakingInfo> {
 		const { api } = this;
+		const historicApi = await api.at(hash);
 
 		const [header, controllerOption] = await Promise.all([
 			api.rpc.chain.getHeader(hash),
-			api.query.staking.bonded.at(hash, stash), // Option<AccountId> representing the controller
+			historicApi.query.staking.bonded(stash), // Option<AccountId> representing the controller
 		]);
 
 		const at = {
@@ -35,9 +36,9 @@ export class AccountsStakingInfoService extends AbstractService {
 
 		const [stakingLedgerOption, rewardDestination, slashingSpansOption] =
 			await Promise.all([
-				api.query.staking.ledger.at(hash, controller),
-				api.query.staking.payee.at(hash, stash),
-				api.query.staking.slashingSpans.at(hash, stash),
+				historicApi.query.staking.ledger(controller),
+				historicApi.query.staking.payee(stash),
+				historicApi.query.staking.slashingSpans(stash),
 			]);
 
 		const stakingLedger = stakingLedgerOption.unwrapOr(null);


### PR DESCRIPTION
Add historicApi to staking info and reflect that in the tests. 
rel: [#698](https://github.com/paritytech/substrate-api-sidecar/issues/698)