### PR TITLE
feat: transition `/paras/*` off of experimental

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -980,13 +980,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /experimental/paras:
+  /paras:
     get:
       tags:
       - paras
       summary: |
-        [Experimental - subject to breaking change.] List all registered paras
-        (parathreads & parachains).
+        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
+        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
+        List all registered paras (parathreads & parachains).
       description: Returns all registered parachains and parathreads with lifecycle info.
       parameters:
       - name: at
@@ -1004,13 +1005,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paras'
-  /experimental/paras/leases/current:
+  /paras/leases/current:
     get:
       tags:
       - paras
       summary: |
-        [Experimental - subject to breaking change.] Get general information about
-        the current lease period.
+        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
+        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
+        Get general information about the current lease period.
       description: |
         Returns an overview of the current lease period, including lease holders.
       parameters:
@@ -1039,13 +1041,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasLeasesCurrent'
-  /experimental/paras/auctions/current:
+  /paras/auctions/current:
     get:
       tags:
       - paras
       summary: |
-        [Experimental - subject to breaking change.] Get the status of the current
-        auction.
+        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
+        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
+        Get the status of the current auction.
       description: |
         Returns an overview of the current of auction. There is only one auction
         at a time. If there is no auction most fields will be `null`.
@@ -1065,12 +1068,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasAuctionsCurrent'
-  /experimental/paras/crowdloans:
+  /paras/crowdloans:
     get:
       tags:
       - paras
       summary: |
-        [Experimental - subject to breaking change.] List all stored crowdloans.
+        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
+        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
+        List all stored crowdloans.
       description: |
         Returns a list of all the crowdloans and their associated paraIds.
       parameters:
@@ -1089,13 +1094,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasCrowdloans'
-  /experimental/paras/{paraId}/crowdloan-info:
+  /paras/{paraId}/crowdloan-info:
     get:
       tags:
       - paras
       summary: |
-        [Experimental - subject to breaking change.] Get crowdloan information for a
-        `paraId`.
+        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
+        The `/experimental/*` endpoint will still be available for use to make the transition simpler. 
+        Get crowdloan information for a `paraId`.
       description: |
         Returns crowdloan's `fundInfo` and the set of `leasePeriods` the crowdloan`
         covers.
@@ -1121,13 +1127,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ParasCrowdloanInfo'
-  /experimental/paras/{paraId}/lease-info:
+  /paras/{paraId}/lease-info:
     get:
       tags:
       - paras
       summary: |
-        [Experimental - subject to breaking change.] Get current and future leases
-        as well as the lifecycle stage for a given `paraId`.
+        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
+        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
+        Get current and future leases as well as the lifecycle stage for a given `paraId`.
       description: |
         Returns a list of leases that belong to the `paraId` as well as the
         `paraId`'s current lifecycle stage.

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -985,8 +985,6 @@ paths:
       tags:
       - paras
       summary: |
-        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
-        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
         List all registered paras (parathreads & parachains).
       description: Returns all registered parachains and parathreads with lifecycle info.
       parameters:
@@ -1010,8 +1008,6 @@ paths:
       tags:
       - paras
       summary: |
-        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
-        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
         Get general information about the current lease period.
       description: |
         Returns an overview of the current lease period, including lease holders.
@@ -1046,8 +1042,6 @@ paths:
       tags:
       - paras
       summary: |
-        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
-        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
         Get the status of the current auction.
       description: |
         Returns an overview of the current of auction. There is only one auction
@@ -1073,8 +1067,6 @@ paths:
       tags:
       - paras
       summary: |
-        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
-        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
         List all stored crowdloans.
       description: |
         Returns a list of all the crowdloans and their associated paraIds.
@@ -1098,9 +1090,7 @@ paths:
     get:
       tags:
       - paras
-      summary: |
-        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
-        The `/experimental/*` endpoint will still be available for use to make the transition simpler. 
+      summary: | 
         Get crowdloan information for a `paraId`.
       description: |
         Returns crowdloan's `fundInfo` and the set of `leasePeriods` the crowdloan`
@@ -1132,8 +1122,6 @@ paths:
       tags:
       - paras
       summary: |
-        This endpoint is no longer experimental, please migrate over to using `/paras/*`.
-        The `/experimental/*` endpoint will still be available for use to make the transition simpler.
         Get current and future leases as well as the lifecycle stage for a given `paraId`.
       description: |
         Returns a list of leases that belong to the `paraId` as well as the

--- a/e2e-tests/endpoints/kusama/paras/auctions-current/index.ts
+++ b/e2e-tests/endpoints/kusama/paras/auctions-current/index.ts
@@ -3,11 +3,11 @@ import parasAuctionsCurrent9828507 from './9828507.json';
 
 export const parasAuctionsCurrentEndpoints = [
 	[
-		'/experimental/paras/auctions/current?at=8400000',
+		'/paras/auctions/current?at=8400000',
 		JSON.stringify(parasAuctionsCurrent8400000),
 	],
 	[
-		'/experimental/paras/auctions/current?at=9828507',
+		'/paras/auctions/current?at=9828507',
 		JSON.stringify(parasAuctionsCurrent9828507),
 	],
 ];

--- a/e2e-tests/endpoints/kusama/paras/crowdloan-info/index.ts
+++ b/e2e-tests/endpoints/kusama/paras/crowdloan-info/index.ts
@@ -4,15 +4,15 @@ import parasCrowdloanInfo9810000 from './9810000.json';
 
 export const parasCrowdloanInfoEndpoints = [
 	[
-		'/experimental/paras/2023/crowdloan-info?at=8367200',
+		'/paras/2023/crowdloan-info?at=8367200',
 		JSON.stringify(parasCrowdloanInfo8367200),
 	],
 	[
-		'/experimental/paras/2077/crowdloan-info?at=9000000',
+		'/paras/2077/crowdloan-info?at=9000000',
 		JSON.stringify(parasCrowdloanInfo9000000),
 	],
 	[
-		'/experimental/paras/2077/crowdloan-info?at=9810000',
+		'/paras/2077/crowdloan-info?at=9810000',
 		JSON.stringify(parasCrowdloanInfo9810000),
 	],
 ];

