### PR TITLE
fix(feeByEvent): sanitize fee for hex values

### DIFF
--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -657,5 +657,15 @@ describe('BlocksService', () => {
 				});
 			});
 		});
+
+		describe('sanitizeFee', () => {
+			it('Should sanitize a hex value correctly', () => {
+				const response = blocksService['sanitizeFee'](
+					'0x000000000000000000119e2433bf11f3'
+				);
+
+				expect(response).toBe('4958952928252403');
+			});
+		});
 	});
 });


### PR DESCRIPTION
closes: https://github.com/paritytech/substrate-api-sidecar/issues/989

When a fee is represented as a hex value, sanitize the fee correctly. 