### PR TITLE
fix(feeByEvent): use registry to convert hex to string

### DIFF
--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -30,7 +30,7 @@ import {
 } from '@polkadot/types/interfaces';
 import { AnyJson, Codec, Registry } from '@polkadot/types/types';
 import { ICompact, INumber } from '@polkadot/types-codec/types/interfaces';
-import { hexToNumber, isHex, u8aToHex } from '@polkadot/util';
+import { isHex, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
 import BN from 'bn.js';
 import { BadRequest, InternalServerError } from 'http-errors';
@@ -618,8 +618,8 @@ export class BlocksService extends AbstractService {
 	 */
 	private sanitizeFee(fee: string): string {
 		if (isHex(fee)) {
-			const numFee = hexToNumber(fee);
-			return numFee.toString(10);
+			const feeType = this.api.registry.createType('Balance', fee);
+			return feeType.toString(10);
 		}
 
 		return fee;


### PR DESCRIPTION
closes: https://github.com/paritytech/substrate-api-sidecar/issues/989

Fix conversion to avoid 53 bit integer limit for node. 