### PR TITLE
ci: increase benchmark threshold

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,7 @@ check-benchmark:
   variables:
     GITHUB_REPO:                   "paritytech/substrate-api-sidecar"
     CI_IMAGE:                      "paritytech/benchmarks:latest"
-    THRESHOLD:                     13000
+    THRESHOLD:                     35000
     GITHUB_TOKEN:                  $GITHUB_PR_TOKEN
   script:
     - export RESULT=$(cat artifacts/result.txt | grep AvgRequestTime | awk '{print $2}')


### PR DESCRIPTION
This increases the benchmark threshold to 35000. Some calls may take some time to resolve since the benchmarks focus on stressing the server. This will also stop us from overloading our issues with benchmark regressions. If its over 35000 then I can take the time to investigate the current version. 