### PR TITLE
fix: set minCalcFee runtime to 1058 for kusama

### DIFF
--- a/e2e-tests/endpoints/kusama/blocks/2101439.json
+++ b/e2e-tests/endpoints/kusama/blocks/2101439.json
@@ -1,0 +1,212 @@
+{
+	"number": "2101439",
+	"hash": "0x8b0fbe687c87fc7c18c21fd255f0010cffcf34a35cb67187d88d110612c50d65",
+	"parentHash": "0x0d11d6871a30514f7923b663285b6c28de2f9ffc8dacad067bcdb22c7db97fe2",
+	"stateRoot": "0x8d3f477766475e39341ef5adcd328dfff4190f1beb2f5f5b5c130156f5e6ce11",
+	"extrinsicsRoot": "0x0d044b05908b803745d9a34c6161f43ad2875ea5fc601e65072abf7c5119a89d",
+	"authorId": "Ed6JFR7JmeGtmrubAbXtJRjq9FPWhGRWMdmYnLRcsqaabT8",
+	"logs": [
+		{
+			"type": "PreRuntime",
+			"index": "6",
+			"value": [
+				"0x42414245",
+				"0x0240000000e614c70f00000000"
+			]
+		},
+		{
+			"type": "Seal",
+			"index": "5",
+			"value": [
+				"0x42414245",
+				"0x800d6fc74842801971bf17bcd414d600f06a9509af881c52725143845805281fa98171ebe7d7c091454060da563f68e2a212f2d8360f04b8af2595400ed7218f"
+			]
+		}
+	],
+	"onInitialize": {
+		"events": []
+	},
+	"extrinsics": [
+		{
+			"method": {
+				"pallet": "timestamp",
+				"method": "set"
+			},
+			"signature": null,
+			"nonce": null,
+			"args": {
+				"now": "1588231524000"
+			},
+			"tip": null,
+			"hash": "0x834bd675513f7121def5132921608c7ba03a52f5f58c1c49e4b4e6aee4720f03",
+			"info": {},
+			"era": {
+				"immortalEra": "0x00"
+			},
+			"events": [
+				{
+					"method": {
+						"pallet": "system",
+						"method": "ExtrinsicSuccess"
+					},
+					"data": [
+						{
+							"weight": "10000000",
+							"class": "Mandatory",
+							"paysFee": true
+						}
+					]
+				}
+			],
+			"success": true,
+			"paysFee": false
+		},
+		{
+			"method": {
+				"pallet": "finalityTracker",
+				"method": "finalHint"
+			},
+			"signature": null,
+			"nonce": null,
+			"args": {
+				"hint": "2101436"
+			},
+			"tip": null,
+			"hash": "0x3f1acf92449112d2a4b1e121656b0dd0343c7947b342940cdc98aa1988c1086d",
+			"info": {},
+			"era": {
+				"immortalEra": "0x00"
+			},
+			"events": [
+				{
+					"method": {
+						"pallet": "system",
+						"method": "ExtrinsicSuccess"
+					},
+					"data": [
+						{
+							"weight": "10000000",
+							"class": "Mandatory",
+							"paysFee": true
+						}
+					]
+				}
+			],
+			"success": true,
+			"paysFee": false
+		},
+		{
+			"method": {
+				"pallet": "parachains",
+				"method": "setHeads"
+			},
+			"signature": null,
+			"nonce": null,
+			"args": {
+				"heads": []
+			},
+			"tip": null,
+			"hash": "0xcf52705d1ade64fc0b05859ac28358c0770a217dd76b75e586ae848c56ae810d",
+			"info": {},
+			"era": {
+				"immortalEra": "0x00"
+			},
+			"events": [
+				{
+					"method": {
+						"pallet": "system",
+						"method": "ExtrinsicSuccess"
+					},
+					"data": [
+						{
+							"weight": "1000000000",
+							"class": "Mandatory",
+							"paysFee": true
+						}
+					]
+				}
+			],
+			"success": true,
+			"paysFee": false
+		},
+		{
+			"method": {
+				"pallet": "balances",
+				"method": "transfer"
+			},
+			"signature": {
+				"signature": "0x151e442827a548221fc4f24eaf144267072b97d3fd67142e238b7c19f30f444beaca1415aae5299e0068899c5678eba43ed9edf37cf6057bc68552651a28ac00",
+				"signer": "GwbM2Sjuk5ewx9ZVcpuoQDyJzkgLEyiz7GfyCvccGfyDHo3"
+			},
+			"nonce": "2",
+			"args": {
+				"dest": "EEWyMLHgwtemr48spFNnS3U2XjaYswqAYAbadx2jr9ppp4X",
+				"value": "4999970000000000"
+			},
+			"tip": "20000000000",
+			"hash": "0xee5af1565795b5f0282b029c2c49a6a1f7be5f53ff5cc3ca2986640f06bc4f7a",
+			"info": {
+				"weight": "200000000",
+				"class": "Normal",
+				"partialFee": "10000000000"
+			},
+			"era": {
+				"mortalEra": [
+					"1024",
+					"185"
+				]
+			},
+			"events": [
+				{
+					"method": {
+						"pallet": "balances",
+						"method": "Transfer"
+					},
+					"data": [
+						"GwbM2Sjuk5ewx9ZVcpuoQDyJzkgLEyiz7GfyCvccGfyDHo3",
+						"EEWyMLHgwtemr48spFNnS3U2XjaYswqAYAbadx2jr9ppp4X",
+						"4999970000000000"
+					]
+				},
+				{
+					"method": {
+						"pallet": "treasury",
+						"method": "Deposit"
+					},
+					"data": [
+						"24000000000"
+					]
+				},
+				{
+					"method": {
+						"pallet": "balances",
+						"method": "Deposit"
+					},
+					"data": [
+						"Ed6JFR7JmeGtmrubAbXtJRjq9FPWhGRWMdmYnLRcsqaabT8",
+						"6000000000"
+					]
+				},
+				{
+					"method": {
+						"pallet": "system",
+						"method": "ExtrinsicSuccess"
+					},
+					"data": [
+						{
+							"weight": "200000000",
+							"class": "Normal",
+							"paysFee": true
+						}
+					]
+				}
+			],
+			"success": true,
+			"paysFee": true
+		}
+	],
+	"onFinalize": {
+		"events": []
+	},
+	"finalized": true
+}

