### PR TITLE
fix: update websocket addresses used for e2e tests

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -26,7 +26,7 @@ export const defaultSasPackOpts = {
 
 export const config: Record<string, IChainConfig> = {
 	polkadot: {
-		wsUrl: 'wss://rpc.polkadot.io',
+		wsUrl: 'wss://polkadot.api.onfinality.io/public-ws',
 		JestProcOpts: {
 			...defaultJestOpts,
 			args: ['test:e2e-tests', '--chain', 'polkadot'],
@@ -34,7 +34,7 @@ export const config: Record<string, IChainConfig> = {
 		SasStartOpts: defaultSasStartOpts,
 	},
 	kusama: {
-		wsUrl: 'wss://kusama-rpc.polkadot.io',
+		wsUrl: 'wss://kusama.api.onfinality.io/public-ws',
 		JestProcOpts: {
 			...defaultJestOpts,
 			args: ['test:e2e-tests', '--chain', 'kusama'],
@@ -42,7 +42,7 @@ export const config: Record<string, IChainConfig> = {
 		SasStartOpts: defaultSasStartOpts,
 	},
 	westend: {
-		wsUrl: 'wss://westend-rpc.polkadot.io',
+		wsUrl: 'wss://westend.api.onfinality.io/public-ws',
 		JestProcOpts: {
 			...defaultJestOpts,
 			args: ['test:e2e-tests', '--chain', 'westend'],
@@ -50,7 +50,7 @@ export const config: Record<string, IChainConfig> = {
 		SasStartOpts: defaultSasStartOpts,
 	},
 	statemine: {
-		wsUrl: 'wss://kusama-statemine-rpc.paritytech.net',
+		wsUrl: 'wss://statemine.api.onfinality.io/public-ws',
 		JestProcOpts: {
 			...defaultJestOpts,
 			args: ['test:e2e-tests', '--chain', 'statemine'],


### PR DESCRIPTION
Currently the public nodes hosted by parity have been unreliable. 

When I run the e2e tests i find myself switching over all the addresses to onFinality to run the tests.

Below are some issues i find when querying the following public nodes. 
`wss://rpc.polkadot.io` -> A query can take up to 100,000 ms 
`wss://westend-rpc.polkadot.io` -> Same with polkadot, incredibly slow. 
`wss://kusama-statemine-rpc.paritytech.net` -> Connection issues, drops connection when initializing the api.

Pros for onFinality nodes:
Haven't ran into a single issue yet for any chain. 
 