### PR TITLE
docs: Update readme with node compatibility chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Compatibility:
 |     v17.x.x   |  Not Stable |
 |     v18.x.x   |   Pending   | 
 
-NOTE: Node LTS (`long term support`) version's start with an even number, and odd number version's are subject to a 6 month testing period with active support before they are unsupported. It is recommended to use sidecar with a stable actively maintained version of node.js.  
+NOTE: Node LTS (`long term support`) versions start with an even number, and odd number versions are subject to a 6 month testing period with active support before they are unsupported. It is recommended to use sidecar with a stable actively maintained version of node.js.  
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,17 @@ learn more.
 
 ## Prerequisites
 
-This service requires Node version 14 or higher.
+This service requires Node versions 14 or higher.
+
+Compatibility:
+| Node Version  | Stablility  |
+|---------------|:-----------:|
+|     v14.x.x   |   Stable    |
+|     v16.x.x   |   Stable    |
+|     v17.x.x   |  Not Stable |
+|     v18.x.x   |   Pending   | 
+
+NOTE: Node LTS (`long term support`) version's start with an even number, and odd number version's begin with an odd number. It is recommended to use sidecar with a stable actively maintained version of node.  
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Compatibility:
 |     v17.x.x   |  Not Stable |
 |     v18.x.x   |   Pending   | 
 
-NOTE: Node LTS (`long term support`) version's start with an even number, and odd number version's begin with an odd number. It is recommended to use sidecar with a stable actively maintained version of node.  
+NOTE: Node LTS (`long term support`) version's start with an even number, and odd number version's are subject to a 6 month testing period with active support before they are unsupported. It is recommended to use sidecar with a stable actively maintained version of node.js.  
 
 ## Table of contents
 


### PR DESCRIPTION
rel: [#771](https://github.com/paritytech/substrate-api-sidecar/issues/771)

This updates the docs with a compatibility chart for Node releases. 