--- a/e2e-tests/endpoints/kusama/blocks/index.ts
+++ b/e2e-tests/endpoints/kusama/blocks/index.ts
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import block9253 from './9253.json';
+import block2101439 from './2101439.json';
 import block2350438 from './2350438.json';
 import block2684767 from './2684767.json';
 import block2713513 from './2713513.json';
@@ -51,6 +52,7 @@ import block11800000 from './11800000.json';
 
 export const kusamaBlockEndpoints = [
 	['/blocks/9253', JSON.stringify(block9253)], //v1020
+	['/blocks/2101439', JSON.stringify(block2101439)], //v1058
 	['/blocks/2350438', JSON.stringify(block2350438)], //v1062
 	['/blocks/2684767', JSON.stringify(block2684767)], //v2005
 	['/blocks/2713513', JSON.stringify(block2713513)], //v2007

--- a/src/chains-config/kusamaControllers.ts
+++ b/src/chains-config/kusamaControllers.ts
@@ -46,7 +46,7 @@ export const kusamaControllers: ControllerConfig = {
 	],
 	options: {
 		finalizes: true,
-		minCalcFeeRuntime: 1062,
+		minCalcFeeRuntime: 1058,
 		blockStore: initLRUCache(),
 	},
 };


### PR DESCRIPTION
closes: [#429](https://github.com/paritytech/substrate-api-sidecar/issues/429)

The lowest runtime which supports fee calculation given payment::queryInfo is 1058 for kusama. 
This updates that, and adds an e2e test for it. 