### PR TITLE
Add benchmark checker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,12 +219,18 @@ check-benchmark:
   <<:                              *kubernetes-env
   <<:                              *collect-artifacts
   needs:
-    - benchmark
+    - job:                         benchmark
+      artifacts:                   true
   variables:
-    PROMETHEUS_URL:                "http://vm-longterm.parity-build.parity.io"
+    GITHUB_REPO:                   "paritytech/substrate-api-sidecar"
     CI_IMAGE:                      "paritytech/benchmarks:latest"
+    THRESHOLD:                     13000
+    GITHUB_TOKEN:                  $GITHUB_PR_TOKEN
   script:
-    - echo "TBD"
+    - export RESULT=$(cat artifacts/result.txt | grep AvgRequestTime | awk '{print $2}')
+    - check_single_bench_result.py -g $GITHUB_REPO
+                                   -c $THRESHOLD
+                                   -v $RESULT
 
 push-benchmark:
   stage: push-benchmark


### PR DESCRIPTION
PR adds check of the result in the `check-benchmark` job.
Currently, the average benchmark result is ~9100ms, so I suggest to set threshold on 13000ms. If this threshold exceeds then the issue will be created in the [tracker](https://github.com/paritytech/substrate-api-sidecar/issues)

Closes https://github.com/paritytech/ci_cd/issues/174