### PR TITLE
test(e2e): update validate endpoint

### DIFF
--- a/e2e-tests/endpoints/kusama/accounts/validate/index.ts
+++ b/e2e-tests/endpoints/kusama/accounts/validate/index.ts
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import validKusama from './validKusama.json';
-
-const validKusamaStringify = JSON.stringify(validKusama);
+import validateKusamaHex from './validateKusamaHex.json';
+import validateKusamaSS58 from './validateKusamaSS58.json';
 
 export const kusamaAccountValidateEndpoints = [
 	[
 		'/accounts/DXgXPAT5zWtPHo6FhVvrDdiaDPgCNGxhJAeVBYLtiwW9hAc/validate',
-		validKusamaStringify,
+		JSON.stringify(validateKusamaSS58),
 	],
 	[
 		'/accounts/0x02ce046d43fc4c0fb8b3b754028515e5020f5f1d8d620b4ef0f983c5df34b1952909e9/validate',
-		validKusamaStringify,
+		JSON.stringify(validateKusamaHex),
 	],
 ];

--- a/e2e-tests/endpoints/kusama/accounts/validate/validKusama.json
+++ b/e2e-tests/endpoints/kusama/accounts/validate/validKusama.json
@@ -1,4 +1,0 @@
-{
-    "isValid": true,
-    "ss58Prefix": "2"
-}

--- a/e2e-tests/endpoints/kusama/accounts/validate/validateKusamaHex.json
+++ b/e2e-tests/endpoints/kusama/accounts/validate/validateKusamaHex.json
@@ -1,0 +1,6 @@
+{
+	"isValid": true,
+	"ss58Prefix": "2",
+	"network": "kusama",
+	"accountId": "0xce046d43fc4c0fb8b3b754028515e5020f5f1d8d620b4ef0f983c5df34b19529"
+}

--- a/e2e-tests/endpoints/kusama/accounts/validate/validateKusamaSS58.json
+++ b/e2e-tests/endpoints/kusama/accounts/validate/validateKusamaSS58.json
@@ -1,0 +1,6 @@
+{
+	"isValid": true,
+	"ss58Prefix": "2",
+	"network": "kusama",
+	"accountId": "0x2a39366f6620a6c2e2fed5990a3d419e6a19dd127fc7a50b515cf17e2dc5cc59"
+}

--- a/e2e-tests/endpoints/polkadot/accounts/validate/index.ts
+++ b/e2e-tests/endpoints/polkadot/accounts/validate/index.ts
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import validPolkadot from './validPolkadot.json';
-
-const validPolkadotStringify = JSON.stringify(validPolkadot);
+import validatePolkadotHex from './validatePolkadotHex.json';
+import validatePolkadotSS58 from './validatePolkadotSS58.json';
 
 export const polkadotAccountValidateEndpoints = [
 	[
 		'/accounts/1xN1Q5eKQmS5AzASdjt6R6sHF76611vKR4PFpFjy1kXau4m/validate',
-		validPolkadotStringify,
+		JSON.stringify(validatePolkadotSS58),
 	],
 	[
 		'/accounts/0x002a39366f6620a6c2e2fed5990a3d419e6a19dd127fc7a50b515cf17e2dc5cc592312/validate',
-		validPolkadotStringify,
+		JSON.stringify(validatePolkadotHex),
 	],
 ];

--- a/e2e-tests/endpoints/polkadot/accounts/validate/validPolkadot.json
+++ b/e2e-tests/endpoints/polkadot/accounts/validate/validPolkadot.json
@@ -1,4 +1,0 @@
-{
-    "isValid": true,
-    "ss58Prefix": "0"
-}

--- a/e2e-tests/endpoints/polkadot/accounts/validate/validatePolkadotHex.json
+++ b/e2e-tests/endpoints/polkadot/accounts/validate/validatePolkadotHex.json
@@ -1,0 +1,6 @@
+{
+	"isValid": true,
+	"ss58Prefix": "0",
+	"network": "polkadot",
+	"accountId": "0x2a39366f6620a6c2e2fed5990a3d419e6a19dd127fc7a50b515cf17e2dc5cc59"
+}

--- a/e2e-tests/endpoints/polkadot/accounts/validate/validatePolkadotSS58.json
+++ b/e2e-tests/endpoints/polkadot/accounts/validate/validatePolkadotSS58.json
@@ -1,0 +1,6 @@
+{
+	"isValid": true,
+	"ss58Prefix": "0",
+	"network": "polkadot",
+	"accountId": "0x2a39366f6620a6c2e2fed5990a3d419e6a19dd127fc7a50b515cf17e2dc5cc59"
+}

--- a/e2e-tests/endpoints/westend/accounts/validate/index.ts
+++ b/e2e-tests/endpoints/westend/accounts/validate/index.ts
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import validWestend from './validWestend.json';
-
-const validWestendStringify = JSON.stringify(validWestend);
+import validateWestendHex from './validateWestendHex.json';
+import validateWestendSS58 from './validateWestendSS58.json';
 
 export const westendAccountValidateEndpoints = [
 	[
 		'/accounts/5CdnmxQUfK6WPreBauvetcLh5PZL4RMPHrtd3nPQpQ9Z2qCS/validate',
-		validWestendStringify,
+		JSON.stringify(validateWestendSS58),
 	],
 	[
 		'/accounts/0x2a193ba804b76499944080c91b8b38b749a482471c317ab8bfa43f52d5ff9c04c7f6bf/validate',
-		validWestendStringify,
+		JSON.stringify(validateWestendHex),
 	],
 ];

--- a/e2e-tests/endpoints/westend/accounts/validate/validWestend.json
+++ b/e2e-tests/endpoints/westend/accounts/validate/validWestend.json
@@ -1,4 +1,0 @@
-{
-    "isValid": true,
-    "ss58Prefix": "42"
-}

--- a/e2e-tests/endpoints/westend/accounts/validate/validateWestendHex.json
+++ b/e2e-tests/endpoints/westend/accounts/validate/validateWestendHex.json
@@ -1,0 +1,6 @@
+{
+	"isValid": true,
+	"ss58Prefix": "42",
+	"network": "substrate",
+	"accountId": "0x193ba804b76499944080c91b8b38b749a482471c317ab8bfa43f52d5ff9c04c7"
+}

--- a/e2e-tests/endpoints/westend/accounts/validate/validateWestendSS58.json
+++ b/e2e-tests/endpoints/westend/accounts/validate/validateWestendSS58.json
@@ -1,0 +1,6 @@
+{
+	"isValid": true,
+	"ss58Prefix": "42",
+	"network": "substrate",
+	"accountId": "0x193ba804b76499944080c91b8b38b749a482471c317ab8bfa43f52d5ff9c04c7"
+}

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -43,7 +43,7 @@ export const defaultSasPackOpts = {
 
 export const config: Record<string, IChainConfig> = {
 	polkadot: {
-		wsUrl: 'wss://polkadot.api.onfinality.io/public-ws',
+		wsUrl: 'wss://rpc.polkadot.io',
 		JestProcOpts: {
 			...defaultJestOpts,
 			args: ['test:e2e-tests', '--chain', 'polkadot'],


### PR DESCRIPTION
This is a follow up to https://github.com/paritytech/substrate-api-sidecar/pull/926

This updates the e2e tests for `/accounts/{address}/validate` for polkadot, kusama, and westend