### PR TITLE
fix(logging): replace TransformableInfo with ITransformableInfo type 

### DIFF
--- a/src/logging/transformers/nodeUtilFormat.ts
+++ b/src/logging/transformers/nodeUtilFormat.ts
@@ -14,17 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { TransformableInfo } from 'logform';
 import { SPLAT } from 'triple-beam';
 import { format } from 'util';
 import * as winston from 'winston';
+
+import { ITransformableInfo } from '../../types/logging';
 
 /**
  * Console.log style formatting using node's `util.format`. We need this so we
  * can override console.{log, error, etc.} without issue.
  */
 export const nodeUtilFormat = winston.format(
-	(info: TransformableInfo, _opts: unknown) => {
+	(info: ITransformableInfo, _opts: unknown) => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const args = info[SPLAT as unknown as string];
 		if (args) {

--- a/src/logging/transformers/stripAnsi.ts
+++ b/src/logging/transformers/stripAnsi.ts
@@ -1,5 +1,22 @@
-import { TransformableInfo } from 'logform';
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import { format } from 'winston';
+
+import { ITransformableInfo } from '../../types/logging';
 
 /**
  * Regex pattern to match ANSI characters.
@@ -48,7 +65,7 @@ function stripAnsiShellCodes(data: unknown): unknown {
 /**
  * Strip ANSI characters from `TransformableInfo.message`.
  */
-export const stripAnsi = format((info: TransformableInfo, _opts: unknown) => {
+export const stripAnsi = format((info: ITransformableInfo, _opts: unknown) => {
 	info.message = stripAnsiShellCodes(info.message) as string;
 	return info;
 });

--- a/src/services/test-helpers/mock/data/mockEventData.ts
+++ b/src/services/test-helpers/mock/data/mockEventData.ts
@@ -1,3 +1,19 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import { Codec, IEventData } from '@polkadot/types/types';
 
 import { polkadotRegistry } from '../../../../test-helpers/registries';


### PR DESCRIPTION
Continuation of https://github.com/paritytech/substrate-api-sidecar/pull/988. Cleans up the TransformableInfo type in a few files for logging. Also adds the license for a missing file. 