### PR TITLE
fix(feeByEvent): handle tip for partialFee

### DIFF
--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -592,7 +592,7 @@ describe('BlocksService', () => {
 			});
 
 			it('Should retrieve the correct fee for balances:withdraw events with a tip', () => {
-				const expectedResponse = { partialFee: '1681144907847007' };
+				const expectedResponse = { partialFee: '1675415080573007' };
 				const fee = polkadotRegistry.createType('Balance', '1675415067070856');
 				const tip = new Compact(polkadotRegistry, 'u64', 5729827274000);
 				const response = blocksService['getPartialFeeByEvents'](

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -541,7 +541,9 @@ export class BlocksService extends AbstractService {
 				// The difference between values is 00.00001% or less so they are alike.
 				if (this.areFeesSimilar(new BN(fee), adjustedPartialFee)) {
 					return {
-						partialFee: fee.toString(),
+						partialFee: tip
+							? new BN(fee).sub(tip.toBn()).toString()
+							: fee.toString(),
 					};
 				}
 			}
@@ -559,7 +561,9 @@ export class BlocksService extends AbstractService {
 				// The difference between values is 00.00001% or less so they are alike.
 				if (this.areFeesSimilar(new BN(fee), adjustedPartialFee)) {
 					return {
-						partialFee: fee.toString(),
+						partialFee: tip
+							? new BN(fee).sub(tip.toBn()).toString()
+							: fee.toString(),
 					};
 				}
 			}
@@ -579,7 +583,9 @@ export class BlocksService extends AbstractService {
 			// The difference between values is 00.00001% or less so they are alike.
 			if (this.areFeesSimilar(sumOfFees, adjustedPartialFee)) {
 				return {
-					partialFee: sumOfFees.toString(),
+					partialFee: tip
+						? new BN(sumOfFees).sub(tip.toBn()).toString()
+						: sumOfFees.toString(),
 				};
 			}
 		}


### PR DESCRIPTION
rel: https://github.com/paritytech/substrate-api-sidecar/issues/969#issuecomment-1201214583

A partialFee needs to not include the tip. When using feeByEvent, if there is a tip we need to make sure we subtract it from the fee data provided by the event. 