### PR TITLE
fix: remove deprecated `reset` for lru cache and replace with `clear`

### DIFF
--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -127,7 +127,7 @@ describe('BlocksService', () => {
 	describe('fetchBlock', () => {
 		it('works when ApiPromise works (block 789629)', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			// fetchBlock options
 			const options = {
@@ -152,7 +152,7 @@ describe('BlocksService', () => {
 
 		it('throws when an extrinsic is undefined', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 			// Create a block with undefined as the first extrinisic and the last extrinsic removed
 			const mockBlock789629BadExt = polkadotRegistry.createType(
 				'Block',
@@ -191,7 +191,7 @@ describe('BlocksService', () => {
 
 		it('Returns the finalized tag as undefined when omitFinalizedTag equals true', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -214,7 +214,7 @@ describe('BlocksService', () => {
 
 	describe('BlocksService.parseGenericCall', () => {
 		// Reset LRU cache
-		cache.reset();
+		cache.clear();
 
 		const transfer = createCall('balances', 'transfer', {
 			value: 12,
@@ -369,7 +369,7 @@ describe('BlocksService', () => {
 
 		it('Returns false when queried blockId is not canonical', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			const getHeader = (_hash: Hash) =>
 				Promise.resolve().then(() => mockForkedBlock789629.header);
@@ -429,7 +429,7 @@ describe('BlocksService', () => {
 
 		it('Returns the correct extrinisics object for block 789629', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			const block = await blocksService.fetchBlock(
 				blockHash789629,
@@ -450,7 +450,7 @@ describe('BlocksService', () => {
 
 		it("Throw an error when `extrinsicIndex` doesn't exist", async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			const block = await blocksService.fetchBlock(
 				blockHash789629,
@@ -503,7 +503,7 @@ describe('BlocksService', () => {
 		};
 		it('Returns the correct summary for the latest block', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			const blockSummary = await blocksService.fetchBlockHeader(
 				blockHash789629
@@ -514,7 +514,7 @@ describe('BlocksService', () => {
 
 		it('Returns the correct summary for the given block number', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			const blockSummary = await blocksService.fetchBlockHeader();
 
@@ -535,7 +535,7 @@ describe('BlocksService', () => {
 
 		it('Should correctly store the most recent queried blocks', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
 			await blocksService.fetchBlock(blockHash20000, mockHistoricApi, options);
@@ -545,7 +545,7 @@ describe('BlocksService', () => {
 
 		it('Should have a max of 2 blocks within the LRUcache, and should save the most recent and remove the oldest block', async () => {
 			// Reset LRU cache
-			cache.reset();
+			cache.clear();
 
 			await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
 			await blocksService.fetchBlock(blockHash20000, mockHistoricApi, options);


### PR DESCRIPTION
`reset` was deprecated via 7.0.0 for `lru-cache`, therefore we replaced it with clear. This does not affect sidecar in any breaking way. 