### PR TITLE
fix: add leaseOffset to leasesCurrent end calc

### DIFF
--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -332,7 +332,8 @@ export class ParasService extends AbstractService {
 
 		const leasePeriod = historicApi.consts.slots.leasePeriod as BlockNumber;
 		const leasePeriodIndex = this.leasePeriodIndexAt(historicApi, blockNumber);
-		const leaseOffset = (historicApi.consts.slots.leaseOffset as BlockNumber) || BN_ZERO;
+		const leaseOffset =
+			(historicApi.consts.slots.leaseOffset as BlockNumber) || BN_ZERO;
 		const endOfLeasePeriod = leasePeriodIndex
 			? leasePeriodIndex.mul(leasePeriod).add(leasePeriod).add(leaseOffset)
 			: null;

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -332,8 +332,9 @@ export class ParasService extends AbstractService {
 
 		const leasePeriod = historicApi.consts.slots.leasePeriod as BlockNumber;
 		const leasePeriodIndex = this.leasePeriodIndexAt(historicApi, blockNumber);
+		const leaseOffset = (historicApi.consts.slots.leaseOffset as BlockNumber) || BN_ZERO;
 		const endOfLeasePeriod = leasePeriodIndex
-			? leasePeriodIndex.mul(leasePeriod).add(leasePeriod)
+			? leasePeriodIndex.mul(leasePeriod).add(leasePeriod).add(leaseOffset)
 			: null;
 
 		return {


### PR DESCRIPTION
Currently the `endOfLeasePeriod` calculation is missing the `leaseOffset` being added to it