### PR TITLE
chore(deps): update polkadot-js api, and util-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "update-pjs-deps": "substrate-update-pjs-deps && yarn"
   },
   "dependencies": {
-    "@polkadot/api": "^8.11.1",
-    "@polkadot/util-crypto": "^9.7.1",
+    "@polkadot/api": "^8.11.2",
+    "@polkadot/util-crypto": "^9.7.2",
     "@substrate/calc": "^0.2.8",
     "argparse": "^2.0.1",
     "confmgr": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "update-pjs-deps": "substrate-update-pjs-deps && yarn"
   },
   "dependencies": {
-    "@polkadot/api": "^8.10.1",
-    "@polkadot/util-crypto": "^9.6.2",
+    "@polkadot/api": "^8.11.1",
+    "@polkadot/util-crypto": "^9.7.1",
     "@substrate/calc": "^0.2.8",
     "argparse": "^2.0.1",
     "confmgr": "1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,409 +780,409 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/api-augment@npm:8.11.1"
+"@polkadot/api-augment@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/api-augment@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/api-base": 8.11.1
-    "@polkadot/rpc-augment": 8.11.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-augment": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/util": ^9.7.1
-  checksum: fa11b7951198b5beea5361df749efe17322d41b765d5b6bd7413bd902b428c12cab91cbd2fd10c708a3cfdc300a751d3b6e3a065d857bd6dc1e372b1562fbed4
+    "@polkadot/api-base": 8.11.2
+    "@polkadot/rpc-augment": 8.11.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-augment": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/util": ^9.7.2
+  checksum: bde458ae4302b4477b7873765b9be90cdf3be1cc01bd4fec4dadf14346ef08570ee4a8839cf5637a1d92be1a77f4ff8536eadac6a9afac1cc94632883c32814e
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/api-base@npm:8.11.1"
+"@polkadot/api-base@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/api-base@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/rpc-core": 8.11.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/util": ^9.7.1
+    "@polkadot/rpc-core": 8.11.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/util": ^9.7.2
     rxjs: ^7.5.5
-  checksum: 5d49a2a222a064fb2c9544fb50b368f52d6d347fa00451eaa2067af543479837803afb254b36f3486b9aa5ba6842e108bdd323e30e9d04682f681677aff1f2a5
+  checksum: fae8e94d34a76302fb0fef2f3e04fdd8bc1eebbc5df80dd463b0c6dce54342a05bbdd0684210dc7f7de25a6db5ab8d06ffa2adc2e7eee823b9d4c3850ba6ea54
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/api-derive@npm:8.11.1"
+"@polkadot/api-derive@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/api-derive@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/api": 8.11.1
-    "@polkadot/api-augment": 8.11.1
-    "@polkadot/api-base": 8.11.1
-    "@polkadot/rpc-core": 8.11.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/util": ^9.7.1
-    "@polkadot/util-crypto": ^9.7.1
+    "@polkadot/api": 8.11.2
+    "@polkadot/api-augment": 8.11.2
+    "@polkadot/api-base": 8.11.2
+    "@polkadot/rpc-core": 8.11.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/util": ^9.7.2
+    "@polkadot/util-crypto": ^9.7.2
     rxjs: ^7.5.5
-  checksum: c8d4f286672c2cde80c528b41f852a3e2809fce8e35cf7e6ca74d6f45d4c4db7c70089df3ce983ba2b48c8ea6c448579cc13dcc17c82d74747888e5c2c23288d
+  checksum: e9ee8ac351e07eec749b5d1c2f6aab4072386dd8a5e298b1686aafd264aa1221dae8da20210598b22e1b3bc6c12746c0a8bfe607b8e297b01b1511aa1f67abbf
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:8.11.1, @polkadot/api@npm:^8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/api@npm:8.11.1"
+"@polkadot/api@npm:8.11.2, @polkadot/api@npm:^8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/api@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/api-augment": 8.11.1
-    "@polkadot/api-base": 8.11.1
-    "@polkadot/api-derive": 8.11.1
-    "@polkadot/keyring": ^9.7.1
-    "@polkadot/rpc-augment": 8.11.1
-    "@polkadot/rpc-core": 8.11.1
-    "@polkadot/rpc-provider": 8.11.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-augment": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/types-create": 8.11.1
-    "@polkadot/types-known": 8.11.1
-    "@polkadot/util": ^9.7.1
-    "@polkadot/util-crypto": ^9.7.1
+    "@polkadot/api-augment": 8.11.2
+    "@polkadot/api-base": 8.11.2
+    "@polkadot/api-derive": 8.11.2
+    "@polkadot/keyring": ^9.7.2
+    "@polkadot/rpc-augment": 8.11.2
+    "@polkadot/rpc-core": 8.11.2
+    "@polkadot/rpc-provider": 8.11.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-augment": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/types-create": 8.11.2
+    "@polkadot/types-known": 8.11.2
+    "@polkadot/util": ^9.7.2
+    "@polkadot/util-crypto": ^9.7.2
     eventemitter3: ^4.0.7
     rxjs: ^7.5.5
-  checksum: d8805863d80d9bfca149b4e7b28cd314d8144ef2f684dba92bd8345b068952c694770841978497d4153476e7777d1f6d8a68207c062da97541b80fba72642523
+  checksum: 174585a652de37bc6b2b5fd05e425b6a154552ecec469cb1999648603a8e3538c7af3726b53b9b1c67b1ce15a539bae23fd059d1183dc691e3c5954acb9c92c3
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/keyring@npm:9.7.1"
+"@polkadot/keyring@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/keyring@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/util": 9.7.1
-    "@polkadot/util-crypto": 9.7.1
+    "@polkadot/util": 9.7.2
+    "@polkadot/util-crypto": 9.7.2
   peerDependencies:
-    "@polkadot/util": 9.7.1
-    "@polkadot/util-crypto": 9.7.1
-  checksum: a01b54837ce2b4c9833e9ba4f3929ce8e832cf2f7f721e4ff141577a9c3fe1c477d26ce43f064873da1f2f5d0ba494d8a388fe6a8bce052e32e4def2a3bc2f69
+    "@polkadot/util": 9.7.2
+    "@polkadot/util-crypto": 9.7.2
+  checksum: 0df98b213b9144a4cab72c0d6fd20a87726484d03ba6371f5a5263048b8b8a7ed8e00932d1e059bb13f867732bc47a58d9a640dc5c4ef5a7ba1bdf5ff02116d9
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:9.7.1, @polkadot/networks@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/networks@npm:9.7.1"
+"@polkadot/networks@npm:9.7.2, @polkadot/networks@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/networks@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/util": 9.7.1
+    "@polkadot/util": 9.7.2
     "@substrate/ss58-registry": ^1.23.0
-  checksum: 87b5c31d497c19b8c0bb069f19d8a09f5cbf25376bb3ebfdf5d05b7b24719cdd0546e93be27057d3e86915d926dec0361c344648460eb7f5b5bc151c84ae1e23
+  checksum: b9fb80eaf2851da2c00dded072402c717cbfa6549f65cf57a35dea90a2e69281e781fd2a605720820bd5b752027085b49a102357482e795b8ae4a974cb2cbd50
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/rpc-augment@npm:8.11.1"
+"@polkadot/rpc-augment@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/rpc-augment@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/rpc-core": 8.11.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/util": ^9.7.1
-  checksum: 9e27c83c7a3e640d8a6ecfd23f3f459a6fd2b2d026ddbed6d98eeefd12754d306cd196e65c8a34a0b6e721a40d6bb426a15be68193a19e7b9b44de1b774194ad
+    "@polkadot/rpc-core": 8.11.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/util": ^9.7.2
+  checksum: bbb91e7593e015c1e3b14ff0ec56cfac47b49e486e44f95c957632753d8115fda47078cb2e3ebae8a5cd31bc31901c4c0d3cecd9ea79825af1bcdd2b7e6159b4
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/rpc-core@npm:8.11.1"
+"@polkadot/rpc-core@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/rpc-core@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/rpc-augment": 8.11.1
-    "@polkadot/rpc-provider": 8.11.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/util": ^9.7.1
+    "@polkadot/rpc-augment": 8.11.2
+    "@polkadot/rpc-provider": 8.11.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/util": ^9.7.2
     rxjs: ^7.5.5
-  checksum: 1432a2328eb07dbd3f56d876a56e82e83d208290567f327ffb7f7695ca33151b17348859371105871b3e2aba0479a182cf5c30521bf19e90efc648debc67bc78
+  checksum: 6eebe5540625f3f6f7fb7f5fa663eab8dd4074161223a9bcc735b58eec3826c1701b7eeba33404a5ddeb37a58b45c674439db62be229643ce60a1063d8b478bf
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/rpc-provider@npm:8.11.1"
+"@polkadot/rpc-provider@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/rpc-provider@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/keyring": ^9.7.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-support": 8.11.1
-    "@polkadot/util": ^9.7.1
-    "@polkadot/util-crypto": ^9.7.1
-    "@polkadot/x-fetch": ^9.7.1
-    "@polkadot/x-global": ^9.7.1
-    "@polkadot/x-ws": ^9.7.1
+    "@polkadot/keyring": ^9.7.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-support": 8.11.2
+    "@polkadot/util": ^9.7.2
+    "@polkadot/util-crypto": ^9.7.2
+    "@polkadot/x-fetch": ^9.7.2
+    "@polkadot/x-global": ^9.7.2
+    "@polkadot/x-ws": ^9.7.2
     "@substrate/connect": 0.7.7
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.5
     nock: ^13.2.8
-  checksum: aa8b427d0f60d4ad10cfcef3703cf4b339945063cc1c2bcef773cb2f46ee1dbd3a354c4a71ff5eb3bb73fa032b72f6cbb540b63d9fb6b7894e5eca6f507da2fd
+  checksum: 8dbb828c9956c77a12e70145ddd424c5b422ac6a70c5e534444aca54070d652c34ca3349f5bf624061a7877afe2c8cd4c5e87ed7d1e8a720660ddfa81ba7ee83
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/types-augment@npm:8.11.1"
+"@polkadot/types-augment@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/types-augment@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/util": ^9.7.1
-  checksum: 899d6d1763d2def0b1d868d2518c7f0e6e50fb1aa876c832f25f9c16f245a29470cff355846d5d0184cc0363e19ed5aab92532aa1b565c10ab5b8d4c9d82b82d
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/util": ^9.7.2
+  checksum: fd1165f600061c4208151880039752ed5ccc66d53a7ba83c5f2c5d6fd80104e616acab48332e36191cd033d48e8843f7713e81c388f15458c8c2c71112dca2e3
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/types-codec@npm:8.11.1"
+"@polkadot/types-codec@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/types-codec@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/util": ^9.7.1
-    "@polkadot/x-bigint": ^9.7.1
-  checksum: df895f575c3687a791d1b4def3f41bd136dd3ad50e250e75ecb64ab99f139a696ccc41e77c8e22252ce950d99b5bd76f0753c39adc000b699a20b07d98390c28
+    "@polkadot/util": ^9.7.2
+    "@polkadot/x-bigint": ^9.7.2
+  checksum: 74fc3071336bd18a7af443a589309f348b548e0d880a8318bad6c89a5b84ce6d3b1aa022fa574e45edfe26af16d734e839b4478398ded96517df3d59dcd32a02
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/types-create@npm:8.11.1"
+"@polkadot/types-create@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/types-create@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/util": ^9.7.1
-  checksum: 5255941d8770914163bb94366077079b968d468992eb38058b853361d883e6a8919587ad14528f5c0f922e70fe394ab86953fb09abe9fb14c536e61787fb24d0
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/util": ^9.7.2
+  checksum: 84867ddd1c1588a569d61b0bcb033c99a27c4a7a1ae5d92dc715b630f021933d32de73b3b23a68dad88f034cc8f9e93536324d6bb485f9eedf6a6feedf89fe91
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/types-known@npm:8.11.1"
+"@polkadot/types-known@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/types-known@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/networks": ^9.7.1
-    "@polkadot/types": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/types-create": 8.11.1
-    "@polkadot/util": ^9.7.1
-  checksum: d65392b6da74adea606ff1105c7e8b0a4b23e786e7846daa34c479e99a4cc40b0ba3ebf060ebb03073168819537d3a4f42b2dd613afb892e91e0ad8381779597
+    "@polkadot/networks": ^9.7.2
+    "@polkadot/types": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/types-create": 8.11.2
+    "@polkadot/util": ^9.7.2
+  checksum: 873004d8d7eaae9a308e3d72ef21a1325f4ef2f8b7c9869c1a7f0c235c30dee78e15f57624c0728bbacfa421ec8e0fe8245299aed76624481f067a5a26ccd7fc
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/types-support@npm:8.11.1"
+"@polkadot/types-support@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/types-support@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/util": ^9.7.1
-  checksum: e39a52dd021b78d9f64595ecb1b8b27256adffccd5bdfd9a6bb321d1b34e0ae3a55e0cbb83e5c8d32dac2fa49d536c094a5fd296ab1d845d01c1ee5ea4cb5db6
+    "@polkadot/util": ^9.7.2
+  checksum: a8d33e00e75748ae671c7cb8ef7eaafb006e2906ad46da0eac74d2c1fc6d791589d06b0b50cf6e05d609e48fdd82896f46064e1268a5f5b4838e32b511a733cc
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:8.11.1":
-  version: 8.11.1
-  resolution: "@polkadot/types@npm:8.11.1"
+"@polkadot/types@npm:8.11.2":
+  version: 8.11.2
+  resolution: "@polkadot/types@npm:8.11.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/keyring": ^9.7.1
-    "@polkadot/types-augment": 8.11.1
-    "@polkadot/types-codec": 8.11.1
-    "@polkadot/types-create": 8.11.1
-    "@polkadot/util": ^9.7.1
-    "@polkadot/util-crypto": ^9.7.1
+    "@polkadot/keyring": ^9.7.2
+    "@polkadot/types-augment": 8.11.2
+    "@polkadot/types-codec": 8.11.2
+    "@polkadot/types-create": 8.11.2
+    "@polkadot/util": ^9.7.2
+    "@polkadot/util-crypto": ^9.7.2
     rxjs: ^7.5.5
-  checksum: 1279fa0d0005d6748855ff418c266bc655fe7896dd6607b71fc87893aef28ef664ef76a7d3fc56db774c9b126e4ba24f9875116d2f1699b70d046cfe527f72ff
+  checksum: 9e25fcac212a3101b296f90b7e0add3a4c9c2345cb546d58f9d99ee73808d5df21623221a049ade288d48ff53317b7b1a7de9ef79ef22d46db48f058ef23f31a
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:9.7.1, @polkadot/util-crypto@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/util-crypto@npm:9.7.1"
+"@polkadot/util-crypto@npm:9.7.2, @polkadot/util-crypto@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/util-crypto@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
     "@noble/hashes": 1.1.2
     "@noble/secp256k1": 1.6.0
-    "@polkadot/networks": 9.7.1
-    "@polkadot/util": 9.7.1
-    "@polkadot/wasm-crypto": ^6.2.1
-    "@polkadot/x-bigint": 9.7.1
-    "@polkadot/x-randomvalues": 9.7.1
+    "@polkadot/networks": 9.7.2
+    "@polkadot/util": 9.7.2
+    "@polkadot/wasm-crypto": ^6.2.2
+    "@polkadot/x-bigint": 9.7.2
+    "@polkadot/x-randomvalues": 9.7.2
     "@scure/base": 1.1.1
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 9.7.1
-  checksum: 69dff4c3417a564bf98c08967e2197c3b64b87e9cc47b83a49924983c00fd8de5e295dc2015fa3911b23712e331a6cfe709bf87ac655d9f14efeb748f06f8514
+    "@polkadot/util": 9.7.2
+  checksum: fb2588671b22f38602dd231184cfeffc77cb848055bda8efed4962a0b8b94888dc7ddb2cfe304e44a175afd3403d94b7551a1c42d3ce54d225b45a80321f6fdb
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:9.7.1, @polkadot/util@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/util@npm:9.7.1"
+"@polkadot/util@npm:9.7.2, @polkadot/util@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/util@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-bigint": 9.7.1
-    "@polkadot/x-global": 9.7.1
-    "@polkadot/x-textdecoder": 9.7.1
-    "@polkadot/x-textencoder": 9.7.1
+    "@polkadot/x-bigint": 9.7.2
+    "@polkadot/x-global": 9.7.2
+    "@polkadot/x-textdecoder": 9.7.2
+    "@polkadot/x-textencoder": 9.7.2
     "@types/bn.js": ^5.1.0
     bn.js: ^5.2.1
     ip-regex: ^4.3.0
-  checksum: 4e8cf7aef0b3cdb94cb464dfdd90b86ff0ce8b37cb1ccd4248b667ff14ce94bc833ee6ae731d38991af28444790ba998864d6e70d82fc416872b762826f070af
+  checksum: ccb7270148a0479c141dc138546a30f31fbe39d6d182c72bfc027ae1f01163702b1d2a568b7b2ae5dd2d1b787ec70243f8bebe55a7209ee3f0321708ada293ba
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-bridge@npm:6.2.1":
-  version: 6.2.1
-  resolution: "@polkadot/wasm-bridge@npm:6.2.1"
+"@polkadot/wasm-bridge@npm:6.2.2":
+  version: 6.2.2
+  resolution: "@polkadot/wasm-bridge@npm:6.2.2"
   dependencies:
     "@babel/runtime": ^7.18.6
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: 4e07c7bed0f0706d406bb19ed85f86ff733ce2cf6452306553f1da66ac27f8421266c040cebbbd07d34f11456a63513e55253c0b4d650a0a6b0325d1f8670d87
+  checksum: ce7c934b4a20099a127f417064ef0690415666f5dab4602c17f39ffe544e154052ef4ca0fc82d9d29acc3516658fc1ce77c2070af0e5622f6bd7e1e32cd7db31
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:6.2.1":
-  version: 6.2.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:6.2.1"
+"@polkadot/wasm-crypto-asmjs@npm:6.2.2":
+  version: 6.2.2
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:6.2.2"
   dependencies:
     "@babel/runtime": ^7.18.6
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 18dae8a9a084bd7e876cecaf2730f931aa1f4428439bdca329e6bdcb8d59b2f58f1857a8eb474e481b5b519b9d86915422d7b6baa15905498e7023c9c1557a5c
+  checksum: 0245a21898e4fb7549b0d125911cbba0d4766e2d15d534bc4e60267ba5a332147d53585132e8ce34884581a0b4bc72c85208ce3150372d88e7a14b94a4b969a4
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-init@npm:6.2.1":
-  version: 6.2.1
-  resolution: "@polkadot/wasm-crypto-init@npm:6.2.1"
+"@polkadot/wasm-crypto-init@npm:6.2.2":
+  version: 6.2.2
+  resolution: "@polkadot/wasm-crypto-init@npm:6.2.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/wasm-bridge": 6.2.1
-    "@polkadot/wasm-crypto-asmjs": 6.2.1
-    "@polkadot/wasm-crypto-wasm": 6.2.1
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: be96206ea47d2b45a8bee9bcd9d695acf1e06cbbce130296a1513cdbe96910816069110fc848ab0ec8314b0ddb519c0bb03aa670a06a6dc184553ccb15bf2eec
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto-wasm@npm:6.2.1":
-  version: 6.2.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:6.2.1"
-  dependencies:
-    "@babel/runtime": ^7.18.6
-    "@polkadot/wasm-util": 6.2.1
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: e3557def1ddf7a3195ab82e34c4eb30ea9789df0e2872ffbf486914001ae9928eb8deaac0fc9dfefcc00c34d3dc64d21398d84e0f5631bda9b4055cd98645d09
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto@npm:^6.2.1":
-  version: 6.2.1
-  resolution: "@polkadot/wasm-crypto@npm:6.2.1"
-  dependencies:
-    "@babel/runtime": ^7.18.6
-    "@polkadot/wasm-bridge": 6.2.1
-    "@polkadot/wasm-crypto-asmjs": 6.2.1
-    "@polkadot/wasm-crypto-init": 6.2.1
-    "@polkadot/wasm-crypto-wasm": 6.2.1
-    "@polkadot/wasm-util": 6.2.1
+    "@polkadot/wasm-bridge": 6.2.2
+    "@polkadot/wasm-crypto-asmjs": 6.2.2
+    "@polkadot/wasm-crypto-wasm": 6.2.2
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: ce4582294f915a469d3acd57a4871b10fd3f1f8a83b4331ecbd7c3013006e415e5ec30a2ecc358e3ad1c484a65e0e8a6ead07a80b51d973bfd459faaba06105d
+  checksum: 517a59d3662b485f375bdd6877477ab85b2c181bf91970d4da9a09acb12b9248a3be0f9de8d4fe9883a6e2fa479e4eb034a0c66a6a9be734a5b90010aa94511d
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-util@npm:6.2.1":
-  version: 6.2.1
-  resolution: "@polkadot/wasm-util@npm:6.2.1"
+"@polkadot/wasm-crypto-wasm@npm:6.2.2":
+  version: 6.2.2
+  resolution: "@polkadot/wasm-crypto-wasm@npm:6.2.2"
+  dependencies:
+    "@babel/runtime": ^7.18.6
+    "@polkadot/wasm-util": 6.2.2
+  peerDependencies:
+    "@polkadot/util": "*"
+  checksum: 73a90282777d3f94ae1f08d708598ffc74d95e19bec8fb9a218b742d20e6ee6b05486f59e207e117ec3587b310ebce38738b588956fe0c79c836d4811aaf2283
+  languageName: node
+  linkType: hard
+
+"@polkadot/wasm-crypto@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "@polkadot/wasm-crypto@npm:6.2.2"
+  dependencies:
+    "@babel/runtime": ^7.18.6
+    "@polkadot/wasm-bridge": 6.2.2
+    "@polkadot/wasm-crypto-asmjs": 6.2.2
+    "@polkadot/wasm-crypto-init": 6.2.2
+    "@polkadot/wasm-crypto-wasm": 6.2.2
+    "@polkadot/wasm-util": 6.2.2
+  peerDependencies:
+    "@polkadot/util": "*"
+    "@polkadot/x-randomvalues": "*"
+  checksum: fb1292120a71e2c8395b11b7fe933a4f455a964586bd3570b9f7e4e50f8afdfdae7ba649e1b72f6c810e7e9d8dd318b8cd781a0418f0c62cbe02df95351bd5d7
+  languageName: node
+  linkType: hard
+
+"@polkadot/wasm-util@npm:6.2.2":
+  version: 6.2.2
+  resolution: "@polkadot/wasm-util@npm:6.2.2"
   dependencies:
     "@babel/runtime": ^7.18.6
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 3efdbab34bb33fef95c5b6fa6194155461962d9121adc89203a6b72c51c8af37b7e8b0289ef390a2f1fb008211ad6a97aaaeb79395cacdb831992af23799d34c
+  checksum: ccc5dd5b60ec7a6571e6d031f5dc72358dbe04a6aa43c58d6d8789015c5a9ce6d0d956b04f25f35a3d79d3ba9a9d7a5b2e0e14976c9566b182981a2c17c84041
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:9.7.1, @polkadot/x-bigint@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-bigint@npm:9.7.1"
+"@polkadot/x-bigint@npm:9.7.2, @polkadot/x-bigint@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-bigint@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-global": 9.7.1
-  checksum: c741f2079c6d68422da6bc972bb77fc5d4092c2a44fa007148a3cef4c2e61acf4fdb7e759dcc93a53c7b1a36eba4b923f3e0acf2efc22f2190890563d43e03f8
+    "@polkadot/x-global": 9.7.2
+  checksum: 18610e4c55388b5c82e8ca6964200751fc20a19f8159f957a321d47b325ce349e3102d4f55a7e8997178e92a2d84cc138e8a39028e986a42175f45c38945b539
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-fetch@npm:9.7.1"
+"@polkadot/x-fetch@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-fetch@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-global": 9.7.1
+    "@polkadot/x-global": 9.7.2
     "@types/node-fetch": ^2.6.2
     node-fetch: ^2.6.7
-  checksum: 091435b014966b2cbe54640ef23a0b3c1609715b8249752cec1130e0e1cca630a6c0e9034c0c7230d1f6d36f111a01ad8c5c38420f7f65a816a79e85a5a55d01
+  checksum: b0739abf8e8dbc0e2126e6d7d651bfebfe6972388422182c38cdff712fcd1993d86c6c1434a45e327e6456fb0b451f295a6df2c1331a571d4616aedf53b6b20a
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:9.7.1, @polkadot/x-global@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-global@npm:9.7.1"
+"@polkadot/x-global@npm:9.7.2, @polkadot/x-global@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-global@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-  checksum: 9d8927ac687e3cd4872144dd196198750a3119d60e7a36f28d2673894aba1c97a65ebc905b211a6de5da9b4a98212673e453ff5df20d5ca5f040afc1534575ed
+  checksum: 1c64fd3ba0d81707887bb0fcb55da1ee5977ebf4bf247bc078e1d96e7a12d2bed089fafa8776b8c219772049521cf49f45d378f37fed82aaafe44b0b5aad41ac
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-randomvalues@npm:9.7.1"
+"@polkadot/x-randomvalues@npm:9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-randomvalues@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-global": 9.7.1
-  checksum: 951692a6f438a00331d74927e812896cf73094827db3dfffe16a949300d4a4cdda8c6678da475e8fd23179df9479a708e3450e291c9b690424202ef16292656e
+    "@polkadot/x-global": 9.7.2
+  checksum: 0c7e3a0b04dea40ce6696613970b523924e364de622e4180cfcb678a2187d4f59f143651aa16380b96bdebe022c462f4bfb53730e3528b24b0d2e9ffcc0276a2
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-textdecoder@npm:9.7.1"
+"@polkadot/x-textdecoder@npm:9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-textdecoder@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-global": 9.7.1
-  checksum: 8f25e83b2b4297b5bbf59627bcdb2dbf8df2464a203aa2b4a69883e16ce929ee3a70aa5fb4b683d3d53db201b4c460d2801f83d4bca1b3c6ca612fad82eecccb
+    "@polkadot/x-global": 9.7.2
+  checksum: e2cb044723a7130fb8ad7f3799ede94f49777e94ab6806318f7fc5a0cfdba91fd06730da3292453c9a4d901b60b07b78efbbd44f917b99ea1490a79f8dfec39d
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-textencoder@npm:9.7.1"
+"@polkadot/x-textencoder@npm:9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-textencoder@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-global": 9.7.1
-  checksum: fe5b4045b790742ff54cef2bcc408a6c1e6a92b3d1816ffbd0b9ed90259a990d02d897ea099a0797cb4c6854ff82ec7b16f73c83149f21eaae4e6503e4d2396c
+    "@polkadot/x-global": 9.7.2
+  checksum: 619bf4eafc086e777abfae67e1027136fb1e4d9761e20583da12c55c5b6cc852f227029b8b3241cda23b157e11d450d273b3526b792a95eaa294f0f785d9fe3c
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^9.7.1":
-  version: 9.7.1
-  resolution: "@polkadot/x-ws@npm:9.7.1"
+"@polkadot/x-ws@npm:^9.7.2":
+  version: 9.7.2
+  resolution: "@polkadot/x-ws@npm:9.7.2"
   dependencies:
     "@babel/runtime": ^7.18.6
-    "@polkadot/x-global": 9.7.1
+    "@polkadot/x-global": 9.7.2
     "@types/websocket": ^1.0.5
     websocket: ^1.0.34
-  checksum: acab2d65149109f4b829eb918fb01415e651f0bcb477a26705ef82501ce0188b263b81d98a80cdd01c4f2156aa11a26f2eeb4451154666534b958ef8df55927b
+  checksum: 0eebb36f601d00f1275abb4085507fd6cea220c3eeed4172102405ea60b1c2e85c4a35536516c49bb95b9f285924fd5489ead9c1a2438d4dd6a8bf8c22e4cfec
   languageName: node
   linkType: hard
 
@@ -1215,8 +1215,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^8.11.1
-    "@polkadot/util-crypto": ^9.7.1
+    "@polkadot/api": ^8.11.2
+    "@polkadot/util-crypto": ^9.7.2
     "@substrate/calc": ^0.2.8
     "@substrate/dev": ^0.6.2
     "@types/argparse": 2.0.10

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,12 +365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.18.3":
-  version: 7.18.3
-  resolution: "@babel/runtime@npm:7.18.3"
+"@babel/runtime@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/runtime@npm:7.18.6"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: db8526226aa02cfa35a5a7ac1a34b5f303c62a1f000c7db48cb06c6290e616483e5036ab3c4e7a84d0f3be6d4e2148d5fe5cec9564bf955f505c3e764b83d7f1
+  checksum: 8b707b64ae0524db617d0c49933b258b96376a38307dc0be8fb42db5697608bcc1eba459acce541e376cff5ed5c5287d24db5780bd776b7c75ba2c2e26ff8a2c
   languageName: node
   linkType: hard
 
@@ -780,407 +780,409 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/api-augment@npm:8.10.1"
+"@polkadot/api-augment@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/api-augment@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/api-base": 8.10.1
-    "@polkadot/rpc-augment": 8.10.1
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-augment": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/util": ^9.6.2
-  checksum: a0346c20189b139fd7ccc4b22ddf4ac58eb07934b238bf01259ba42bd7c50726af85afce914ec7439fc5a9f2cd233f63355d0f25ced87b687d7ada104d1c9cc0
+    "@babel/runtime": ^7.18.6
+    "@polkadot/api-base": 8.11.1
+    "@polkadot/rpc-augment": 8.11.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-augment": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/util": ^9.7.1
+  checksum: fa11b7951198b5beea5361df749efe17322d41b765d5b6bd7413bd902b428c12cab91cbd2fd10c708a3cfdc300a751d3b6e3a065d857bd6dc1e372b1562fbed4
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/api-base@npm:8.10.1"
+"@polkadot/api-base@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/api-base@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/rpc-core": 8.10.1
-    "@polkadot/types": 8.10.1
-    "@polkadot/util": ^9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/rpc-core": 8.11.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/util": ^9.7.1
     rxjs: ^7.5.5
-  checksum: 66ae810c62581e0994c1209577dec0284b9916d09a69552adcc079ec8ae8d36ec750c50ad7bd0f7294baa88ca4ef6c5b5c4bcf4e3bfa4e7d3c815fd36126971e
+  checksum: 5d49a2a222a064fb2c9544fb50b368f52d6d347fa00451eaa2067af543479837803afb254b36f3486b9aa5ba6842e108bdd323e30e9d04682f681677aff1f2a5
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/api-derive@npm:8.10.1"
+"@polkadot/api-derive@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/api-derive@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/api": 8.10.1
-    "@polkadot/api-augment": 8.10.1
-    "@polkadot/api-base": 8.10.1
-    "@polkadot/rpc-core": 8.10.1
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/util": ^9.6.2
-    "@polkadot/util-crypto": ^9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/api": 8.11.1
+    "@polkadot/api-augment": 8.11.1
+    "@polkadot/api-base": 8.11.1
+    "@polkadot/rpc-core": 8.11.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/util": ^9.7.1
+    "@polkadot/util-crypto": ^9.7.1
     rxjs: ^7.5.5
-  checksum: 72e241bce0beccb0858ca393b5852a75d84dce1fe26ee74abc7639ae8b45b958c5ff0d650befefe1535faae3ff9cf76320691429a79794a230dd7768bc025140
+  checksum: c8d4f286672c2cde80c528b41f852a3e2809fce8e35cf7e6ca74d6f45d4c4db7c70089df3ce983ba2b48c8ea6c448579cc13dcc17c82d74747888e5c2c23288d
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:8.10.1, @polkadot/api@npm:^8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/api@npm:8.10.1"
+"@polkadot/api@npm:8.11.1, @polkadot/api@npm:^8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/api@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/api-augment": 8.10.1
-    "@polkadot/api-base": 8.10.1
-    "@polkadot/api-derive": 8.10.1
-    "@polkadot/keyring": ^9.6.2
-    "@polkadot/rpc-augment": 8.10.1
-    "@polkadot/rpc-core": 8.10.1
-    "@polkadot/rpc-provider": 8.10.1
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-augment": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/types-create": 8.10.1
-    "@polkadot/types-known": 8.10.1
-    "@polkadot/util": ^9.6.2
-    "@polkadot/util-crypto": ^9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/api-augment": 8.11.1
+    "@polkadot/api-base": 8.11.1
+    "@polkadot/api-derive": 8.11.1
+    "@polkadot/keyring": ^9.7.1
+    "@polkadot/rpc-augment": 8.11.1
+    "@polkadot/rpc-core": 8.11.1
+    "@polkadot/rpc-provider": 8.11.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-augment": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/types-create": 8.11.1
+    "@polkadot/types-known": 8.11.1
+    "@polkadot/util": ^9.7.1
+    "@polkadot/util-crypto": ^9.7.1
     eventemitter3: ^4.0.7
     rxjs: ^7.5.5
-  checksum: 3dab6e6c30f7fa9328df038973977157dcb3f19fd64bb2a6b7e26db1d1c435afca9c6772915f5b5e0654c3f930eb610139a2e86d2ccdaec756886c2a83a0d6c0
+  checksum: d8805863d80d9bfca149b4e7b28cd314d8144ef2f684dba92bd8345b068952c694770841978497d4153476e7777d1f6d8a68207c062da97541b80fba72642523
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/keyring@npm:9.6.2"
+"@polkadot/keyring@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/keyring@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/util": 9.6.2
-    "@polkadot/util-crypto": 9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/util": 9.7.1
+    "@polkadot/util-crypto": 9.7.1
   peerDependencies:
-    "@polkadot/util": 9.6.2
-    "@polkadot/util-crypto": 9.6.2
-  checksum: af5e7db3e8c72d7c105d240db6cdf4fb0c07f5ac4ad4d7f8ab6b3b5422ab5ce503b966a0a6594c2b474f05c1385f0953ea2d5617bed9744eb026ffdbc95ec62c
+    "@polkadot/util": 9.7.1
+    "@polkadot/util-crypto": 9.7.1
+  checksum: a01b54837ce2b4c9833e9ba4f3929ce8e832cf2f7f721e4ff141577a9c3fe1c477d26ce43f064873da1f2f5d0ba494d8a388fe6a8bce052e32e4def2a3bc2f69
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:9.6.2, @polkadot/networks@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/networks@npm:9.6.2"
+"@polkadot/networks@npm:9.7.1, @polkadot/networks@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/networks@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/util": 9.6.2
-    "@substrate/ss58-registry": ^1.22.0
-  checksum: 9b217921a6bbc2399a5fae62c9d83a6888063d92953e84604c79b44c9fcbc6b77863fbeb3b21e936b4a059815424c339ad48a0ff6289cd5af23c649d58b2c5c0
+    "@babel/runtime": ^7.18.6
+    "@polkadot/util": 9.7.1
+    "@substrate/ss58-registry": ^1.23.0
+  checksum: 87b5c31d497c19b8c0bb069f19d8a09f5cbf25376bb3ebfdf5d05b7b24719cdd0546e93be27057d3e86915d926dec0361c344648460eb7f5b5bc151c84ae1e23
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/rpc-augment@npm:8.10.1"
+"@polkadot/rpc-augment@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/rpc-augment@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/rpc-core": 8.10.1
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/util": ^9.6.2
-  checksum: 8aa958d9fcda21e9ff015463868da349b276b7389cf636dc257643aab4383c8f39098c51d2056bc863b6a72dd19c5b08a87263f74f1c8d3effb6a716804f7cce
+    "@babel/runtime": ^7.18.6
+    "@polkadot/rpc-core": 8.11.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/util": ^9.7.1
+  checksum: 9e27c83c7a3e640d8a6ecfd23f3f459a6fd2b2d026ddbed6d98eeefd12754d306cd196e65c8a34a0b6e721a40d6bb426a15be68193a19e7b9b44de1b774194ad
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/rpc-core@npm:8.10.1"
+"@polkadot/rpc-core@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/rpc-core@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/rpc-augment": 8.10.1
-    "@polkadot/rpc-provider": 8.10.1
-    "@polkadot/types": 8.10.1
-    "@polkadot/util": ^9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/rpc-augment": 8.11.1
+    "@polkadot/rpc-provider": 8.11.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/util": ^9.7.1
     rxjs: ^7.5.5
-  checksum: e6e72cc3501c5868f9639c7c981411be29b550d00c5bc6844e9690f8a6a2858be3363251fcd929daef8910eca698054633435d63f9ef4126fbd5b0cb8396c837
+  checksum: 1432a2328eb07dbd3f56d876a56e82e83d208290567f327ffb7f7695ca33151b17348859371105871b3e2aba0479a182cf5c30521bf19e90efc648debc67bc78
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/rpc-provider@npm:8.10.1"
+"@polkadot/rpc-provider@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/rpc-provider@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/keyring": ^9.6.2
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-support": 8.10.1
-    "@polkadot/util": ^9.6.2
-    "@polkadot/util-crypto": ^9.6.2
-    "@polkadot/x-fetch": ^9.6.2
-    "@polkadot/x-global": ^9.6.2
-    "@polkadot/x-ws": ^9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/keyring": ^9.7.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-support": 8.11.1
+    "@polkadot/util": ^9.7.1
+    "@polkadot/util-crypto": ^9.7.1
+    "@polkadot/x-fetch": ^9.7.1
+    "@polkadot/x-global": ^9.7.1
+    "@polkadot/x-ws": ^9.7.1
     "@substrate/connect": 0.7.7
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.5
-    nock: ^13.2.7
-  checksum: 6223dc722127e9d2850b5e92e095ada462befb38854f9af62a559e97b3a357cc3addf56c85535f536b4d2d399ffa821433d9de19a95193ca3ddcbb55a64ba400
+    nock: ^13.2.8
+  checksum: aa8b427d0f60d4ad10cfcef3703cf4b339945063cc1c2bcef773cb2f46ee1dbd3a354c4a71ff5eb3bb73fa032b72f6cbb540b63d9fb6b7894e5eca6f507da2fd
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/types-augment@npm:8.10.1"
+"@polkadot/types-augment@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/types-augment@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/util": ^9.6.2
-  checksum: 8a77ad256f9b0c04e2a64d1bed4649d7d50a61755dda491ecc1fda841ad7ceb31aa1e725880103437564d57ea11da349e99e10dc4e64ce6508010e2ab0fad8a4
+    "@babel/runtime": ^7.18.6
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/util": ^9.7.1
+  checksum: 899d6d1763d2def0b1d868d2518c7f0e6e50fb1aa876c832f25f9c16f245a29470cff355846d5d0184cc0363e19ed5aab92532aa1b565c10ab5b8d4c9d82b82d
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/types-codec@npm:8.10.1"
+"@polkadot/types-codec@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/types-codec@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/util": ^9.6.2
-    "@polkadot/x-bigint": ^9.6.2
-  checksum: d39fa5b65997d834de8d408e57602607b4f12dbd0a35e5a52a066032b441289ee7ca165eedcb61d761927dc3d3898d2659ad9bf5f6a586e84707e3607bd5e062
+    "@babel/runtime": ^7.18.6
+    "@polkadot/util": ^9.7.1
+    "@polkadot/x-bigint": ^9.7.1
+  checksum: df895f575c3687a791d1b4def3f41bd136dd3ad50e250e75ecb64ab99f139a696ccc41e77c8e22252ce950d99b5bd76f0753c39adc000b699a20b07d98390c28
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/types-create@npm:8.10.1"
+"@polkadot/types-create@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/types-create@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/util": ^9.6.2
-  checksum: 041843c89fd94dd496e03bf3df01fd6493a6e345e26652a74a1253dc3edadc6d6f887883f99ed9b6f8f79e2391a62767a23dd0427d25af21eb6fb4239c12793f
+    "@babel/runtime": ^7.18.6
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/util": ^9.7.1
+  checksum: 5255941d8770914163bb94366077079b968d468992eb38058b853361d883e6a8919587ad14528f5c0f922e70fe394ab86953fb09abe9fb14c536e61787fb24d0
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/types-known@npm:8.10.1"
+"@polkadot/types-known@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/types-known@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/networks": ^9.6.2
-    "@polkadot/types": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/types-create": 8.10.1
-    "@polkadot/util": ^9.6.2
-  checksum: fef2cad7b59b673841df19548187ed9b3b228c1657fbe7294dcefedba8feada5600c975f142ef5cae7b59c15713c0ec313d7f22ca1e6d943d064ba9380a5577b
+    "@babel/runtime": ^7.18.6
+    "@polkadot/networks": ^9.7.1
+    "@polkadot/types": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/types-create": 8.11.1
+    "@polkadot/util": ^9.7.1
+  checksum: d65392b6da74adea606ff1105c7e8b0a4b23e786e7846daa34c479e99a4cc40b0ba3ebf060ebb03073168819537d3a4f42b2dd613afb892e91e0ad8381779597
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/types-support@npm:8.10.1"
+"@polkadot/types-support@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/types-support@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/util": ^9.6.2
-  checksum: dde318725884a6db4eef9cb5037c556bb755d8454a158f1ef65e39f3842c353856267674ddc70d52bc320966ec31b437da2a014b66302eab7ef12a67f60a38f2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/util": ^9.7.1
+  checksum: e39a52dd021b78d9f64595ecb1b8b27256adffccd5bdfd9a6bb321d1b34e0ae3a55e0cbb83e5c8d32dac2fa49d536c094a5fd296ab1d845d01c1ee5ea4cb5db6
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@polkadot/types@npm:8.10.1"
+"@polkadot/types@npm:8.11.1":
+  version: 8.11.1
+  resolution: "@polkadot/types@npm:8.11.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/keyring": ^9.6.2
-    "@polkadot/types-augment": 8.10.1
-    "@polkadot/types-codec": 8.10.1
-    "@polkadot/types-create": 8.10.1
-    "@polkadot/util": ^9.6.2
-    "@polkadot/util-crypto": ^9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/keyring": ^9.7.1
+    "@polkadot/types-augment": 8.11.1
+    "@polkadot/types-codec": 8.11.1
+    "@polkadot/types-create": 8.11.1
+    "@polkadot/util": ^9.7.1
+    "@polkadot/util-crypto": ^9.7.1
     rxjs: ^7.5.5
-  checksum: c59a466e6f7045f24b6e475faf99ab7368574c00214f8ff8e0f15f13e97a7593c683f7f36a259e5a17253197047bf268d21fad1e1f2149e8752965d6fbb6f801
+  checksum: 1279fa0d0005d6748855ff418c266bc655fe7896dd6607b71fc87893aef28ef664ef76a7d3fc56db774c9b126e4ba24f9875116d2f1699b70d046cfe527f72ff
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:9.6.2, @polkadot/util-crypto@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/util-crypto@npm:9.6.2"
+"@polkadot/util-crypto@npm:9.7.1, @polkadot/util-crypto@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/util-crypto@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
+    "@babel/runtime": ^7.18.6
     "@noble/hashes": 1.1.2
     "@noble/secp256k1": 1.6.0
-    "@polkadot/networks": 9.6.2
-    "@polkadot/util": 9.6.2
-    "@polkadot/wasm-crypto": ^6.1.5
-    "@polkadot/x-bigint": 9.6.2
-    "@polkadot/x-randomvalues": 9.6.2
+    "@polkadot/networks": 9.7.1
+    "@polkadot/util": 9.7.1
+    "@polkadot/wasm-crypto": ^6.2.1
+    "@polkadot/x-bigint": 9.7.1
+    "@polkadot/x-randomvalues": 9.7.1
     "@scure/base": 1.1.1
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 9.6.2
-  checksum: 435cb87dfe80b4fbf8b64fe06f75dc78ba43785dd29d4f873c9d387be41c9b5fe7118b3ba8c7d1b07a33261a445563f831582804417c8f701c19c6948ef4f01c
+    "@polkadot/util": 9.7.1
+  checksum: 69dff4c3417a564bf98c08967e2197c3b64b87e9cc47b83a49924983c00fd8de5e295dc2015fa3911b23712e331a6cfe709bf87ac655d9f14efeb748f06f8514
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:9.6.2, @polkadot/util@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/util@npm:9.6.2"
+"@polkadot/util@npm:9.7.1, @polkadot/util@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/util@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-bigint": 9.6.2
-    "@polkadot/x-global": 9.6.2
-    "@polkadot/x-textdecoder": 9.6.2
-    "@polkadot/x-textencoder": 9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-bigint": 9.7.1
+    "@polkadot/x-global": 9.7.1
+    "@polkadot/x-textdecoder": 9.7.1
+    "@polkadot/x-textencoder": 9.7.1
     "@types/bn.js": ^5.1.0
     bn.js: ^5.2.1
     ip-regex: ^4.3.0
-  checksum: 210972653a451c92a9059901debc924c3315147895e735784f2b891f3d03fc3705269fcf8e7ec0fa4ce4673bcb84be9d228a712c5b465b2feca2259fef20d6b7
+  checksum: 4e8cf7aef0b3cdb94cb464dfdd90b86ff0ce8b37cb1ccd4248b667ff14ce94bc833ee6ae731d38991af28444790ba998864d6e70d82fc416872b762826f070af
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-bridge@npm:6.1.5":
-  version: 6.1.5
-  resolution: "@polkadot/wasm-bridge@npm:6.1.5"
+"@polkadot/wasm-bridge@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@polkadot/wasm-bridge@npm:6.2.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
+    "@babel/runtime": ^7.18.6
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: 81da501fd04c44d5de9f9aa900e7125248cbb49f39b497d77d06cfa3252739c08501aab19a4d46bb4b84358bbf4ce064fc3d96674ab133e61cb4129fe8835b34
+  checksum: 4e07c7bed0f0706d406bb19ed85f86ff733ce2cf6452306553f1da66ac27f8421266c040cebbbd07d34f11456a63513e55253c0b4d650a0a6b0325d1f8670d87
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:6.1.5":
-  version: 6.1.5
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:6.1.5"
+"@polkadot/wasm-crypto-asmjs@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:6.2.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
+    "@babel/runtime": ^7.18.6
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: a68b5612dc27d6b0eeae4c0d292b07c3689f78dfb9592db1077cda61cd5aab3ab8b5b3af9fb72448dc317723076a950b9a50ea6d4c03b8055e179ab9fb87d938
+  checksum: 18dae8a9a084bd7e876cecaf2730f931aa1f4428439bdca329e6bdcb8d59b2f58f1857a8eb474e481b5b519b9d86915422d7b6baa15905498e7023c9c1557a5c
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-init@npm:6.1.5":
-  version: 6.1.5
-  resolution: "@polkadot/wasm-crypto-init@npm:6.1.5"
+"@polkadot/wasm-crypto-init@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@polkadot/wasm-crypto-init@npm:6.2.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/wasm-bridge": 6.1.5
-    "@polkadot/wasm-crypto-asmjs": 6.1.5
-    "@polkadot/wasm-crypto-wasm": 6.1.5
+    "@babel/runtime": ^7.18.6
+    "@polkadot/wasm-bridge": 6.2.1
+    "@polkadot/wasm-crypto-asmjs": 6.2.1
+    "@polkadot/wasm-crypto-wasm": 6.2.1
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 2ec430b412893ac8b0c898da3d1563fa53dbe52e9db41ffea376349b7e3f26a36f6b75d1a6b4f81ddebeb1f2d82b686b8cc793101f672b43224cce2ab5a6b632
+    "@polkadot/x-randomvalues": "*"
+  checksum: be96206ea47d2b45a8bee9bcd9d695acf1e06cbbce130296a1513cdbe96910816069110fc848ab0ec8314b0ddb519c0bb03aa670a06a6dc184553ccb15bf2eec
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-wasm@npm:6.1.5":
-  version: 6.1.5
-  resolution: "@polkadot/wasm-crypto-wasm@npm:6.1.5"
+"@polkadot/wasm-crypto-wasm@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@polkadot/wasm-crypto-wasm@npm:6.2.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/wasm-util": 6.1.5
+    "@babel/runtime": ^7.18.6
+    "@polkadot/wasm-util": 6.2.1
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 780844529bf606a6adb93ef8bd053381546cbbdc0ff9062b9c10765550c3a079e2ffe7ae4301686076e2b159a3596997fa63bb8937ad0bfc445dc5cf093f364f
+  checksum: e3557def1ddf7a3195ab82e34c4eb30ea9789df0e2872ffbf486914001ae9928eb8deaac0fc9dfefcc00c34d3dc64d21398d84e0f5631bda9b4055cd98645d09
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:^6.1.5":
-  version: 6.1.5
-  resolution: "@polkadot/wasm-crypto@npm:6.1.5"
+"@polkadot/wasm-crypto@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "@polkadot/wasm-crypto@npm:6.2.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/wasm-bridge": 6.1.5
-    "@polkadot/wasm-crypto-asmjs": 6.1.5
-    "@polkadot/wasm-crypto-init": 6.1.5
-    "@polkadot/wasm-crypto-wasm": 6.1.5
-    "@polkadot/wasm-util": 6.1.5
+    "@babel/runtime": ^7.18.6
+    "@polkadot/wasm-bridge": 6.2.1
+    "@polkadot/wasm-crypto-asmjs": 6.2.1
+    "@polkadot/wasm-crypto-init": 6.2.1
+    "@polkadot/wasm-crypto-wasm": 6.2.1
+    "@polkadot/wasm-util": 6.2.1
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 8ff82a7bb497ae42d4b68d68751ff926395e9d794f6371feb799e14e996ba2f8eaa2574ce5f59fad08e05518e6da971c8efde2d70ef52ebc964c420e27c61f6a
+    "@polkadot/x-randomvalues": "*"
+  checksum: ce4582294f915a469d3acd57a4871b10fd3f1f8a83b4331ecbd7c3013006e415e5ec30a2ecc358e3ad1c484a65e0e8a6ead07a80b51d973bfd459faaba06105d
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-util@npm:6.1.5":
-  version: 6.1.5
-  resolution: "@polkadot/wasm-util@npm:6.1.5"
+"@polkadot/wasm-util@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@polkadot/wasm-util@npm:6.2.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
+    "@babel/runtime": ^7.18.6
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 1e3081fc38b67317b1f4463b212e309024baf1d75b64511d65d8c46038f8741062cde164728c29464194a9d4ffff567cc6bd09158f7a0d0f1b0ae14cf568f48e
+  checksum: 3efdbab34bb33fef95c5b6fa6194155461962d9121adc89203a6b72c51c8af37b7e8b0289ef390a2f1fb008211ad6a97aaaeb79395cacdb831992af23799d34c
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:9.6.2, @polkadot/x-bigint@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-bigint@npm:9.6.2"
+"@polkadot/x-bigint@npm:9.7.1, @polkadot/x-bigint@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-bigint@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-global": 9.6.2
-  checksum: 8edb51f5eccb97a49edee2eecc52dc086c644d9c1551833a0a071f7576d14105ff37e61e2fc9706ed55ec2cd675f1650bb8f459f49218134b023f57fe80ef9d1
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-global": 9.7.1
+  checksum: c741f2079c6d68422da6bc972bb77fc5d4092c2a44fa007148a3cef4c2e61acf4fdb7e759dcc93a53c7b1a36eba4b923f3e0acf2efc22f2190890563d43e03f8
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-fetch@npm:9.6.2"
+"@polkadot/x-fetch@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-fetch@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-global": 9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-global": 9.7.1
     "@types/node-fetch": ^2.6.2
     node-fetch: ^2.6.7
-  checksum: 92b36b61204d68f47ab6f66470b69e116322dfec4246df921d671514b9f888f87784be8e8a11d22d68647f6292244973667eca3a06d0071aee5dd3c288c128a0
+  checksum: 091435b014966b2cbe54640ef23a0b3c1609715b8249752cec1130e0e1cca630a6c0e9034c0c7230d1f6d36f111a01ad8c5c38420f7f65a816a79e85a5a55d01
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:9.6.2, @polkadot/x-global@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-global@npm:9.6.2"
+"@polkadot/x-global@npm:9.7.1, @polkadot/x-global@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-global@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-  checksum: e2f1e430aa804b93f819eefe0a8d9b98d67db89ac6a30b45d6798595891c6547a6e09aa08a5eb9077bd9524b71d57985a12bf50b7b809c036f414dd3edd64777
+    "@babel/runtime": ^7.18.6
+  checksum: 9d8927ac687e3cd4872144dd196198750a3119d60e7a36f28d2673894aba1c97a65ebc905b211a6de5da9b4a98212673e453ff5df20d5ca5f040afc1534575ed
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-randomvalues@npm:9.6.2"
+"@polkadot/x-randomvalues@npm:9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-randomvalues@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-global": 9.6.2
-  checksum: de46d5ffd1ffd8f594363451ebcb3c6d1ba6f48284270b9cf01e1a23f7d043314812824f01a72affbb8f9a2237b629532b41f5dd200a9af08d382e8011671f73
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-global": 9.7.1
+  checksum: 951692a6f438a00331d74927e812896cf73094827db3dfffe16a949300d4a4cdda8c6678da475e8fd23179df9479a708e3450e291c9b690424202ef16292656e
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-textdecoder@npm:9.6.2"
+"@polkadot/x-textdecoder@npm:9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-textdecoder@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-global": 9.6.2
-  checksum: 1e8187fec3f1c24c76f90a1ff75fd9dae04eb55613bffc68d082271c6742c3e7cea552a8e010c6642e0ff62686aafe5607dd87f724f7d26bac03ad6e54c6eb1b
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-global": 9.7.1
+  checksum: 8f25e83b2b4297b5bbf59627bcdb2dbf8df2464a203aa2b4a69883e16ce929ee3a70aa5fb4b683d3d53db201b4c460d2801f83d4bca1b3c6ca612fad82eecccb
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-textencoder@npm:9.6.2"
+"@polkadot/x-textencoder@npm:9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-textencoder@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-global": 9.6.2
-  checksum: daf7020b06f215c05586d4186c3833f7718bee5e1ccefbebb6e09af4af62037f0dac7ec51abe7f45256116e9ced79f5de19ce96de043c3bb6d6c4e1c87dcaf0e
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-global": 9.7.1
+  checksum: fe5b4045b790742ff54cef2bcc408a6c1e6a92b3d1816ffbd0b9ed90259a990d02d897ea099a0797cb4c6854ff82ec7b16f73c83149f21eaae4e6503e4d2396c
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^9.6.2":
-  version: 9.6.2
-  resolution: "@polkadot/x-ws@npm:9.6.2"
+"@polkadot/x-ws@npm:^9.7.1":
+  version: 9.7.1
+  resolution: "@polkadot/x-ws@npm:9.7.1"
   dependencies:
-    "@babel/runtime": ^7.18.3
-    "@polkadot/x-global": 9.6.2
+    "@babel/runtime": ^7.18.6
+    "@polkadot/x-global": 9.7.1
     "@types/websocket": ^1.0.5
     websocket: ^1.0.34
-  checksum: 0825ab6cbae499f6a92c43b8701b6b0265eeb284d5debc34b64b2ea5185124194d8e6bbdfd94221d47e46c870c7f4bc9e9961cc19660bad8df4355bae6e5960c
+  checksum: acab2d65149109f4b829eb918fb01415e651f0bcb477a26705ef82501ce0188b263b81d98a80cdd01c4f2156aa11a26f2eeb4451154666534b958ef8df55927b
   languageName: node
   linkType: hard
 
@@ -1213,8 +1215,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": ^8.10.1
-    "@polkadot/util-crypto": ^9.6.2
+    "@polkadot/api": ^8.11.1
+    "@polkadot/util-crypto": ^9.7.1
     "@substrate/calc": ^0.2.8
     "@substrate/dev": ^0.6.2
     "@types/argparse": 2.0.10
@@ -1303,10 +1305,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.22.0":
-  version: 1.22.0
-  resolution: "@substrate/ss58-registry@npm:1.22.0"
-  checksum: 5674b586680bd0d83a5da1bb790f84ed5184221e1b2935aed4f539c2e72311c53affb9d8a93e9a30727a409f874f7493569bd4e6990473957409dbf0a165b24d
+"@substrate/ss58-registry@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "@substrate/ss58-registry@npm:1.23.0"
+  checksum: 6544c713f4200c32ed8cdc3dfe6296bbc5f6f32c27f05c725004eab10f2c0e17f56a44631c35ab58612b5e143de98321aa599b3bdc8c2a9ff6fc41e6e9b8c26b
   languageName: node
   linkType: hard
 
@@ -4902,15 +4904,15 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.2.7":
-  version: 13.2.7
-  resolution: "nock@npm:13.2.7"
+"nock@npm:^13.2.8":
+  version: 13.2.8
+  resolution: "nock@npm:13.2.8"
   dependencies:
     debug: ^4.1.0
     json-stringify-safe: ^5.0.1
     lodash: ^4.17.21
     propagate: ^2.0.0
-  checksum: 0d7d3163ca973393d43a0334aafe59677ca6e7eea133338166be9bd06e577667da2dd2d5148046022b9e9dd4339f5ae5d0ef0274abc1462c4e896f8729c24b40
+  checksum: 656f696d3c1b6267b8ec366f5cc464306d2aa308ce9b41414e9992eea5b0b71e475a582945b936e16263961c3a0f9e1c388a3a36da53c1e300398a7826550f96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates polkadot-js deps to:

    "@polkadot/api": "^8.11.2",
    "@polkadot/util-crypto": "^9.7.2",