### PR TITLE
fix: update polkadot-js deps, and adjust tests for getWeight

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "test:test-release": "yarn start:test-release"
   },
   "dependencies": {
-    "@polkadot/api": "^7.14.3",
-    "@polkadot/apps-config": "^0.110.1",
+    "@polkadot/api": "^7.15.1",
+    "@polkadot/apps-config": "^0.111.1",
     "@polkadot/util-crypto": "^8.7.1",
     "@substrate/calc": "^0.2.8",
     "argparse": "^2.0.1",
@@ -78,11 +78,11 @@
     "tsc-watch": "^4.4.0"
   },
   "resolutions": {
-    "@polkadot/api": "7.14.3",
+    "@polkadot/api": "7.15.1",
     "@polkadot/keyring": "8.7.1",
     "@polkadot/networks": "8.7.1",
-    "@polkadot/types": "7.14.3",
-    "@polkadot/types-known": "7.14.3",
+    "@polkadot/types": "7.15.1",
+    "@polkadot/types-known": "7.15.1",
     "@polkadot/util": "8.7.1",
     "@polkadot/util-crypto": "8.7.1",
     "@polkadot/wasm-crypto": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,12 +450,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bifrost-finance/type-definitions@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@bifrost-finance/type-definitions@npm:1.4.0"
+"@bifrost-finance/type-definitions@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@bifrost-finance/type-definitions@npm:1.5.0"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-38
-  checksum: 11f1918bbf425def8650a9b80e17f7dcae83fa3abf4e9f1f499dbfb18b8e43e5f1cbffc5f751aee4d285ee947ef46ae5863934025347cbd45a0cb99467fa36a3
+  checksum: 5972a232e08739da6a8885b08d4cef7316b0e5c19c50c8d5a6806d0c544cd34636d578eb9bc51a1efdb0a4070533ed845fc6f84f7f117acf7b5080c68a596c0c
   languageName: node
   linkType: hard
 
@@ -834,6 +834,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mangata-finance/types@npm:^0.0.12":
+  version: 0.0.12
+  resolution: "@mangata-finance/types@npm:0.0.12"
+  dependencies:
+    "@polkadot/api": ^7.13.1
+  checksum: b4b8fa7d938fe3043e8bc07adccf49b2bcd017a185f10251c3de8c0efbc3fdf571ce2ab3d54f20b659b0e1f0b32f68274d25f8adc31d08bfe3cdbf0050116bb2
+  languageName: node
+  linkType: hard
+
 "@metaverse-network-sdk/type-definitions@npm:^0.0.1-13":
   version: 0.0.1-13
   resolution: "@metaverse-network-sdk/type-definitions@npm:0.0.1-13"
@@ -919,12 +928,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parallel-finance/type-definitions@npm:1.5.9":
-  version: 1.5.9
-  resolution: "@parallel-finance/type-definitions@npm:1.5.9"
+"@parallel-finance/type-definitions@npm:1.6.5":
+  version: 1.6.5
+  resolution: "@parallel-finance/type-definitions@npm:1.6.5"
   dependencies:
     "@open-web3/orml-type-definitions": ^1.0.2-3
-  checksum: f290d86e41ade8dc1f26aca0ba0d41d239dc2a81e73ad259c54bf535df38e5e85cf8ce7f110db4a6aa1c8181ee0ac818060dbfedcda24a12b222fb69b8871d68
+  checksum: d6cded6822c276ca5a2b4435585dd2c3059643cb0e5c574f4f33ccf6e7c75eb4f51c52c7d5e89ddeba25a93c9d59a473d504a9604e32cf915d9062b5a1a5e07a
   languageName: node
   linkType: hard
 
@@ -935,84 +944,84 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/api-augment@npm:7.14.3"
+"@polkadot/api-augment@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/api-augment@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/api-base": 7.14.3
-    "@polkadot/rpc-augment": 7.14.3
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-augment": 7.14.3
-    "@polkadot/types-codec": 7.14.3
+    "@polkadot/api-base": 7.15.1
+    "@polkadot/rpc-augment": 7.15.1
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-augment": 7.15.1
+    "@polkadot/types-codec": 7.15.1
     "@polkadot/util": ^8.7.1
-  checksum: 823974f83ee98f0b1f627ee04acc02d6c7e2426c0de1ecf98b6a886ded67b6020d17a3f039f5182cbb24d1fe58e71bc3b68278ab6af2dbe8a7ca632eb048232c
+  checksum: b9fca9867450238eedb698e08288c7e58239ba0e90cf1952f65087a81896ab8d370b2bccc114760ff672ac3fac9b07b36f49b00a8c9ea1b3f30129f6470bea40
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/api-base@npm:7.14.3"
+"@polkadot/api-base@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/api-base@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/rpc-core": 7.14.3
-    "@polkadot/types": 7.14.3
+    "@polkadot/rpc-core": 7.15.1
+    "@polkadot/types": 7.15.1
     "@polkadot/util": ^8.7.1
     rxjs: ^7.5.5
-  checksum: abd4be8054a3f7115d9af13db469f51452aec4cfcfeda32b768b4650ab3800901847a8d3b373f8b3c1aa1944bd6103c68ae0a5fd47f52b49e84f60386f15efba
+  checksum: e97476137d1f7083d5472579635d2cabc38b3f6b9d66b2b25395926e77d4c24e8198b44ede11933e4d115e55d658ea1ed461b3cbc8db17489c9a341b29b49d4c
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:7.14.3, @polkadot/api-derive@npm:^7.13.1":
-  version: 7.14.3
-  resolution: "@polkadot/api-derive@npm:7.14.3"
+"@polkadot/api-derive@npm:7.15.1, @polkadot/api-derive@npm:^7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/api-derive@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/api": 7.14.3
-    "@polkadot/api-augment": 7.14.3
-    "@polkadot/api-base": 7.14.3
-    "@polkadot/rpc-core": 7.14.3
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-codec": 7.14.3
+    "@polkadot/api": 7.15.1
+    "@polkadot/api-augment": 7.15.1
+    "@polkadot/api-base": 7.15.1
+    "@polkadot/rpc-core": 7.15.1
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-codec": 7.15.1
     "@polkadot/util": ^8.7.1
     "@polkadot/util-crypto": ^8.7.1
     rxjs: ^7.5.5
-  checksum: d98ced65cfe71d6b46c19fbcaabe4dcbd26240fbf91f33088c9a7441e72573c43a1d69c80452167f81c049c4729a39652feb377333cee06f2fc6e8b7da8d2b2b
+  checksum: 25b3d2ce6f8698720839e8fb079744385730dd5a6ef103cd0d1af7a8726091318fe8b025dfe889943770d61f4e93238a7420d76305806eb38101c6c6d012429b
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/api@npm:7.14.3"
+"@polkadot/api@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/api@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/api-augment": 7.14.3
-    "@polkadot/api-base": 7.14.3
-    "@polkadot/api-derive": 7.14.3
+    "@polkadot/api-augment": 7.15.1
+    "@polkadot/api-base": 7.15.1
+    "@polkadot/api-derive": 7.15.1
     "@polkadot/keyring": ^8.7.1
-    "@polkadot/rpc-augment": 7.14.3
-    "@polkadot/rpc-core": 7.14.3
-    "@polkadot/rpc-provider": 7.14.3
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-augment": 7.14.3
-    "@polkadot/types-codec": 7.14.3
-    "@polkadot/types-create": 7.14.3
-    "@polkadot/types-known": 7.14.3
+    "@polkadot/rpc-augment": 7.15.1
+    "@polkadot/rpc-core": 7.15.1
+    "@polkadot/rpc-provider": 7.15.1
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-augment": 7.15.1
+    "@polkadot/types-codec": 7.15.1
+    "@polkadot/types-create": 7.15.1
+    "@polkadot/types-known": 7.15.1
     "@polkadot/util": ^8.7.1
     "@polkadot/util-crypto": ^8.7.1
     eventemitter3: ^4.0.7
     rxjs: ^7.5.5
-  checksum: 37b10d00fadb877d9251c01faa679e80faf9ce3bf6b129ff23ec8951f536993dc8e760e78499d044e679de8dfea9bdfdb6956b891c07d8e7d0c6784f6d433cf7
+  checksum: 6960685b9169e07a124aaeb14a335c6f161a364603773e828141001d780e11d62c6f68fa4b07227f065450004f237a447260ff89e81012a9186992c8499073b5
   languageName: node
   linkType: hard
 
-"@polkadot/apps-config@npm:^0.110.1":
-  version: 0.110.1
-  resolution: "@polkadot/apps-config@npm:0.110.1"
+"@polkadot/apps-config@npm:^0.111.1":
+  version: 0.111.1
+  resolution: "@polkadot/apps-config@npm:0.111.1"
   dependencies:
     "@acala-network/type-definitions": ^4.0.1
     "@babel/runtime": ^7.17.8
-    "@bifrost-finance/type-definitions": 1.4.0
+    "@bifrost-finance/type-definitions": 1.5.0
     "@crustio/type-definitions": 1.2.0
     "@darwinia/types": 2.7.2
     "@digitalnative/type-definitions": 1.1.27
@@ -1022,18 +1031,19 @@ __metadata:
     "@interlay/interbtc-types": 1.5.10
     "@kiltprotocol/type-definitions": 0.1.23
     "@laminar/type-definitions": 0.3.1
+    "@mangata-finance/types": ^0.0.12
     "@metaverse-network-sdk/type-definitions": ^0.0.1-13
-    "@parallel-finance/type-definitions": 1.5.9
+    "@parallel-finance/type-definitions": 1.6.5
     "@phala/typedefs": 0.2.30
-    "@polkadot/api": ^7.13.1
-    "@polkadot/api-derive": ^7.13.1
-    "@polkadot/networks": ^8.6.1
-    "@polkadot/types": ^7.13.1
-    "@polkadot/util": ^8.6.1
-    "@polkadot/x-fetch": ^8.6.1
+    "@polkadot/api": ^7.15.1
+    "@polkadot/api-derive": ^7.15.1
+    "@polkadot/networks": ^8.7.1
+    "@polkadot/types": ^7.15.1
+    "@polkadot/util": ^8.7.1
+    "@polkadot/x-fetch": ^8.7.1
     "@polymathnetwork/polymesh-types": 0.0.2
     "@snowfork/snowbridge-types": 0.2.7
-    "@sora-substrate/type-definitions": 1.8.1
+    "@sora-substrate/type-definitions": 1.8.6
     "@subsocial/types": 0.6.5
     "@unique-nft/types": 0.3.1
     "@zeitgeistpm/type-defs": 0.4.5
@@ -1043,7 +1053,7 @@ __metadata:
     moonbeam-types-bundle: 2.0.3
     pontem-types-bundle: 1.0.15
     rxjs: ^7.5.5
-  checksum: 6341c6554f455831e1a09896818924e18297c931982a39ca922e5e62f8e2adce3a8bef5acf18cb34ccde93318db2095cdabd16183e51e8f1270ab9bd31c06364
+  checksum: 8b1e071c9680968e37be7fb777fe02a8103bd0c6fc8b2c07dd9b66d65f179acfbde0468fd76cd4e8eb2421b3513cec82c3ef3ff3adb13d062e5a6b98ca1ecd11
   languageName: node
   linkType: hard
 
@@ -1072,41 +1082,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/rpc-augment@npm:7.14.3"
+"@polkadot/rpc-augment@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/rpc-augment@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/rpc-core": 7.14.3
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-codec": 7.14.3
+    "@polkadot/rpc-core": 7.15.1
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-codec": 7.15.1
     "@polkadot/util": ^8.7.1
-  checksum: 13b75445691a34ccbdd51de39d9fee85c5dc9899dda5cb31bcf25c31370d173c7351c09c3b16cfa3190108cab56e2828c5906cc865d7143fb0ed665add70bd1f
+  checksum: 39558203cad2f15e84d90eb0132def58e590e9eb3fa055041247f76dea10cb236ee59ba0cf9efd101e28af5d274653288170a2d158fe77f2c74fecf9842d254f
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/rpc-core@npm:7.14.3"
+"@polkadot/rpc-core@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/rpc-core@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/rpc-augment": 7.14.3
-    "@polkadot/rpc-provider": 7.14.3
-    "@polkadot/types": 7.14.3
+    "@polkadot/rpc-augment": 7.15.1
+    "@polkadot/rpc-provider": 7.15.1
+    "@polkadot/types": 7.15.1
     "@polkadot/util": ^8.7.1
     rxjs: ^7.5.5
-  checksum: 927432a70ac528f0ef8ee2499bbd6ef947e6ef66e4bcd779a4d834435e279fdddf9cfa7c07dc84939c53014d7d118d1048a9ca112c6a54ca1dbcf300414ccf78
+  checksum: c42a50a83c8cdec5464cfe32051485512831f8799c680fb9559376649b05634b82ffab2389a1d9a5594b799e5feb127b0ee853e26c9c650365f4deba2d0cc43a
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/rpc-provider@npm:7.14.3"
+"@polkadot/rpc-provider@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/rpc-provider@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
     "@polkadot/keyring": ^8.7.1
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-support": 7.14.3
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-support": 7.15.1
     "@polkadot/util": ^8.7.1
     "@polkadot/util-crypto": ^8.7.1
     "@polkadot/x-fetch": ^8.7.1
@@ -1116,54 +1126,54 @@ __metadata:
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.2
     nock: ^13.2.4
-  checksum: be0d57f4fcfcc45749bf36f5bee4c43dd66c1f714abdae00cfe3354f353601c17b079ef1c0f78fc994b480805484a037d30dd689a21930b410274882b8f6c68b
+  checksum: cb54ed6ff5bfea7606ba8bd96c59f11f34eca835c52130aff3c671c73b73070218d19143195ba445c39d55870086e9da894fe12d0cb186867407ed182f29b3f0
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/types-augment@npm:7.14.3"
+"@polkadot/types-augment@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/types-augment@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-codec": 7.14.3
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-codec": 7.15.1
     "@polkadot/util": ^8.7.1
-  checksum: 29cf70fa066f7ee865f877b52bd8a937f0a42a1f0b23319f68be5a04f7c97a74cfabe99532e18100434780277224ef420fe0978486a898ec5c0d59c04788a6ef
+  checksum: 114546294b2ac16d517f821564d51c3c0d9be1a516afdbf428a078a40fe86887ee5bbacceebad5259ad36f107358e9da86f5921ae85e8b74a56267f4157ce84b
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/types-codec@npm:7.14.3"
+"@polkadot/types-codec@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/types-codec@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
     "@polkadot/util": ^8.7.1
-  checksum: dd686d5f56139142506baf75adf7503c4dae695d8466df15ff5c99b99c7bdb189473a4663d7f8b89aeb581fa553020f1c40f994f78b346722e4595b2feb151c3
+  checksum: 001178689b4d36a4c5b317c46aca177b183ba14b2f534df88995fd9755d936c73f7cbc0d0386f42c1c384e305a9394e80c95528e8d5de677005faa871efff763
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/types-create@npm:7.14.3"
+"@polkadot/types-create@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/types-create@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
-    "@polkadot/types-codec": 7.14.3
+    "@polkadot/types-codec": 7.15.1
     "@polkadot/util": ^8.7.1
-  checksum: 22bcf804f4d55de547e13029481124697d0373dfbdcec163950b719dfdbae84c9af9820047ad991924a7966d30b59dd139a4ec2101b9e7deffa48c8a33606571
+  checksum: 7a45db13c0f098b6fc83977ed2e16ff804082d5b3ead763e5b6f3bdc405e37f02d9042a97a175128819d6b0954ac3db8a1f05126491def920b1e737209af4d1b
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/types-known@npm:7.14.3"
+"@polkadot/types-known@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/types-known@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
     "@polkadot/networks": ^8.7.1
-    "@polkadot/types": 7.14.3
-    "@polkadot/types-codec": 7.14.3
-    "@polkadot/types-create": 7.14.3
+    "@polkadot/types": 7.15.1
+    "@polkadot/types-codec": 7.15.1
+    "@polkadot/types-create": 7.15.1
     "@polkadot/util": ^8.7.1
-  checksum: 452d71261d24a0e661d4b9432f0a0bc2d9ccde41938388c14fa94461541645e189460ec0ee396f1252c833da70e23cea61e6ef874ae8fa48a899cf6b273281d9
+  checksum: 9c537352382aba733d1975094f116c7522a105d419d029e25a5a6c457653b6ef0231cd8eaa1a424af2cc085e03597a4af5626abb9e17fbe709952a14b3a4ba40
   languageName: node
   linkType: hard
 
@@ -1177,29 +1187,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/types-support@npm:7.14.3"
+"@polkadot/types-support@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/types-support@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
     "@polkadot/util": ^8.7.1
-  checksum: a7687a34d7565489e0b51c552e603c66c003861d36d4b2a88c7a94b822f4dfb8d482883f2763a4488e86a674463e3e92e194308c3f6b59379d11b7b3f5d6dfc3
+  checksum: 2894e3ee948349bee07cc31d7a86ab38f6c82366af67a7ec69733611623a938be5601162366d4c4a3b63e8d29e2c5ea35c33ef263e4b494458065ea619d0328c
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:7.14.3":
-  version: 7.14.3
-  resolution: "@polkadot/types@npm:7.14.3"
+"@polkadot/types@npm:7.15.1":
+  version: 7.15.1
+  resolution: "@polkadot/types@npm:7.15.1"
   dependencies:
     "@babel/runtime": ^7.17.8
     "@polkadot/keyring": ^8.7.1
-    "@polkadot/types-augment": 7.14.3
-    "@polkadot/types-codec": 7.14.3
-    "@polkadot/types-create": 7.14.3
+    "@polkadot/types-augment": 7.15.1
+    "@polkadot/types-codec": 7.15.1
+    "@polkadot/types-create": 7.15.1
     "@polkadot/util": ^8.7.1
     "@polkadot/util-crypto": ^8.7.1
     rxjs: ^7.5.5
-  checksum: 88db80efd23e14cb1bb29dd1c42f3d30e493d7d8a982f17aaa3084b0389e0af416c0b783cd0825647bfd3c2abc710e1cb92c8a9acd1d1881a56566b83eb7d0ad
+  checksum: ec8ca507a75a548df196f79bd744485bb2f1ba9058402c969be9299db45a63628ceca52d7588281ff4f6762809e297916d566b8c0869e92f1b6f4bca640b109f
   languageName: node
   linkType: hard
 
@@ -1286,7 +1296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^8.6.1, @polkadot/x-fetch@npm:^8.7.1":
+"@polkadot/x-fetch@npm:^8.7.1":
   version: 8.7.1
   resolution: "@polkadot/x-fetch@npm:8.7.1"
   dependencies:
@@ -1412,12 +1422,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sora-substrate/type-definitions@npm:1.8.1":
-  version: 1.8.1
-  resolution: "@sora-substrate/type-definitions@npm:1.8.1"
+"@sora-substrate/type-definitions@npm:1.8.6":
+  version: 1.8.6
+  resolution: "@sora-substrate/type-definitions@npm:1.8.6"
   dependencies:
     "@open-web3/orml-type-definitions": ^0.9.4-35
-  checksum: e228117f0f5b10a3ea98b451216529771ee224c9cd6236d8cfc7b57f80bf2c87dadd18e051dab006dd61ba68dfa31ad8ccc5158e75a287e7f480aa55aee2ec70
+  checksum: 0a543e7405d1ab5c551cf1b77a28359a9c33d1236390fd907ea7b857b9781408373808ab97216e445b3510028873d508e8e7f48f755f3f618a3ae393ffb7b9cd
   languageName: node
   linkType: hard
 
@@ -1459,8 +1469,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^7.14.3
-    "@polkadot/apps-config": ^0.110.1
+    "@polkadot/api": ^7.15.1
+    "@polkadot/apps-config": ^0.111.1
     "@polkadot/util-crypto": ^8.7.1
     "@substrate/calc": ^0.2.8
     "@substrate/dev": ^0.5.7


### PR DESCRIPTION
Updates the following deps:
    @polkadot/api: ^7.15.1,
    @polkadot/apps-config: ^0.111.1,
    
This PR also fixes a test regarding `getWeights` in `BlocksService`. It removes the `createApiWithAugmentation` and replaces it with a set of known weights without having to generate it through injected metadata (which has been deprecated for what its worth ie `api.injectMetadata`). 
