### PR TITLE
fix: update polkadot-js api to 7.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:test-release": "yarn start:test-release"
   },
   "dependencies": {
-    "@polkadot/api": "^7.0.1",
+    "@polkadot/api": "^7.2.1",
     "@polkadot/apps-config": "0.98.2-164",
     "@polkadot/util-crypto": "^8.2.2",
     "@polkadot/x-rxjs": "^6.11.1",
@@ -75,11 +75,11 @@
     "tsc-watch": "^4.4.0"
   },
   "resolutions": {
-    "@polkadot/api": "7.0.1",
+    "@polkadot/api": "7.2.1",
     "@polkadot/keyring": "8.2.2",
     "@polkadot/networks": "8.2.2",
-    "@polkadot/types": "7.0.1",
-    "@polkadot/types-known": "7.0.1",
+    "@polkadot/types": "7.2.1",
+    "@polkadot/types-known": "7.2.1",
     "@polkadot/util": "8.2.2",
     "@polkadot/util-crypto": "8.2.2",
     "@polkadot/wasm-crypto": "4.5.1",

--- a/src/services/accounts/AccountsAssetsService.spec.ts
+++ b/src/services/accounts/AccountsAssetsService.spec.ts
@@ -4,9 +4,13 @@ import { Hash } from '@polkadot/types/interfaces';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { blockHash789629, defaultMockApi } from '../test-helpers/mock';
+import {
+	assetApprovals,
+	assetsAccount,
+	assetsInfoKeysInjected,
+	assetsMetadata,
+} from '../test-helpers/mock/assets/mockAssetData';
 import { AccountsAssetsService } from './AccountsAssetsService';
-
-import { assetsInfoKeysInjected, assetApprovals, assetsAccount, assetsMetadata } from '../test-helpers/mock/assets/mockAssetData';
 
 const historicApi = {
 	query: {

--- a/src/services/accounts/AccountsAssetsService.spec.ts
+++ b/src/services/accounts/AccountsAssetsService.spec.ts
@@ -1,155 +1,19 @@
 import { ApiPromise } from '@polkadot/api';
 import { ApiDecoration } from '@polkadot/api/types';
-import { AssetId, Hash } from '@polkadot/types/interfaces';
-import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
+import { Hash } from '@polkadot/types/interfaces';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
-import { statemintV1 } from '../../test-helpers/metadata/statemintMetadata';
-import { rococoRegistry } from '../../test-helpers/registries';
-import { createApiWithAugmentations } from '../../test-helpers/typeFactory';
-import { TypeFactory } from '../../test-helpers/typeFactory';
 import { blockHash789629, defaultMockApi } from '../test-helpers/mock';
 import { AccountsAssetsService } from './AccountsAssetsService';
 
-const statemintApiV1 = createApiWithAugmentations(statemintV1);
-const statemintTypeFactory = new TypeFactory(statemintApiV1);
-
-const falseBool = rococoRegistry.createType('bool', false);
-const trueBool = rococoRegistry.createType('bool', true);
-const assetTBalanceOne = rococoRegistry.createType('u64', 10000000);
-const assetTBalanceTwo = rococoRegistry.createType('u64', 20000000);
-
-const accountIdOne = rococoRegistry.createType(
-	'AccountId',
-	'1TYrFCWxwHA5bhiXf6uLvPfG6eEvrzzL7uiPK3Yc6yHLUqc'
-);
-const accountIdTwo = rococoRegistry.createType(
-	'AccountId',
-	'13NXiLYYzVEjXxU3eaZNcrjEX9vPyVDNNpURCzK8Bj9BiCWH'
-);
-const balanceOfTwo = rococoRegistry.createType('BalanceOf', 2000000);
-
-const assetsInfo = () =>
-	Promise.resolve().then(() => {
-		const responseObj = {
-			owner: accountIdOne,
-			issue: accountIdTwo,
-			admin: accountIdTwo,
-			freezer: accountIdTwo,
-			supply: assetTBalanceOne,
-			deposit: balanceOfTwo,
-			minBalance: rococoRegistry.createType('u64', 10000),
-			isSufficient: trueBool,
-			accounts: rococoRegistry.createType('u32', 10),
-			sufficients: rococoRegistry.createType('u32', 15),
-			approvals: rococoRegistry.createType('u32', 20),
-			isFrozen: falseBool,
-		};
-
-		return rococoRegistry.createType('AssetDetails', responseObj);
-	});
-
-const assetsMetadata = () =>
-	Promise.resolve().then(() => {
-		const responseObj = {
-			deposit: balanceOfTwo,
-			name: rococoRegistry.createType('Bytes', 'statemint'),
-			symbol: rococoRegistry.createType('Bytes', 'DOT'),
-			decimals: rococoRegistry.createType('u8', 10),
-			isFrozen: falseBool,
-		};
-
-		return rococoRegistry.createType('AssetMetadata', responseObj);
-	});
-
-const assetBalanceObjOne = {
-	balance: assetTBalanceOne,
-	isFrozen: falseBool,
-	sufficient: trueBool,
-};
-
-const assetBalanceObjTwo = {
-	balance: assetTBalanceTwo,
-	isFrozen: trueBool,
-	sufficient: trueBool,
-};
-
-const assetBalanceObjThree = {
-	balance: assetTBalanceTwo,
-	isFrozen: falseBool,
-	sufficient: falseBool,
-};
-
-const assetBalanceFactory = {
-	'10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
-	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
-	'30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
-};
-
-const assetStorageKeyOne = statemintTypeFactory.storageKey(
-	10,
-	'AssetId',
-	statemintApiV1.query.assets.asset
-);
-
-const assetStorageKeyTwo = statemintTypeFactory.storageKey(
-	20,
-	'AssetId',
-	statemintApiV1.query.assets.asset
-);
-
-const assetStorageKeyThree = statemintTypeFactory.storageKey(
-	30,
-	'AssetId',
-	statemintApiV1.query.assets.asset
-);
-
-const assetsAccountKeysAt = () =>
-	Promise.resolve().then(() => {
-		return [assetStorageKeyOne, assetStorageKeyTwo, assetStorageKeyThree];
-	});
-
-/**
- * Attach `keys` to mockApi.query.assets.asset
- */
-Object.assign(assetsInfo, {
-	keys: assetsAccountKeysAt,
-});
-
-/**
- * @param assetId options are 10, 20, 30
- */
-const assetsAccount = (assetId: number | AssetId, _address: string) => {
-	const id =
-		typeof assetId === 'number' ? assetId : parseInt(assetId.toString());
-
-	switch (id) {
-		case 10:
-			return assetBalanceFactory[10];
-		case 20:
-			return assetBalanceFactory[20];
-		case 30:
-			return assetBalanceFactory[30];
-		default:
-			return;
-	}
-};
-
-const assetApprovals = () =>
-	Promise.resolve().then(() => {
-		const assetObj = {
-			amount: assetTBalanceOne,
-			deposit: balanceOfTwo,
-		};
-		return rococoRegistry.createType('Option<AssetApproval>', assetObj);
-	});
+import { assetsInfoKeysInjected, assetApprovals, assetsAccount, assetsMetadata } from '../test-helpers/mock/assets/mockAssetData';
 
 const historicApi = {
 	query: {
 		assets: {
 			account: assetsAccount,
 			approvals: assetApprovals,
-			asset: assetsInfo,
+			asset: assetsInfoKeysInjected(),
 			metadata: assetsMetadata,
 		},
 	},

--- a/src/services/accounts/AccountsAssetsService.spec.ts
+++ b/src/services/accounts/AccountsAssetsService.spec.ts
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { ApiDecoration } from '@polkadot/api/types';
 import { AssetId, Hash } from '@polkadot/types/interfaces';
-import { PalletAssetsAssetBalance } from '@polkadot/types/lookup';
+import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { statemintV1 } from '../../test-helpers/metadata/statemintMetadata';
@@ -81,9 +81,9 @@ const assetBalanceObjThree = {
 };
 
 const assetBalanceFactory = {
-	'10': assetBalanceObjOne as unknown as PalletAssetsAssetBalance,
-	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetBalance,
-	'30': assetBalanceObjThree as unknown as PalletAssetsAssetBalance,
+	'10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
+	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
+	'30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
 };
 
 const assetStorageKeyOne = statemintTypeFactory.storageKey(

--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -17,7 +17,10 @@ import { AbstractService } from '../AbstractService';
  * https://github.com/paritytech/substrate/pull/10382/files#diff-9acae09f48474b7f0b96e7a3d66644e0ce5179464cbb0e00671ad09aa3f73a5fR88
  *
  * Both `PalletAssetsAssetBalance`, and `LegacyPalletAssetsAssetBalance` have either,
- * a `sufficient` or `isSufficient` field exposed instead.
+ * a `sufficient` or `isSufficient` field exposed instead and are the types used
+ * pre v9160.
+ *
+ * For v9160 and future runtimes, the returned type is `PalletAssetsAssetAccount`.
  */
 interface PalletAssetsAssetBalance extends Struct {
 	readonly balance: u128;

--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -198,8 +198,8 @@ export class AccountsAssetsService extends AbstractService {
 				/**
 				 * This return value wont ever be reached as polkadot-js defaults the
 				 * `balance` value to `0`, `isFrozen` to false, and `isSufficient` to false.
-				 * This ensures the the typescript compiler is happy, but we also follow with
-				 * its convention.
+				 * This ensures that the typescript compiler is happy, but we also follow along
+				 * with polkadot-js/substrate convention.
 				 */
 				return {
 					assetId,

--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -125,8 +125,8 @@ export class AccountsAssetsService extends AbstractService {
 					address
 				);
 
-				let balance = null, 
-					isFrozen =  null,
+				let balance = null,
+					isFrozen = null,
 					reason = null;
 				if (assetBalance.isSome) {
 					({ balance, isFrozen, reason } = assetBalance.unwrap());

--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -12,13 +12,16 @@ import {
 import { AbstractService } from '../AbstractService';
 
 /**
- * This is a type that is necessary for any runtime pre 9160. It excludes the
- * `reason` field which 9160 introduces via the following PR.
+ * These two types (`PalletAssetsAssetBalance, LegacyPalletAssetsAssetBalance`) are necessary for any
+ * runtime pre 9160. It excludes the `reason` field which v9160 introduces via the following PR.
  * https://github.com/paritytech/substrate/pull/10382/files#diff-9acae09f48474b7f0b96e7a3d66644e0ce5179464cbb0e00671ad09aa3f73a5fR88
  *
- * Both `PalletAssetsAssetBalance`, and `LegacyPalletAssetsAssetBalance` have either,
- * a `sufficient` or `isSufficient` field exposed instead and are the types used
- * pre v9160.
+ * `LegacyPalletAssetsAssetBalance` which is the oldest historic type here had a `isSufficient`
+ * key. It was then updated to be `sufficient` which we represent here within `PalletAssetsAssetBalance`.
+ *
+ * v9160 removes the `sufficient` key typed as a boolean, and instead
+ * replaces it with a `reason` key. `reason` is an enum and has the following values
+ * in polkadot-js: (`isConsumer`, `isSufficient`, `isDepositHeld`, `asDepositHeld`, `isDepositRefunded`, `type`).
  *
  * For v9160 and future runtimes, the returned type is `PalletAssetsAssetAccount`.
  */

--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -192,11 +192,17 @@ export class AccountsAssetsService extends AbstractService {
 					};
 				}
 
+				/**
+				 * This return value wont ever be reached as polkadot-js defaults the
+				 * `balance` value to `0`, `isFrozen` to false, and `isSufficient` to false.
+				 * This ensures the the typescript compiler is happy, but we also follow with
+				 * its convention.
+				 */
 				return {
 					assetId,
-					balance: null,
-					isFrozen: null,
-					isSufficient: null,
+					balance: historicApi.registry.createType('u128', 0),
+					isFrozen: historicApi.registry.createType('bool', false),
+					isSufficient: historicApi.registry.createType('bool', false),
 				};
 			})
 		);

--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -1,5 +1,5 @@
 import { ApiDecoration } from '@polkadot/api/types';
-import { bool, StorageKey } from '@polkadot/types';
+import { StorageKey } from '@polkadot/types';
 import { AssetId, BlockHash } from '@polkadot/types/interfaces';
 import { BadRequest } from 'http-errors';
 
@@ -125,12 +125,18 @@ export class AccountsAssetsService extends AbstractService {
 					address
 				);
 
+				let balance = null, 
+					isFrozen =  null,
+					reason = null;
+				if (assetBalance.isSome) {
+					({ balance, isFrozen, reason } = assetBalance.unwrap());
+				}
+
 				return {
 					assetId,
-					balance: assetBalance.balance,
-					isFrozen: assetBalance.isFrozen,
-					isSufficient:
-						assetBalance.sufficient || (assetBalance['isSufficient'] as bool),
+					balance,
+					isFrozen,
+					reason,
 				};
 			})
 		);

--- a/src/services/pallets/PalletsAssetsService.spec.ts
+++ b/src/services/pallets/PalletsAssetsService.spec.ts
@@ -2,9 +2,13 @@ import { ApiPromise } from '@polkadot/api';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { blockHash789629, defaultMockApi } from '../test-helpers/mock';
+import {
+	assetApprovals,
+	assetsAccount,
+	assetsInfoKeysInjected,
+	assetsMetadata,
+} from '../test-helpers/mock/assets/mockAssetData';
 import { PalletsAssetsService } from './PalletsAssetsService';
-
-import { assetsInfoKeysInjected, assetApprovals, assetsAccount, assetsMetadata } from '../test-helpers/mock/assets/mockAssetData';
 
 const mockApi = {
 	...defaultMockApi,

--- a/src/services/pallets/PalletsAssetsService.spec.ts
+++ b/src/services/pallets/PalletsAssetsService.spec.ts
@@ -5,7 +5,7 @@ import { blockHash789629, defaultMockApi } from '../test-helpers/mock';
 import {
 	assetApprovals,
 	assetsAccount,
-	assetsInfoKeysInjected,
+	assetsInfo,
 	assetsMetadata,
 } from '../test-helpers/mock/assets/mockAssetData';
 import { PalletsAssetsService } from './PalletsAssetsService';
@@ -14,7 +14,7 @@ const mockApi = {
 	...defaultMockApi,
 	query: {
 		assets: {
-			asset: assetsInfoKeysInjected,
+			asset: assetsInfo,
 			approvals: assetApprovals,
 			account: assetsAccount,
 			metadata: assetsMetadata,

--- a/src/services/pallets/PalletsAssetsService.spec.ts
+++ b/src/services/pallets/PalletsAssetsService.spec.ts
@@ -1,159 +1,16 @@
 import { ApiPromise } from '@polkadot/api';
-import { AssetId } from '@polkadot/types/interfaces';
-import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
-import { statemintV1 } from '../../test-helpers/metadata/statemintMetadata';
-import { rococoRegistry } from '../../test-helpers/registries';
-import { createApiWithAugmentations } from '../../test-helpers/typeFactory';
-import { TypeFactory } from '../../test-helpers/typeFactory';
 import { blockHash789629, defaultMockApi } from '../test-helpers/mock';
 import { PalletsAssetsService } from './PalletsAssetsService';
 
-/**
- * Asset specific constants.
- * Note: It borrows some variables used in the parachains constant section
- *
- * Used in `/assets` and `/accounts` endpoints
- */
-const statemintApiV1 = createApiWithAugmentations(statemintV1);
-const statemintTypeFactory = new TypeFactory(statemintApiV1);
-
-const falseBool = rococoRegistry.createType('bool', false);
-const trueBool = rococoRegistry.createType('bool', true);
-const assetTBalanceOne = rococoRegistry.createType('u64', 10000000);
-const assetTBalanceTwo = rococoRegistry.createType('u64', 20000000);
-
-const accountIdOne = rococoRegistry.createType(
-	'AccountId',
-	'1TYrFCWxwHA5bhiXf6uLvPfG6eEvrzzL7uiPK3Yc6yHLUqc'
-);
-const accountIdTwo = rococoRegistry.createType(
-	'AccountId',
-	'13NXiLYYzVEjXxU3eaZNcrjEX9vPyVDNNpURCzK8Bj9BiCWH'
-);
-const balanceOfTwo = rococoRegistry.createType('BalanceOf', 2000000);
-
-const assetsInfo = () =>
-	Promise.resolve().then(() => {
-		const responseObj = {
-			owner: accountIdOne,
-			issue: accountIdTwo,
-			admin: accountIdTwo,
-			freezer: accountIdTwo,
-			supply: assetTBalanceOne,
-			deposit: balanceOfTwo,
-			minBalance: rococoRegistry.createType('u64', 10000),
-			isSufficient: trueBool,
-			accounts: rococoRegistry.createType('u32', 10),
-			sufficients: rococoRegistry.createType('u32', 15),
-			approvals: rococoRegistry.createType('u32', 20),
-			isFrozen: falseBool,
-		};
-
-		return rococoRegistry.createType('AssetDetails', responseObj);
-	});
-
-const assetsMetadata = () =>
-	Promise.resolve().then(() => {
-		const responseObj = {
-			deposit: balanceOfTwo,
-			name: rococoRegistry.createType('Bytes', 'statemint'),
-			symbol: rococoRegistry.createType('Bytes', 'DOT'),
-			decimals: rococoRegistry.createType('u8', 10),
-			isFrozen: falseBool,
-		};
-
-		return rococoRegistry.createType('AssetMetadata', responseObj);
-	});
-
-const assetBalanceObjOne = {
-	balance: assetTBalanceOne,
-	isFrozen: falseBool,
-	sufficient: trueBool,
-};
-
-const assetBalanceObjTwo = {
-	balance: assetTBalanceTwo,
-	isFrozen: trueBool,
-	sufficient: trueBool,
-};
-
-const assetBalanceObjThree = {
-	balance: assetTBalanceTwo,
-	isFrozen: falseBool,
-	sufficient: falseBool,
-};
-
-const assetBalanceFactory = {
-	'10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
-	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
-	'30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
-};
-
-const assetStorageKeyOne = statemintTypeFactory.storageKey(
-	10,
-	'AssetId',
-	statemintApiV1.query.assets.asset
-);
-
-const assetStorageKeyTwo = statemintTypeFactory.storageKey(
-	20,
-	'AssetId',
-	statemintApiV1.query.assets.asset
-);
-
-const assetStorageKeyThree = statemintTypeFactory.storageKey(
-	30,
-	'AssetId',
-	statemintApiV1.query.assets.asset
-);
-
-const assetsAccountKeysAt = () =>
-	Promise.resolve().then(() => {
-		return [assetStorageKeyOne, assetStorageKeyTwo, assetStorageKeyThree];
-	});
-
-/**
- * Attach `keysAt` to mockApi.query.assets.asset
- */
-Object.assign(assetsInfo, {
-	keysAt: assetsAccountKeysAt,
-});
-
-/**
- * @param assetId options are 10, 20, 30
- */
-const assetsAccount = (assetId: number | AssetId, _address: string) => {
-	const id =
-		typeof assetId === 'number' ? assetId : parseInt(assetId.toString());
-
-	switch (id) {
-		case 10:
-			return assetBalanceFactory[10];
-		case 20:
-			return assetBalanceFactory[20];
-		case 30:
-			return assetBalanceFactory[30];
-		default:
-			return;
-	}
-};
-
-const assetApprovals = () =>
-	Promise.resolve().then(() => {
-		const assetObj = {
-			amount: assetTBalanceOne,
-			deposit: balanceOfTwo,
-		};
-		return rococoRegistry.createType('Option<AssetApproval>', assetObj);
-	});
+import { assetsInfoKeysInjected, assetApprovals, assetsAccount, assetsMetadata } from '../test-helpers/mock/assets/mockAssetData';
 
 const mockApi = {
 	...defaultMockApi,
 	query: {
 		assets: {
-			asset: assetsInfo,
+			asset: assetsInfoKeysInjected,
 			approvals: assetApprovals,
 			account: assetsAccount,
 			metadata: assetsMetadata,

--- a/src/services/pallets/PalletsAssetsService.spec.ts
+++ b/src/services/pallets/PalletsAssetsService.spec.ts
@@ -1,6 +1,6 @@
 import { ApiPromise } from '@polkadot/api';
 import { AssetId } from '@polkadot/types/interfaces';
-import { PalletAssetsAssetBalance } from '@polkadot/types/lookup';
+import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { statemintV1 } from '../../test-helpers/metadata/statemintMetadata';
@@ -86,9 +86,9 @@ const assetBalanceObjThree = {
 };
 
 const assetBalanceFactory = {
-	'10': assetBalanceObjOne as unknown as PalletAssetsAssetBalance,
-	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetBalance,
-	'30': assetBalanceObjThree as unknown as PalletAssetsAssetBalance,
+	'10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
+	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
+	'30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
 };
 
 const assetStorageKeyOne = statemintTypeFactory.storageKey(

--- a/src/services/test-helpers/mock/assets/mockAssetData.ts
+++ b/src/services/test-helpers/mock/assets/mockAssetData.ts
@@ -1,5 +1,11 @@
-import { AssetId } from '@polkadot/types/interfaces';
+import {
+	AssetApproval,
+	AssetDetails,
+	AssetId,
+	AssetMetadata,
+} from '@polkadot/types/interfaces';
 import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
+import { Option } from '@polkadot/types-codec/base';
 
 import { statemintV1 } from '../../../../test-helpers/metadata/statemintMetadata';
 import { rococoRegistry } from '../../../../test-helpers/registries';
@@ -18,131 +24,134 @@ const assetTBalanceOne = rococoRegistry.createType('u64', 10000000);
 const assetTBalanceTwo = rococoRegistry.createType('u64', 20000000);
 
 const accountIdOne = rococoRegistry.createType(
-    'AccountId',
-    '1TYrFCWxwHA5bhiXf6uLvPfG6eEvrzzL7uiPK3Yc6yHLUqc'
+	'AccountId',
+	'1TYrFCWxwHA5bhiXf6uLvPfG6eEvrzzL7uiPK3Yc6yHLUqc'
 );
 const accountIdTwo = rococoRegistry.createType(
-    'AccountId',
-    '13NXiLYYzVEjXxU3eaZNcrjEX9vPyVDNNpURCzK8Bj9BiCWH'
+	'AccountId',
+	'13NXiLYYzVEjXxU3eaZNcrjEX9vPyVDNNpURCzK8Bj9BiCWH'
 );
 const balanceOfTwo = rococoRegistry.createType('BalanceOf', 2000000);
 
 const assetBalanceObjOne = {
-    balance: assetTBalanceOne,
-    isFrozen: falseBool,
-    sufficient: trueBool,
+	balance: assetTBalanceOne,
+	isFrozen: falseBool,
+	sufficient: trueBool,
 };
 
 const assetBalanceObjTwo = {
-    balance: assetTBalanceTwo,
-    isFrozen: trueBool,
-    sufficient: trueBool,
+	balance: assetTBalanceTwo,
+	isFrozen: trueBool,
+	sufficient: trueBool,
 };
 
 const assetBalanceObjThree = {
-    balance: assetTBalanceTwo,
-    isFrozen: falseBool,
-    sufficient: falseBool,
+	balance: assetTBalanceTwo,
+	isFrozen: falseBool,
+	sufficient: falseBool,
 };
 
 const assetBalanceFactory = {
-    '10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
-    '20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
-    '30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
+	'10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
+	'20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
+	'30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
 };
 
 const assetStorageKeyOne = statemintTypeFactory.storageKey(
-    10,
-    'AssetId',
-    statemintApiV1.query.assets.asset
+	10,
+	'AssetId',
+	statemintApiV1.query.assets.asset
 );
 
 const assetStorageKeyTwo = statemintTypeFactory.storageKey(
-    20,
-    'AssetId',
-    statemintApiV1.query.assets.asset
+	20,
+	'AssetId',
+	statemintApiV1.query.assets.asset
 );
 
 const assetStorageKeyThree = statemintTypeFactory.storageKey(
-    30,
-    'AssetId',
-    statemintApiV1.query.assets.asset
+	30,
+	'AssetId',
+	statemintApiV1.query.assets.asset
 );
 
 const assetsAccountKeysAt = () =>
-    Promise.resolve().then(() => {
-        return [assetStorageKeyOne, assetStorageKeyTwo, assetStorageKeyThree];
-    });
+	Promise.resolve().then(() => {
+		return [assetStorageKeyOne, assetStorageKeyTwo, assetStorageKeyThree];
+	});
 
-export const assetsInfo = () =>
-    Promise.resolve().then(() => {
-        const responseObj = {
-            owner: accountIdOne,
-            issue: accountIdTwo,
-            admin: accountIdTwo,
-            freezer: accountIdTwo,
-            supply: assetTBalanceOne,
-            deposit: balanceOfTwo,
-            minBalance: rococoRegistry.createType('u64', 10000),
-            isSufficient: trueBool,
-            accounts: rococoRegistry.createType('u32', 10),
-            sufficients: rococoRegistry.createType('u32', 15),
-            approvals: rococoRegistry.createType('u32', 20),
-            isFrozen: falseBool,
-        };
+export const assetsInfo = (): Promise<AssetDetails> =>
+	Promise.resolve().then(() => {
+		const responseObj = {
+			owner: accountIdOne,
+			issue: accountIdTwo,
+			admin: accountIdTwo,
+			freezer: accountIdTwo,
+			supply: assetTBalanceOne,
+			deposit: balanceOfTwo,
+			minBalance: rococoRegistry.createType('u64', 10000),
+			isSufficient: trueBool,
+			accounts: rococoRegistry.createType('u32', 10),
+			sufficients: rococoRegistry.createType('u32', 15),
+			approvals: rococoRegistry.createType('u32', 20),
+			isFrozen: falseBool,
+		};
 
-        return rococoRegistry.createType('AssetDetails', responseObj);
-    });
+		return rococoRegistry.createType('AssetDetails', responseObj);
+	});
 
-export const assetsInfoKeysInjected = () => {
-    // Create a shallow copy of assetsInfo
-    const assetInfoCopy = Object.assign({}, assetsInfo);
+export const assetsInfoKeysInjected = (): (() => Promise<AssetDetails>) => {
+	// Create a shallow copy of assetsInfo
+	const assetInfoCopy = Object.assign({}, assetsInfo);
 
-    // Inject the keys into assetsInfo
-    Object.assign(assetInfoCopy, {
-        keys: assetsAccountKeysAt,
-    });
+	// Inject the keys into assetsInfo
+	Object.assign(assetInfoCopy, {
+		keys: assetsAccountKeysAt,
+	});
 
-    return assetInfoCopy;
-}
+	return assetInfoCopy;
+};
 
-export const assetsMetadata = () =>
-    Promise.resolve().then(() => {
-        const responseObj = {
-            deposit: balanceOfTwo,
-            name: rococoRegistry.createType('Bytes', 'statemint'),
-            symbol: rococoRegistry.createType('Bytes', 'DOT'),
-            decimals: rococoRegistry.createType('u8', 10),
-            isFrozen: falseBool,
-        };
+export const assetsMetadata = (): Promise<AssetMetadata> =>
+	Promise.resolve().then(() => {
+		const responseObj = {
+			deposit: balanceOfTwo,
+			name: rococoRegistry.createType('Bytes', 'statemint'),
+			symbol: rococoRegistry.createType('Bytes', 'DOT'),
+			decimals: rococoRegistry.createType('u8', 10),
+			isFrozen: falseBool,
+		};
 
-        return rococoRegistry.createType('AssetMetadata', responseObj);
-    });
+		return rococoRegistry.createType('AssetMetadata', responseObj);
+	});
 
 /**
  * @param assetId options are 10, 20, 30
  */
-export const assetsAccount = (assetId: number | AssetId, _address: string) => {
-    const id =
-        typeof assetId === 'number' ? assetId : parseInt(assetId.toString());
+export const assetsAccount = (
+	assetId: number | AssetId,
+	_address: string
+): PalletAssetsAssetAccount | undefined => {
+	const id =
+		typeof assetId === 'number' ? assetId : parseInt(assetId.toString());
 
-    switch (id) {
-        case 10:
-            return assetBalanceFactory[10];
-        case 20:
-            return assetBalanceFactory[20];
-        case 30:
-            return assetBalanceFactory[30];
-        default:
-            return;
-    }
+	switch (id) {
+		case 10:
+			return assetBalanceFactory[10];
+		case 20:
+			return assetBalanceFactory[20];
+		case 30:
+			return assetBalanceFactory[30];
+		default:
+			return;
+	}
 };
 
-export const assetApprovals = () =>
-    Promise.resolve().then(() => {
-        const assetObj = {
-            amount: assetTBalanceOne,
-            deposit: balanceOfTwo,
-        };
-        return rococoRegistry.createType('Option<AssetApproval>', assetObj);
-    });
+export const assetApprovals = (): Promise<Option<AssetApproval>> =>
+	Promise.resolve().then(() => {
+		const assetObj = {
+			amount: assetTBalanceOne,
+			deposit: balanceOfTwo,
+		};
+		return rococoRegistry.createType('Option<AssetApproval>', assetObj);
+	});

--- a/src/services/test-helpers/mock/assets/mockAssetData.ts
+++ b/src/services/test-helpers/mock/assets/mockAssetData.ts
@@ -104,7 +104,7 @@ export const assetsInfoKeysInjected = (): (() => Promise<AssetDetails>) => {
 	// Create a shallow copy of assetsInfo
 	const assetInfoCopy = Object.assign({}, assetsInfo);
 
-	// Inject the keys into assetsInfo
+	// Inject the keys into `assetsInfoCopy`
 	Object.assign(assetInfoCopy, {
 		keys: assetsAccountKeysAt,
 	});

--- a/src/services/test-helpers/mock/assets/mockAssetData.ts
+++ b/src/services/test-helpers/mock/assets/mockAssetData.ts
@@ -1,0 +1,148 @@
+import { AssetId } from '@polkadot/types/interfaces';
+import { PalletAssetsAssetAccount } from '@polkadot/types/lookup';
+
+import { statemintV1 } from '../../../../test-helpers/metadata/statemintMetadata';
+import { rococoRegistry } from '../../../../test-helpers/registries';
+import { createApiWithAugmentations } from '../../../../test-helpers/typeFactory';
+import { TypeFactory } from '../../../../test-helpers/typeFactory';
+
+/**
+ * This mock data uses Statemint specVersion 1
+ */
+const statemintApiV1 = createApiWithAugmentations(statemintV1);
+const statemintTypeFactory = new TypeFactory(statemintApiV1);
+
+const falseBool = rococoRegistry.createType('bool', false);
+const trueBool = rococoRegistry.createType('bool', true);
+const assetTBalanceOne = rococoRegistry.createType('u64', 10000000);
+const assetTBalanceTwo = rococoRegistry.createType('u64', 20000000);
+
+const accountIdOne = rococoRegistry.createType(
+    'AccountId',
+    '1TYrFCWxwHA5bhiXf6uLvPfG6eEvrzzL7uiPK3Yc6yHLUqc'
+);
+const accountIdTwo = rococoRegistry.createType(
+    'AccountId',
+    '13NXiLYYzVEjXxU3eaZNcrjEX9vPyVDNNpURCzK8Bj9BiCWH'
+);
+const balanceOfTwo = rococoRegistry.createType('BalanceOf', 2000000);
+
+const assetBalanceObjOne = {
+    balance: assetTBalanceOne,
+    isFrozen: falseBool,
+    sufficient: trueBool,
+};
+
+const assetBalanceObjTwo = {
+    balance: assetTBalanceTwo,
+    isFrozen: trueBool,
+    sufficient: trueBool,
+};
+
+const assetBalanceObjThree = {
+    balance: assetTBalanceTwo,
+    isFrozen: falseBool,
+    sufficient: falseBool,
+};
+
+const assetBalanceFactory = {
+    '10': assetBalanceObjOne as unknown as PalletAssetsAssetAccount,
+    '20': assetBalanceObjTwo as unknown as PalletAssetsAssetAccount,
+    '30': assetBalanceObjThree as unknown as PalletAssetsAssetAccount,
+};
+
+const assetStorageKeyOne = statemintTypeFactory.storageKey(
+    10,
+    'AssetId',
+    statemintApiV1.query.assets.asset
+);
+
+const assetStorageKeyTwo = statemintTypeFactory.storageKey(
+    20,
+    'AssetId',
+    statemintApiV1.query.assets.asset
+);
+
+const assetStorageKeyThree = statemintTypeFactory.storageKey(
+    30,
+    'AssetId',
+    statemintApiV1.query.assets.asset
+);
+
+const assetsAccountKeysAt = () =>
+    Promise.resolve().then(() => {
+        return [assetStorageKeyOne, assetStorageKeyTwo, assetStorageKeyThree];
+    });
+
+export const assetsInfo = () =>
+    Promise.resolve().then(() => {
+        const responseObj = {
+            owner: accountIdOne,
+            issue: accountIdTwo,
+            admin: accountIdTwo,
+            freezer: accountIdTwo,
+            supply: assetTBalanceOne,
+            deposit: balanceOfTwo,
+            minBalance: rococoRegistry.createType('u64', 10000),
+            isSufficient: trueBool,
+            accounts: rococoRegistry.createType('u32', 10),
+            sufficients: rococoRegistry.createType('u32', 15),
+            approvals: rococoRegistry.createType('u32', 20),
+            isFrozen: falseBool,
+        };
+
+        return rococoRegistry.createType('AssetDetails', responseObj);
+    });
+
+export const assetsInfoKeysInjected = () => {
+    // Create a shallow copy of assetsInfo
+    const assetInfoCopy = Object.assign({}, assetsInfo);
+
+    // Inject the keys into assetsInfo
+    Object.assign(assetInfoCopy, {
+        keys: assetsAccountKeysAt,
+    });
+
+    return assetInfoCopy;
+}
+
+export const assetsMetadata = () =>
+    Promise.resolve().then(() => {
+        const responseObj = {
+            deposit: balanceOfTwo,
+            name: rococoRegistry.createType('Bytes', 'statemint'),
+            symbol: rococoRegistry.createType('Bytes', 'DOT'),
+            decimals: rococoRegistry.createType('u8', 10),
+            isFrozen: falseBool,
+        };
+
+        return rococoRegistry.createType('AssetMetadata', responseObj);
+    });
+
+/**
+ * @param assetId options are 10, 20, 30
+ */
+export const assetsAccount = (assetId: number | AssetId, _address: string) => {
+    const id =
+        typeof assetId === 'number' ? assetId : parseInt(assetId.toString());
+
+    switch (id) {
+        case 10:
+            return assetBalanceFactory[10];
+        case 20:
+            return assetBalanceFactory[20];
+        case 30:
+            return assetBalanceFactory[30];
+        default:
+            return;
+    }
+};
+
+export const assetApprovals = () =>
+    Promise.resolve().then(() => {
+        const assetObj = {
+            amount: assetTBalanceOne,
+            deposit: balanceOfTwo,
+        };
+        return rococoRegistry.createType('Option<AssetApproval>', assetObj);
+    });

--- a/src/types/responses/AccountAssets.ts
+++ b/src/types/responses/AccountAssets.ts
@@ -12,11 +12,11 @@ export interface IAssetBalance {
 	/**
 	 * The units in which substrate records balances.
 	 */
-	balance: u128 | null;
+	balance: u128;
 	/**
 	 * Whether this asset class is frozen except for permissioned/admin instructions.
 	 */
-	isFrozen: bool | null;
+	isFrozen: bool;
 	/**
 	 * Whether a non-zero balance of this asset is deposit of sufficient
 	 * value to account for the state bloat associated with its balance storage. If set to
@@ -24,7 +24,7 @@ export interface IAssetBalance {
 	 * an ED in the Balances pallet or whatever else is used to control user-account state
 	 * growth).
 	 */
-	isSufficient?: bool | boolean | null;
+	isSufficient: bool | boolean;
 }
 
 /**

--- a/src/types/responses/AccountAssets.ts
+++ b/src/types/responses/AccountAssets.ts
@@ -1,7 +1,7 @@
 import { TAssetDepositBalance } from '@polkadot/types/interfaces';
 import { AssetId } from '@polkadot/types/interfaces/runtime';
+import { PalletAssetsExistenceReason } from '@polkadot/types/lookup';
 import { bool, u128 } from '@polkadot/types/primitive';
-import { PalletAssetsExistenceReason } from '@polkadot/types/lookup'
 
 import { IAt } from '.';
 

--- a/src/types/responses/AccountAssets.ts
+++ b/src/types/responses/AccountAssets.ts
@@ -1,6 +1,5 @@
 import { TAssetDepositBalance } from '@polkadot/types/interfaces';
 import { AssetId } from '@polkadot/types/interfaces/runtime';
-import { PalletAssetsExistenceReason } from '@polkadot/types/lookup';
 import { bool, u128 } from '@polkadot/types/primitive';
 
 import { IAt } from '.';
@@ -19,9 +18,13 @@ export interface IAssetBalance {
 	 */
 	isFrozen: bool | null;
 	/**
-	 * The reason for the existence of the account.
+	 * Whether a non-zero balance of this asset is deposit of sufficient
+	 * value to account for the state bloat associated with its balance storage. If set to
+	 * `true`, then non-zero balances may be stored without a `consumer` reference (and thus
+	 * an ED in the Balances pallet or whatever else is used to control user-account state
+	 * growth).
 	 */
-	reason: PalletAssetsExistenceReason | null;
+	isSufficient?: bool | boolean | null;
 }
 
 /**

--- a/src/types/responses/AccountAssets.ts
+++ b/src/types/responses/AccountAssets.ts
@@ -1,7 +1,7 @@
-import {} from '@polkadot/types';
 import { TAssetDepositBalance } from '@polkadot/types/interfaces';
 import { AssetId } from '@polkadot/types/interfaces/runtime';
 import { bool, u128 } from '@polkadot/types/primitive';
+import { PalletAssetsExistenceReason } from '@polkadot/types/lookup'
 
 import { IAt } from '.';
 
@@ -13,19 +13,15 @@ export interface IAssetBalance {
 	/**
 	 * The units in which substrate records balances.
 	 */
-	balance: u128;
+	balance: u128 | null;
 	/**
 	 * Whether this asset class is frozen except for permissioned/admin instructions.
 	 */
-	isFrozen: bool;
+	isFrozen: bool | null;
 	/**
-	 * Whether a non-zero balance of this asset is deposit of sufficient
-	 * value to account for the state bloat associated with its balance storage. If set to
-	 * `true`, then non-zero balances may be stored without a `consumer` reference (and thus
-	 * an ED in the Balances pallet or whatever else is used to control user-account state
-	 * growth).
+	 * The reason for the existence of the account.
 	 */
-	isSufficient: bool;
+	reason: PalletAssetsExistenceReason | null;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/runtime@npm:7.16.7"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 47912f0aaacd1cab2e2552aaf3e6eaffbcaf2d5ac9b07a89a12ac0d42029cb92c070b0d16f825e4277c4a34677c54d8ffe85e1f7c6feb57de58f700eec67ce2f
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.14.5, @babel/template@npm:^7.15.4, @babel/template@npm:^7.3.3":
   version: 7.15.4
   resolution: "@babel/template@npm:7.15.4"
@@ -924,18 +933,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@polkadot/api-augment@npm:7.0.1"
+"@polkadot/api-augment@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/api-augment@npm:7.2.1"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/api-base": 7.0.1
-    "@polkadot/rpc-augment": 7.0.1
-    "@polkadot/types": 7.0.1
-    "@polkadot/types-augment": 7.0.1
-    "@polkadot/types-codec": 7.0.1
+    "@babel/runtime": ^7.16.7
+    "@polkadot/api-base": 7.2.1
+    "@polkadot/rpc-augment": 7.2.1
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-augment": 7.2.1
+    "@polkadot/types-codec": 7.2.1
     "@polkadot/util": ^8.2.2
-  checksum: 2f1b17150b45133c296dd5b98f1be846b2cd5ad9e802c534a8fec4c0e95bfe59deeaca1ef7054e3ab8ff70ba44e89b4ff549329cf3cdd839396e2a1cd6788f4b
+  checksum: 103fe6cf69887a27b6287a37f2bfaf11307e7b665204908079d8d4335bf9dfc51c2619642e2a270f07f249d393df9cd5fcc8e4a4089507ab35c74527973224d1
   languageName: node
   linkType: hard
 
@@ -952,7 +961,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:7.0.1, @polkadot/api-derive@npm:^7.0.1":
+"@polkadot/api-base@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/api-base@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/rpc-core": 7.2.1
+    "@polkadot/types": 7.2.1
+    "@polkadot/util": ^8.2.2
+    rxjs: ^7.5.1
+  checksum: 7eddf57f4b39a0eac74fd25c891c5dc5250b39234839c0bd2518ddd9164d8d766dcdffa09646dfd10ce5a7af7ec7798123d05b6c002edde2a668ad47f90b8172
+  languageName: node
+  linkType: hard
+
+"@polkadot/api-derive@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/api-derive@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/api": 7.2.1
+    "@polkadot/api-augment": 7.2.1
+    "@polkadot/api-base": 7.2.1
+    "@polkadot/rpc-core": 7.2.1
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-codec": 7.2.1
+    "@polkadot/util": ^8.2.2
+    "@polkadot/util-crypto": ^8.2.2
+    rxjs: ^7.5.1
+  checksum: cf39d23a63f2c8a2806f401e351be3df4479e5d050931ade61d322dbfc29424e6acd48049d4e852c8ddf3fda531e3f25b77c5e6164637ec9df129efcc50e9ec5
+  languageName: node
+  linkType: hard
+
+"@polkadot/api-derive@npm:^7.0.1":
   version: 7.0.1
   resolution: "@polkadot/api-derive@npm:7.0.1"
   dependencies:
@@ -969,28 +1009,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@polkadot/api@npm:7.0.1"
+"@polkadot/api@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/api@npm:7.2.1"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/api-augment": 7.0.1
-    "@polkadot/api-base": 7.0.1
-    "@polkadot/api-derive": 7.0.1
+    "@babel/runtime": ^7.16.7
+    "@polkadot/api-augment": 7.2.1
+    "@polkadot/api-base": 7.2.1
+    "@polkadot/api-derive": 7.2.1
     "@polkadot/keyring": ^8.2.2
-    "@polkadot/rpc-augment": 7.0.1
-    "@polkadot/rpc-core": 7.0.1
-    "@polkadot/rpc-provider": 7.0.1
-    "@polkadot/types": 7.0.1
-    "@polkadot/types-augment": 7.0.1
-    "@polkadot/types-codec": 7.0.1
-    "@polkadot/types-create": 7.0.1
-    "@polkadot/types-known": 7.0.1
+    "@polkadot/rpc-augment": 7.2.1
+    "@polkadot/rpc-core": 7.2.1
+    "@polkadot/rpc-provider": 7.2.1
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-augment": 7.2.1
+    "@polkadot/types-codec": 7.2.1
+    "@polkadot/types-create": 7.2.1
+    "@polkadot/types-known": 7.2.1
     "@polkadot/util": ^8.2.2
     "@polkadot/util-crypto": ^8.2.2
     eventemitter3: ^4.0.7
-    rxjs: ^7.4.0
-  checksum: 5d1d62b7736047f2c3b150895bb820f1a4cede32ff4991afd827b00a0b3ad6665706e91b0f1d282517dfa3c5b8253489ca89b6c431731dddf4566e6a0469b5eb
+    rxjs: ^7.5.1
+  checksum: c7905b86747a1bd19acdd9f77e16b2d50e56c4f3eec65a6dc82e6dba6eb27ff149a3d8cee6c1a21dff9556ed1f7fe2fe940ab7de12c09fb9d0d76ee376031d56
   languageName: node
   linkType: hard
 
@@ -1071,6 +1111,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polkadot/rpc-augment@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/rpc-augment@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/rpc-core": 7.2.1
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-codec": 7.2.1
+    "@polkadot/util": ^8.2.2
+  checksum: 397ea807b6837439f1322ec10dcf07dc4495f4b1454710c3d3f217c703c41bfcbf6d0c550ec417053079ebb1901208f7a75af2e0347e86ac5dd0055636233c2c
+  languageName: node
+  linkType: hard
+
 "@polkadot/rpc-core@npm:7.0.1":
   version: 7.0.1
   resolution: "@polkadot/rpc-core@npm:7.0.1"
@@ -1082,6 +1135,20 @@ __metadata:
     "@polkadot/util": ^8.2.2
     rxjs: ^7.4.0
   checksum: 307731a92bfda9020e029f1e27744b724407f312896550937bba97b2c3098b0ca5a40a8d7df5c1aa969f142e180bbd824989691e190cfffa992654a193ba0d87
+  languageName: node
+  linkType: hard
+
+"@polkadot/rpc-core@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/rpc-core@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/rpc-augment": 7.2.1
+    "@polkadot/rpc-provider": 7.2.1
+    "@polkadot/types": 7.2.1
+    "@polkadot/util": ^8.2.2
+    rxjs: ^7.5.1
+  checksum: 4faa3e2c1668d5bfbbcd7743a820d366d52067bf72063edf9525ef02a16f2ae6ecf280e8051b41821a5196aad05ebfb4fc56b27d6b2ed5209384d0ab520078e3
   languageName: node
   linkType: hard
 
@@ -1105,15 +1172,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@polkadot/types-augment@npm:7.0.1"
+"@polkadot/rpc-provider@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/rpc-provider@npm:7.2.1"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/types": 7.0.1
-    "@polkadot/types-codec": 7.0.1
+    "@babel/runtime": ^7.16.7
+    "@polkadot/keyring": ^8.2.2
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-support": 7.2.1
     "@polkadot/util": ^8.2.2
-  checksum: 2a8ca48e04cfd676a7aa891a4d32f1fe4d9b7765af34b7b48a5087c83b9e51b34a528152dee538dc0dfe4eb050214eb6eeb1048e1bc0d0a4fe91157450d9565b
+    "@polkadot/util-crypto": ^8.2.2
+    "@polkadot/x-fetch": ^8.2.2
+    "@polkadot/x-global": ^8.2.2
+    "@polkadot/x-ws": ^8.2.2
+    eventemitter3: ^4.0.7
+    mock-socket: ^9.0.8
+    nock: ^13.2.1
+  checksum: b3ee2174ad7d576d1bfac1d768f75ed7a6272b2f212d60c905d36ba51bcc2f67f42b16dd4090b3f7eb9cbd11a4ad0215a83edb9a6241fd1a10204e26e66c5dc7
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-augment@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/types-augment@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-codec": 7.2.1
+    "@polkadot/util": ^8.2.2
+  checksum: fea27b8b52f2b5f729f9b98fcf22cdf79925686461a9466b2924ae0029767805c56d52ebb74c54913625912f088d1fa18c9991cf7951a94c692b231229b2c056
   languageName: node
   linkType: hard
 
@@ -1127,28 +1214,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@polkadot/types-create@npm:7.0.1"
+"@polkadot/types-codec@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/types-codec@npm:7.2.1"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/types-codec": 7.0.1
+    "@babel/runtime": ^7.16.7
     "@polkadot/util": ^8.2.2
-  checksum: 9180d351baac10d67523ed9fd1be6b66f8a767eb30751ecfff5a8d1d2fc396c08a02ec0e28ebb473ce09c250cf4f5d059bc563abcb467ee6f462b6960da08945
+  checksum: 25cdb8a47ccd4d1831d57910c9226dc2af379643e8110f8cdeaa652b825fdcadaad403aad451322f47296a840584e9097097307922a3d4d6f3c881c9a0eaa528
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@polkadot/types-known@npm:7.0.1"
+"@polkadot/types-create@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/types-create@npm:7.2.1"
   dependencies:
-    "@babel/runtime": ^7.16.5
-    "@polkadot/networks": ^8.2.2
-    "@polkadot/types": 7.0.1
-    "@polkadot/types-codec": 7.0.1
-    "@polkadot/types-create": 7.0.1
+    "@babel/runtime": ^7.16.7
+    "@polkadot/types-codec": 7.2.1
     "@polkadot/util": ^8.2.2
-  checksum: 91defef12ca77ba0db1207187094c771fc893285824dccbef6644582e6a3120a58c52bf8d68cf7d5ce655beb7a29a71135068e5b385c5651f57f983e3d3d5f76
+  checksum: ae8d64b845c23a674112fce13e10e0bc512c3a2770eebbc54706bd75d031f19405abc04e8b9fa613ad9b2dcc5e3834b17e3fdd82ac7723d3269f009593a2b0f9
+  languageName: node
+  linkType: hard
+
+"@polkadot/types-known@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/types-known@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
+    "@polkadot/networks": ^8.2.2
+    "@polkadot/types": 7.2.1
+    "@polkadot/types-codec": 7.2.1
+    "@polkadot/types-create": 7.2.1
+    "@polkadot/util": ^8.2.2
+  checksum: f3c908e1933e153218649a0e3ba58eb203b57ecd6c36e7cefa06dfabc4191a4ce8ef0a7e3ce56262449220091d8ee73d0e5ee226c22e30da62edb5d0af9b953c
   languageName: node
   linkType: hard
 
@@ -1172,19 +1269,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@polkadot/types@npm:7.0.1"
+"@polkadot/types-support@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/types-support@npm:7.2.1"
   dependencies:
-    "@babel/runtime": ^7.16.5
+    "@babel/runtime": ^7.16.7
+    "@polkadot/util": ^8.2.2
+  checksum: 66920d3c77680a4391aa885d28d1ec6c24a9442b66714b8361b21e09c9a81c9dfa8b1637e16e7135c5cefb6ddd4b2ad003c9c6ca35a76ae40c75bd630d0d65ba
+  languageName: node
+  linkType: hard
+
+"@polkadot/types@npm:7.2.1":
+  version: 7.2.1
+  resolution: "@polkadot/types@npm:7.2.1"
+  dependencies:
+    "@babel/runtime": ^7.16.7
     "@polkadot/keyring": ^8.2.2
-    "@polkadot/types-augment": 7.0.1
-    "@polkadot/types-codec": 7.0.1
-    "@polkadot/types-create": 7.0.1
+    "@polkadot/types-augment": 7.2.1
+    "@polkadot/types-codec": 7.2.1
+    "@polkadot/types-create": 7.2.1
     "@polkadot/util": ^8.2.2
     "@polkadot/util-crypto": ^8.2.2
-    rxjs: ^7.4.0
-  checksum: 0f35c0f6f2e0ececeeab9981f0232e72e4809b3a4ad22236b42be9e7925807a831527709291cba7f6cb11f54bb5bf9496db63bdea360f7a2e4830f6693e055d1
+    rxjs: ^7.5.1
+  checksum: f736cbef11c39bbc6669e8503a22e7ec5082ed5a4baf04ecd774fbf9cc32a7125236c0662e82691501b30d01cbdecd3376f468532e15dd43d46fa4861707de6f
   languageName: node
   linkType: hard
 
@@ -1442,7 +1549,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^7.0.1
+    "@polkadot/api": ^7.2.1
     "@polkadot/apps-config": 0.98.2-164
     "@polkadot/util-crypto": ^8.2.2
     "@polkadot/x-rxjs": ^6.11.1
@@ -7532,6 +7639,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.5.1":
+  version: 7.5.1
+  resolution: "rxjs@npm:7.5.1"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 78e3eecb1644dd83adabc8d956f879dca62eb19c8afcd6acac71cf6d94534c33ea201e65387494fdeb1332395cba081e194f5a9699d58a5d48e416b8b52372aa
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
@@ -8382,6 +8498,13 @@ fsevents@^2.3.2:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "tslib@npm:2.3.1"
+  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR does a couple of things. 

1. It refactors the asset mock data to keep code cleaner and DRY. 

2. Updates polkadot-js api to 7.2.1 which introduces some new logic. 
- The `reasons` field is now added and replaces `sufficient` as of v9160. This is because the return type of `query.assets.account()` went from `PalletAssetsAssetBalance` too `Option<PalletAssetsAssetAccount>`. 

There are 3 cases we look for, and I wrote them in the comments of the code. 

It's good to note as well, once 9160 is released we can change the structure of the response to include all the contents of `reasons`. This PR is to make it compatible with Sidecar without breaking any code, and to allow us to catch up with p.js

ref: 
https://github.com/paritytech/substrate/pull/10382/files#diff-9acae09f48474b7f0b96e7a3d66644e0ce5179464cbb0e00671ad09aa3f73a5fR88


