### PR TITLE
fix(bug): set min calc fee runtime version to 601

### DIFF
--- a/src/chains-config/statemintControllers.ts
+++ b/src/chains-config/statemintControllers.ts
@@ -24,7 +24,7 @@ export const statemintControllers: ControllerConfig = {
 	],
 	options: {
 		finalizes: true,
-		minCalcFeeRuntime: 2,
+		minCalcFeeRuntime: 601,
 		blockWeightStore: {},
 		blockStore: initLRUCache(),
 	},


### PR DESCRIPTION
Runtime `2` doesnt have `query.<>.<>.nextFeeMultiplier`