### PR TITLE
fix(scripts): jest pass-fail bug

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -19,6 +19,7 @@ import { IChainConfig } from './types';
 const defaultJestOpts = {
 	proc: 'jest',
 	resolver: 'PASS',
+	resolverJestErr: 'FAIL',
 };
 
 export const defaultSasStartOpts = {

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -83,12 +83,12 @@ export const killAll = (procs: ProcsType): void => {
 export const launchProcess = (
 	cmd: string,
 	procs: ProcsType,
-	{ proc, resolver, resolverStartupErr, args }: IProcOpts
+	{ proc, resolver, resolverJestErr, resolverStartupErr, args }: IProcOpts
 ): Promise<StatusCode> => {
 	return new Promise<StatusCode>((resolve, reject) => {
 		const { Success, Failed } = StatusCode;
-
 		const command = cmd || 'yarn';
+		let jestStatus = Success;
 
 		procs[proc] = spawn(command, args, { detached: true });
 
@@ -103,12 +103,17 @@ export const launchProcess = (
 		procs[proc].stderr.on('data', (data: Buffer) => {
 			console.error(data.toString().trim());
 
+			if (resolverJestErr && data.toString().trim().includes(resolverJestErr)) {
+				jestStatus = Failed;
+			}
+
 			if (resolverStartupErr && data.toString().includes(resolverStartupErr)) {
 				resolve(Failed);
 			}
 		});
 
 		procs[proc].on('close', () => {
+			if (jestStatus === Failed) resolve(Failed);
 			resolve(Success);
 		});
 

--- a/scripts/sidecarScriptApi.ts
+++ b/scripts/sidecarScriptApi.ts
@@ -107,7 +107,7 @@ export const launchProcess = (
 				jestStatus = Failed;
 			}
 
-			if (resolverStartupErr && data.toString().includes(resolverStartupErr)) {
+			if (resolverStartupErr && data.toString().trim().includes(resolverStartupErr)) {
 				resolve(Failed);
 			}
 		});

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -34,5 +34,6 @@ export interface IProcOpts {
 	proc: string;
 	resolver: string;
 	resolverStartupErr?: string;
+	resolverJestErr?: string;
 	args: string[];
 }


### PR DESCRIPTION
Currently there was an issue when running the e2e tests where it wouldn't properly catch whether or not a test failed. It would always assume it passed and resolve a success code. This PR fixes that and allows the script to properly handle the error code on a failed test. 