--- a/e2e-tests/endpoints/kusama/paras/crowdloans/index.ts
+++ b/e2e-tests/endpoints/kusama/paras/crowdloans/index.ts
@@ -3,11 +3,11 @@ import parasCrowdloans9800000 from './9800000.json';
 
 export const parasCrowdloansEndpoints = [
 	[
-		'/experimental/paras/crowdloans?at=8200000',
+		'/paras/crowdloans?at=8200000',
 		JSON.stringify(parasCrowdloans8200000),
 	],
 	[
-		'/experimental/paras/crowdloans?at=9800000',
+		'/paras/crowdloans?at=9800000',
 		JSON.stringify(parasCrowdloans9800000),
 	],
 ];

--- a/e2e-tests/endpoints/kusama/paras/lease-info/index.ts
+++ b/e2e-tests/endpoints/kusama/paras/lease-info/index.ts
@@ -4,15 +4,15 @@ import parasLeaseInfo9800000 from './9800000.json';
 
 export const parasLeaseInfoEndpoints = [
 	[
-		'/experimental/paras/2007/lease-info?at=8500000',
+		'/paras/2007/lease-info?at=8500000',
 		JSON.stringify(parasLeaseInfo8500000),
 	],
 	[
-		'/experimental/paras/2000/lease-info?at=9000000',
+		'/paras/2000/lease-info?at=9000000',
 		JSON.stringify(parasLeaseInfo9000000),
 	],
 	[
-		'/experimental/paras/2023/lease-info?at=9800000',
+		'/paras/2023/lease-info?at=9800000',
 		JSON.stringify(parasLeaseInfo9800000),
 	],
 ];

--- a/e2e-tests/endpoints/kusama/paras/leases-current/index.ts
+++ b/e2e-tests/endpoints/kusama/paras/leases-current/index.ts
@@ -4,15 +4,15 @@ import parasLeasesCurrent9800000 from './9800000.json';
 
 export const parasLeasesCurrentEndpoints = [
 	[
-		'/experimental/paras/leases/current?at=8200000',
+		'/paras/leases/current?at=8200000',
 		JSON.stringify(parasLeasesCurrent8200000),
 	],
 	[
-		'/experimental/paras/leases/current?at=9000000',
+		'/paras/leases/current?at=9000000',
 		JSON.stringify(parasLeasesCurrent9000000),
 	],
 	[
-		'/experimental/paras/leases/current?at=9800000',
+		'/paras/leases/current?at=9800000',
 		JSON.stringify(parasLeasesCurrent9800000),
 	],
 ];

--- a/e2e-tests/endpoints/kusama/paras/paras/index.ts
+++ b/e2e-tests/endpoints/kusama/paras/paras/index.ts
@@ -3,7 +3,7 @@ import parasParas9400000 from './9400000.json';
 import parasParas9800000 from './9800000.json';
 
 export const parasParasEndpoints = [
-	['/experimental/paras?at=8400000', JSON.stringify(parasParas8400000)],
-	['/experimental/paras?at=9400000', JSON.stringify(parasParas9400000)],
-	['/experimental/paras?at=9800000', JSON.stringify(parasParas9800000)],
+	['/paras?at=8400000', JSON.stringify(parasParas8400000)],
+	['/paras?at=9400000', JSON.stringify(parasParas9400000)],
+	['/paras?at=9800000', JSON.stringify(parasParas9800000)],
 ];

--- a/src/controllers/paras/ParasController.ts
+++ b/src/controllers/paras/ParasController.ts
@@ -7,18 +7,24 @@ import AbstractController from '../AbstractController';
 
 export default class ParasController extends AbstractController<ParasService> {
 	constructor(api: ApiPromise) {
-		super(api, '/experimental/paras', new ParasService(api));
+		super(api, '', new ParasService(api));
 		this.initRoutes();
 	}
 
 	protected initRoutes(): void {
 		this.safeMountAsyncGetHandlers([
-			['/', this.getParas],
-			['/crowdloans', this.getCrowdloans],
-			['/:paraId/crowdloan-info', this.getCrowdloanInfo],
-			['/:paraId/lease-info', this.getLeaseInfo],
-			['/leases/current', this.getLeasesCurrent],
-			['/auctions/current', this.getAuctionsCurrent],
+			['/paras', this.getParas],
+			['/paras/crowdloans', this.getCrowdloans],
+			['/paras/:paraId/crowdloan-info', this.getCrowdloanInfo],
+			['/paras/:paraId/lease-info', this.getLeaseInfo],
+			['/paras/leases/current', this.getLeasesCurrent],
+			['/paras/auctions/current', this.getAuctionsCurrent],
+			['/experimental/paras/', this.getParas],
+			['/experimental/paras/crowdloans', this.getCrowdloans],
+			['/experimental/paras/:paraId/crowdloan-info', this.getCrowdloanInfo],
+			['/experimental/paras/:paraId/lease-info', this.getLeaseInfo],
+			['/experimental/paras/leases/current', this.getLeasesCurrent],
+			['/experimental/paras/auctions/current', this.getAuctionsCurrent],
 		]);
 	}
 


### PR DESCRIPTION
This removes the `/paras/*` endpoints off of experimental. We are going to leave the `/experimental/*` endpoints for a little to give users ample amount of time to transition over. 