### PR TITLE
fix: error handling on account balances

### DIFF
--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -174,8 +174,8 @@ export class AccountsBalanceInfoService extends AbstractService {
 	}
 
 	/**
-	 * Returns HttpError with the correct err message for querying accounts balances. 
-	 * 
+	 * Returns HttpError with the correct err message for querying accounts balances.
+	 *
 	 * @param address Address that was queried
 	 * @param err Error returned from the promise
 	 */

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -45,7 +45,9 @@ export class AccountsBalanceInfoService extends AbstractService {
 				historicApi.query.balances.locks(address),
 				historicApi.query.balances.reservedBalance(address) as Promise<Balance>,
 				historicApi.query.system.accountNonce(address) as Promise<Index>,
-			]);
+			]).catch((err: Error) => {
+				throw new BadRequest(err.message);
+			});
 
 			// Values dont exist for these historic runtimes
 			const miscFrozen = api.registry.createType('Balance', 0),
@@ -75,7 +77,9 @@ export class AccountsBalanceInfoService extends AbstractService {
 				api.rpc.chain.getHeader(hash),
 				historicApi.query.system.account(address),
 				historicApi.query.balances.locks(address),
-			]);
+			]).catch((err: Error) => {
+				throw new BadRequest(err.message);
+			});
 
 			const {
 				data: { free, reserved, feeFrozen, miscFrozen },
@@ -112,7 +116,9 @@ export class AccountsBalanceInfoService extends AbstractService {
 				api.rpc.chain.getHeader(hash),
 				historicApi.query.balances.locks(address),
 				historicApi.query.system.account(address),
-			]);
+			]).catch((err: Error) => {
+				throw new BadRequest(err.message);
+			});
 
 			accountData =
 				accountInfo.data != null

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -7,7 +7,8 @@ import {
 	BlockHash,
 	Index,
 } from '@polkadot/types/interfaces';
-import { BadRequest } from 'http-errors';
+import { isEthereumAddress } from '@polkadot/util-crypto';
+import { BadRequest, HttpError } from 'http-errors';
 import { IAccountBalanceInfo } from 'src/types/responses';
 
 import { AbstractService } from '../AbstractService';
@@ -46,7 +47,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				historicApi.query.balances.reservedBalance(address) as Promise<Balance>,
 				historicApi.query.system.accountNonce(address) as Promise<Index>,
 			]).catch((err: Error) => {
-				throw new BadRequest(err.message);
+				throw this.createHttpError(address, err);
 			});
 
 			// Values dont exist for these historic runtimes
@@ -78,7 +79,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				historicApi.query.system.account(address),
 				historicApi.query.balances.locks(address),
 			]).catch((err: Error) => {
-				throw new BadRequest(err.message);
+				throw this.createHttpError(address, err);
 			});
 
 			const {
@@ -117,7 +118,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				historicApi.query.balances.locks(address),
 				historicApi.query.system.account(address),
 			]).catch((err: Error) => {
-				throw new BadRequest(err.message);
+				throw this.createHttpError(address, err);
 			});
 
 			accountData =
@@ -170,5 +171,19 @@ export class AccountsBalanceInfoService extends AbstractService {
 		} else {
 			throw new BadRequest('Account not found');
 		}
+	}
+
+	/**
+	 * Returns HttpError with the correct err message for querying accounts balances. 
+	 * 
+	 * @param address Address that was queried
+	 * @param err Error returned from the promise
+	 */
+	private createHttpError(address: string, err: Error): HttpError {
+		return isEthereumAddress(address)
+			? new BadRequest(
+					`Etheurem addresses may not be supported on this network: ${err.message}`
+			  )
+			: new BadRequest(err.message);
 	}
 }


### PR DESCRIPTION
closes: [#812](https://github.com/paritytech/substrate-api-sidecar/issues/812)

This adds some more verbose error handling in the account Balances endpoint. Since we allow ethereum addresses to pass through our validate address middleware we need to also make sure that when the ethereum address is used against a substrate network that doesnt have support for it, it will error properly with the right code, and message. 