### PR TITLE
fix(feeByEvent): fix tip inclusion for partialFee

### DIFF
--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -562,7 +562,8 @@ describe('BlocksService', () => {
 			it('Should retrieve the correct fee for balances::withdraw events', () => {
 				const response = blocksService['getPartialFeeByEvents'](
 					withdrawEvent,
-					partialFee
+					partialFee,
+					null
 				);
 
 				expect(response).toStrictEqual(expectedResponse);
@@ -571,7 +572,8 @@ describe('BlocksService', () => {
 			it('Should retrieve the correct fee for treasury::deposit events', () => {
 				const response = blocksService['getPartialFeeByEvents'](
 					treasuryEvent,
-					partialFee
+					partialFee,
+					null
 				);
 
 				expect(response).toStrictEqual(expectedResponse);
@@ -580,7 +582,8 @@ describe('BlocksService', () => {
 			it('Should retrieve the correct fee for balances::deposit events', () => {
 				const response = blocksService['getPartialFeeByEvents'](
 					balancesDepositEvent,
-					partialFee
+					partialFee,
+					null
 				);
 
 				expect(response).toStrictEqual(expectedResponse);
@@ -594,7 +597,8 @@ describe('BlocksService', () => {
 				const emptyArray = [] as unknown as ISanitizedEvent[];
 				const response = blocksService['getPartialFeeByEvents'](
 					emptyArray,
-					partialFee
+					partialFee,
+					null
 				);
 
 				expect(response).toStrictEqual(expectedResponseWithError);
@@ -611,7 +615,8 @@ describe('BlocksService', () => {
 					mockEvent,
 					'0x',
 					blockHash789629,
-					true
+					true,
+					null
 				);
 
 				expect(sanitizeNumbers(response)).toStrictEqual({
@@ -626,7 +631,8 @@ describe('BlocksService', () => {
 					mockEvent,
 					'0x',
 					blockHash789629,
-					false
+					false,
+					null
 				);
 
 				expect(sanitizeNumbers(response)).toStrictEqual({

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -20,6 +20,7 @@ import { PromiseRpcResult } from '@polkadot/api-base/types/rpc';
 import { GenericExtrinsic } from '@polkadot/types';
 import { GenericCall } from '@polkadot/types/generic';
 import { BlockHash, Hash, SignedBlock } from '@polkadot/types/interfaces';
+import { Compact } from '@polkadot/types-codec/base';
 import { BadRequest } from 'http-errors';
 import LRU from 'lru-cache';
 
@@ -44,6 +45,7 @@ import {
 	constructEvent,
 	treasuryEvent,
 	withdrawEvent,
+	withdrawEventForTip,
 } from '../test-helpers/mock/data/mockEventData';
 import { validators789629Hex } from '../test-helpers/mock/data/validators789629Hex';
 import { parseNumberOrThrow } from '../test-helpers/mock/parseNumberOrThrow';
@@ -584,6 +586,19 @@ describe('BlocksService', () => {
 					balancesDepositEvent,
 					partialFee,
 					null
+				);
+
+				expect(response).toStrictEqual(expectedResponse);
+			});
+
+			it('Should retrieve the correct fee for balances:withdraw events with a tip', () => {
+				const expectedResponse = { partialFee: '1681144907847007' };
+				const fee = polkadotRegistry.createType('Balance', '1675415067070856');
+				const tip = new Compact(polkadotRegistry, 'u64', 5729827274000);
+				const response = blocksService['getPartialFeeByEvents'](
+					withdrawEventForTip,
+					fee,
+					tip
 				);
 
 				expect(response).toStrictEqual(expectedResponse);

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -533,9 +533,11 @@ export class BlocksService extends AbstractService {
 			const dataArr = withdrawEvent[0].data.toJSON();
 			if (Array.isArray(dataArr)) {
 				const fee = (dataArr as Array<number>)[dataArr.length - 1];
-				const adjustedFee = tip ? tip.toBn().add(new BN(fee)) : new BN(fee);
+				const adjustedPartialFee = tip
+					? tip.toBn().add(partialFee)
+					: partialFee;
 				// The difference between values is 00.00001% or less so they are alike.
-				if (this.areFeesSimilar(adjustedFee, partialFee)) {
+				if (this.areFeesSimilar(new BN(fee), adjustedPartialFee)) {
 					return {
 						partialFee: fee.toString(),
 					};
@@ -549,9 +551,11 @@ export class BlocksService extends AbstractService {
 			const dataArr = treasuryEvent[0].data.toJSON();
 			if (Array.isArray(dataArr)) {
 				const fee = (dataArr as Array<number>)[0];
-				const adjustedFee = tip ? tip.toBn().add(new BN(fee)) : new BN(fee);
+				const adjustedPartialFee = tip
+					? tip.toBn().add(partialFee)
+					: partialFee;
 				// The difference between values is 00.00001% or less so they are alike.
-				if (this.areFeesSimilar(adjustedFee, partialFee)) {
+				if (this.areFeesSimilar(new BN(fee), adjustedPartialFee)) {
 					return {
 						partialFee: fee.toString(),
 					};
@@ -567,9 +571,9 @@ export class BlocksService extends AbstractService {
 				({ data }) =>
 					(sumOfFees = sumOfFees.add(new BN(data[data.length - 1].toString())))
 			);
-			const adjustedFee = tip ? tip.toBn().add(sumOfFees) : sumOfFees;
+			const adjustedPartialFee = tip ? tip.toBn().add(partialFee) : partialFee;
 			// The difference between values is 00.00001% or less so they are alike.
-			if (this.areFeesSimilar(adjustedFee, partialFee)) {
+			if (this.areFeesSimilar(sumOfFees, adjustedPartialFee)) {
 				return {
 					partialFee: sumOfFees.toString(),
 				};

--- a/src/services/test-helpers/mock/data/mockEventData.ts
+++ b/src/services/test-helpers/mock/data/mockEventData.ts
@@ -41,6 +41,10 @@ export const withdrawEvent = [
 	constructEvent('balances', 'Withdraw', ['0x', '2490128143']),
 ];
 
+export const withdrawEventForTip = [
+	constructEvent('balances', 'Withdraw', ['0x', '1681144907847007']),
+];
+
 export const treasuryEvent = [
 	// Set the fee inside of the data for withdraw 1 decimal larger than expected.
 	constructEvent('balances', 'Withdraw', ['0x', '24901281430']),


### PR DESCRIPTION
This fixes a bug in the `feeByEvent` query parameter for the `/blocks/*` endpoint where the tip was not included in the partialFee when doing an approximation for whether or not the events data included the fee. 

This fixes that by including the tip if it exists. 

closes: https://github.com/paritytech/substrate-api-sidecar/issues/969