### PR TITLE
feat: validateBooleanMiddleware for controllers

### DIFF
--- a/src/controllers/accounts/AccountsBalanceInfoController.ts
+++ b/src/controllers/accounts/AccountsBalanceInfoController.ts
@@ -18,7 +18,7 @@ import { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express';
 import { IAddressParam } from 'src/types/requests';
 
-import { validateAddress } from '../../middleware';
+import { validateAddress, validateBoolean } from '../../middleware';
 import { AccountsBalanceInfoService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -66,7 +66,7 @@ export default class AccountsBalanceController extends AbstractController<Accoun
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateAddress);
+		this.router.use(this.path, validateAddress, validateBoolean);
 
 		this.safeMountAsyncGetHandlers([['', this.getAccountBalanceInfo]]);
 	}

--- a/src/controllers/accounts/AccountsBalanceInfoController.ts
+++ b/src/controllers/accounts/AccountsBalanceInfoController.ts
@@ -66,7 +66,11 @@ export default class AccountsBalanceController extends AbstractController<Accoun
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateAddress, validateBoolean);
+		this.router.use(
+			this.path,
+			validateAddress,
+			validateBoolean(['denominated'])
+		);
 
 		this.safeMountAsyncGetHandlers([['', this.getAccountBalanceInfo]]);
 	}

--- a/src/controllers/accounts/AccountsStakingPayoutsController.ts
+++ b/src/controllers/accounts/AccountsStakingPayoutsController.ts
@@ -20,7 +20,7 @@ import BN from 'bn.js';
 import { RequestHandler } from 'express';
 import { BadRequest, InternalServerError } from 'http-errors';
 
-import { validateAddress } from '../../middleware';
+import { validateAddress, validateBoolean } from '../../middleware';
 import { AccountsStakingPayoutsService } from '../../services';
 import { IAddressParam } from '../../types/requests';
 import AbstractController from '../AbstractController';
@@ -87,7 +87,7 @@ export default class AccountsStakingPayoutsController extends AbstractController
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateAddress);
+		this.router.use(this.path, validateAddress, validateBoolean);
 
 		this.safeMountAsyncGetHandlers([['', this.getStakingPayoutsByAccountId]]);
 	}

--- a/src/controllers/accounts/AccountsStakingPayoutsController.ts
+++ b/src/controllers/accounts/AccountsStakingPayoutsController.ts
@@ -87,7 +87,11 @@ export default class AccountsStakingPayoutsController extends AbstractController
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateAddress, validateBoolean);
+		this.router.use(
+			this.path,
+			validateAddress,
+			validateBoolean(['unclaimedOnly'])
+		);
 
 		this.safeMountAsyncGetHandlers([['', this.getStakingPayoutsByAccountId]]);
 	}

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -20,6 +20,7 @@ import { RequestHandler } from 'express';
 import { BadRequest } from 'http-errors';
 import LRU from 'lru-cache';
 
+import { validateBoolean } from '../../middleware/validate';
 import { BlocksService } from '../../services';
 import { INumberParam, IRangeQueryParam } from '../../types/requests';
 import { IBlock } from '../../types/responses';
@@ -102,6 +103,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateBoolean);
 		this.safeMountAsyncGetHandlers([
 			['/', this.getBlocks],
 			['/head', this.getLatestBlock],

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -103,7 +103,10 @@ export default class BlocksController extends AbstractController<BlocksService> 
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateBoolean);
+		this.router.use(
+			this.path,
+			validateBoolean(['eventDocs', 'extrinsicDocs', 'finalized'])
+		);
 		this.safeMountAsyncGetHandlers([
 			['/', this.getBlocks],
 			['/head', this.getLatestBlock],

--- a/src/controllers/blocks/BlocksTraceController.ts
+++ b/src/controllers/blocks/BlocksTraceController.ts
@@ -29,7 +29,7 @@ export default class BlocksTraceController extends AbstractController<BlocksTrac
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateBoolean);
+		this.router.use(this.path, validateBoolean(['actions']));
 		this.safeMountAsyncGetHandlers([
 			['/head/traces', this.getLatestBlockTraces],
 			['/:number/traces', this.getBlockTraces],

--- a/src/controllers/blocks/BlocksTraceController.ts
+++ b/src/controllers/blocks/BlocksTraceController.ts
@@ -17,6 +17,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express-serve-static-core';
 
+import { validateBoolean } from '../../middleware';
 import { BlocksTraceService } from '../../services';
 import AbstractController from '../AbstractController';
 import BlocksController from './BlocksController';
@@ -28,6 +29,7 @@ export default class BlocksTraceController extends AbstractController<BlocksTrac
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateBoolean);
 		this.safeMountAsyncGetHandlers([
 			['/head/traces', this.getLatestBlockTraces],
 			['/:number/traces', this.getBlockTraces],

--- a/src/controllers/node/NodeTransactionPoolController.ts
+++ b/src/controllers/node/NodeTransactionPoolController.ts
@@ -17,6 +17,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express';
 
+import { validateBoolean } from '../../middleware';
 import { NodeTransactionPoolService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -39,6 +40,7 @@ export default class NodeTransactionPoolController extends AbstractController<No
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateBoolean);
 		this.safeMountAsyncGetHandlers([['', this.getNodeTransactionPool]]);
 	}
 

--- a/src/controllers/node/NodeTransactionPoolController.ts
+++ b/src/controllers/node/NodeTransactionPoolController.ts
@@ -40,7 +40,7 @@ export default class NodeTransactionPoolController extends AbstractController<No
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateBoolean);
+		this.router.use(this.path, validateBoolean(['includeFee']));
 		this.safeMountAsyncGetHandlers([['', this.getNodeTransactionPool]]);
 	}
 

--- a/src/controllers/pallets/PalletsStorageController.ts
+++ b/src/controllers/pallets/PalletsStorageController.ts
@@ -47,7 +47,7 @@ export default class PalletsStorageController extends AbstractController<Pallets
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateBoolean);
+		this.router.use(this.path, validateBoolean(['adjustMetadataV13']));
 		this.safeMountAsyncGetHandlers([
 			['/:storageItemId', this.getStorageItem],
 			['/', this.getStorage],

--- a/src/controllers/pallets/PalletsStorageController.ts
+++ b/src/controllers/pallets/PalletsStorageController.ts
@@ -18,6 +18,7 @@ import { ApiPromise } from '@polkadot/api';
 import { stringCamelCase } from '@polkadot/util';
 import { RequestHandler } from 'express-serve-static-core';
 
+import { validateBoolean } from '../..//middleware';
 import { Log } from '../../logging/Log';
 import { PalletsStorageService } from '../../services';
 import AbstractController from '../AbstractController';
@@ -46,7 +47,7 @@ export default class PalletsStorageController extends AbstractController<Pallets
 	}
 
 	protected initRoutes(): void {
-		// TODO look into middleware validation of in path IDs. https://github.com/paritytech/substrate-api-sidecar/issues/281
+		this.router.use(this.path, validateBoolean);
 		this.safeMountAsyncGetHandlers([
 			['/:storageItemId', this.getStorageItem],
 			['/', this.getStorage],

--- a/src/controllers/paras/ParasController.ts
+++ b/src/controllers/paras/ParasController.ts
@@ -29,7 +29,10 @@ export default class ParasController extends AbstractController<ParasService> {
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path + '/paras/leases/current', validateBoolean);
+		this.router.use(
+			this.path + '/paras/leases/current',
+			validateBoolean(['currentLeaseHolders'])
+		);
 		this.safeMountAsyncGetHandlers([
 			['/paras', this.getParas],
 			['/paras/crowdloans', this.getCrowdloans],

--- a/src/controllers/paras/ParasController.ts
+++ b/src/controllers/paras/ParasController.ts
@@ -17,6 +17,7 @@
 import { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express';
 
+import { validateBoolean } from '../../middleware';
 import { ParasService } from '../../services';
 import { IParaIdParam } from '../../types/requests';
 import AbstractController from '../AbstractController';
@@ -28,6 +29,7 @@ export default class ParasController extends AbstractController<ParasService> {
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path + '/paras/leases/current', validateBoolean);
 		this.safeMountAsyncGetHandlers([
 			['/paras', this.getParas],
 			['/paras/crowdloans', this.getCrowdloans],

--- a/src/controllers/transaction/TransactionMaterialController.ts
+++ b/src/controllers/transaction/TransactionMaterialController.ts
@@ -18,6 +18,7 @@ import { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express';
 
 import { Log } from '../../logging/Log';
+import { validateBoolean } from '../../middleware';
 import { TransactionMaterialService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -60,6 +61,7 @@ export default class TransactionMaterialController extends AbstractController<Tr
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateBoolean);
 		this.safeMountAsyncGetHandlers([['', this.getTransactionMaterial]]);
 	}
 

--- a/src/controllers/transaction/TransactionMaterialController.ts
+++ b/src/controllers/transaction/TransactionMaterialController.ts
@@ -61,7 +61,7 @@ export default class TransactionMaterialController extends AbstractController<Tr
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateBoolean);
+		this.router.use(this.path, validateBoolean(['noMeta']));
 		this.safeMountAsyncGetHandlers([['', this.getTransactionMaterial]]);
 	}
 

--- a/src/middleware/validate/index.ts
+++ b/src/middleware/validate/index.ts
@@ -15,3 +15,4 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export { validateAddressMiddleware as validateAddress } from './validateAddressMiddleware';
+export { validateBooleanMiddleware as validateBoolean } from './validateBooleanMiddleware';

--- a/src/middleware/validate/util.ts
+++ b/src/middleware/validate/util.ts
@@ -18,10 +18,10 @@ import { Request, Response } from 'express';
 import { RequestHandler } from 'express-serve-static-core';
 
 /**
- * Assert that a middleware does not error with a the given `req`.
+ * Assert that a middleware does not error with the given request.
  *
- * @param name thing it does not error on
- * @param req Express Request containing thing it errors on
+ * @param name String for tests to log.
+ * @param req Express Request containing thing it errors on.
  */
 export const doesNotErrorWith = (
 	name: string,
@@ -40,9 +40,9 @@ export const doesNotErrorWith = (
  * Assert that a middleware passes `err` to next with the given
  * `req`.
  *
- * @param name thing it errors on
- * @param req Express Request containing thing it errors on
- * @param err expected error that it passes to next
+ * @param name String for tests to log.
+ * @param req Express Request containing thing it errors on.
+ * @param err Expected error that it passes to next.
  */
 export const errorsWith = (
 	name: string,

--- a/src/middleware/validate/util.ts
+++ b/src/middleware/validate/util.ts
@@ -1,0 +1,60 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { Request, Response } from 'express';
+import { RequestHandler } from 'express-serve-static-core';
+
+/**
+ * Assert that a middleware does not error with a the given `req`.
+ *
+ * @param name thing it does not error on
+ * @param req Express Request containing thing it errors on
+ */
+export const doesNotErrorWith = (
+	name: string,
+	req: Request,
+	middleware: RequestHandler
+): void => {
+	it(`does not error with ${name}`, () => {
+		const next = jest.fn();
+		middleware(req, null as unknown as Response, next);
+		expect(next).toBeCalledTimes(1);
+		expect(next).toBeCalledWith();
+	});
+};
+
+/**
+ * Assert that a middleware passes `err` to next with the given
+ * `req`.
+ *
+ * @param name thing it errors on
+ * @param req Express Request containing thing it errors on
+ * @param err expected error that it passes to next
+ */
+export const errorsWith = (
+	name: string,
+	req: Request,
+	err: unknown,
+	middleware: RequestHandler
+): void => {
+	it(`errors with ${name}`, () => {
+		const next = jest.fn();
+
+		middleware(req, null as unknown as Response, next);
+		expect(next).toBeCalledTimes(1);
+		expect(next).toBeCalledWith(err);
+	});
+};

--- a/src/middleware/validate/validateAddressMiddleware.spec.ts
+++ b/src/middleware/validate/validateAddressMiddleware.spec.ts
@@ -14,92 +14,88 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { Request, Response } from 'express';
+import { Request } from 'express';
 import { BadRequest } from 'http-errors';
 
+import { doesNotErrorWith, errorsWith } from './util';
 import { validateAddressMiddleware } from './validateAddressMiddleware';
 
-/**
- * Assert that `validateAddressMiddleware` does not error with a the given `req`.
- *
- * @param name thing it does not error on
- * @param req Express Request containing thing it errors on
- */
-function doesNotErrorWith(name: string, req: Request): void {
-	it(`does not error with ${name}`, () => {
-		const next = jest.fn();
-		validateAddressMiddleware(req, null as unknown as Response, next);
-		expect(next).toBeCalledTimes(1);
-		expect(next).toBeCalledWith();
-	});
-}
-
-/**
- * Assert that `validateAddressMiddleware` passes `err` to next with the given
- * `req`.
- *
- * @param name thing it errors on
- * @param req Express Request containing thing it errors on
- * @param err expected error that it passes to next
- */
-function errorsWith(name: string, req: Request, err: unknown): void {
-	it(`errors with ${name}`, () => {
-		const next = jest.fn();
-
-		validateAddressMiddleware(req, null as unknown as Response, next);
-		expect(next).toBeCalledTimes(1);
-		expect(next).toBeCalledWith(err);
-	});
-}
-
 describe('validateAddressMiddleware', () => {
-	doesNotErrorWith('no address in params', {
-		params: {
-			number: '1',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'no address in params',
+		{
+			params: {
+				number: '1',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
-	doesNotErrorWith('a valid substrate address', {
-		params: {
-			number: '1',
-			address: '5EnxxUmEbw8DkENKiYuZ1DwQuMoB2UWEQJZZXrTsxoz7SpgG',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'a valid substrate address',
+		{
+			params: {
+				number: '1',
+				address: '5EnxxUmEbw8DkENKiYuZ1DwQuMoB2UWEQJZZXrTsxoz7SpgG',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
-	doesNotErrorWith('a valid kusama address', {
-		params: {
-			number: '1',
-			address: 'DXgXPAT5zWtPHo6FhVvrDdiaDPgCNGxhJAeVBYLtiwW9hAc',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'a valid kusama address',
+		{
+			params: {
+				number: '1',
+				address: 'DXgXPAT5zWtPHo6FhVvrDdiaDPgCNGxhJAeVBYLtiwW9hAc',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
-	doesNotErrorWith('a valid kulupu address', {
-		params: {
-			number: '1',
-			address: '2cYv9Gk6U4m4a7Taw9pG8qMfd1Pnxw6FLTvV6kYZNhGL6M9y',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'a valid kulupu address',
+		{
+			params: {
+				number: '1',
+				address: '2cYv9Gk6U4m4a7Taw9pG8qMfd1Pnxw6FLTvV6kYZNhGL6M9y',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
-	doesNotErrorWith('a valid edgeware address', {
-		params: {
-			number: '1',
-			address: '5D24s4paTdVxddyeUzgsxGGiRd7SPhTnEvKu6XGPQvj1QSYN',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'a valid edgeware address',
+		{
+			params: {
+				number: '1',
+				address: '5D24s4paTdVxddyeUzgsxGGiRd7SPhTnEvKu6XGPQvj1QSYN',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
-	doesNotErrorWith('a valid polkadot address', {
-		params: {
-			number: '1',
-			address: '1xN1Q5eKQmS5AzASdjt6R6sHF76611vKR4PFpFjy1kXau4m',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'a valid polkadot address',
+		{
+			params: {
+				number: '1',
+				address: '1xN1Q5eKQmS5AzASdjt6R6sHF76611vKR4PFpFjy1kXau4m',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
-	doesNotErrorWith('a valid H160 address', {
-		params: {
-			number: '1',
-			address: '0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac',
-		},
-	} as unknown as Request);
+	doesNotErrorWith(
+		'a valid H160 address',
+		{
+			params: {
+				number: '1',
+				address: '0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac',
+			},
+		} as unknown as Request,
+		validateAddressMiddleware
+	);
 
 	errorsWith(
 		'an address containing an invalid base58 char',
@@ -109,7 +105,8 @@ describe('validateAddressMiddleware', () => {
 				address: '5EnxIUmEbw8DkENKiYuZ1DwQuMoB2UWEQJZZXrTsxoz7SpgG',
 			},
 		} as unknown as Request,
-		new BadRequest('Invalid base58 character "I" (0x49) at index 4')
+		new BadRequest('Invalid base58 character "I" (0x49) at index 4'),
+		validateAddressMiddleware
 	);
 
 	errorsWith(
@@ -120,7 +117,8 @@ describe('validateAddressMiddleware', () => {
 				address: 'y9EMHt34JJo4rWLSaxoLGdYXvjgSXEd4zHUnQgfNzwES8b',
 			},
 		} as unknown as Request,
-		new BadRequest('Invalid address format')
+		new BadRequest('Invalid address format'),
+		validateAddressMiddleware
 	);
 
 	errorsWith(
@@ -131,7 +129,8 @@ describe('validateAddressMiddleware', () => {
 				address: '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDwU',
 			},
 		} as unknown as Request,
-		new BadRequest('Invalid decoded address checksum')
+		new BadRequest('Invalid decoded address checksum'),
+		validateAddressMiddleware
 	);
 
 	errorsWith(
@@ -142,6 +141,7 @@ describe('validateAddressMiddleware', () => {
 				address: 'hello',
 			},
 		} as unknown as Request,
-		new BadRequest('Invalid base58 character "l" (0x6c) at index 2')
+		new BadRequest('Invalid base58 character "l" (0x6c) at index 2'),
+		validateAddressMiddleware
 	);
 });

--- a/src/middleware/validate/validateBooleanMiddleware.spec.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.spec.ts
@@ -1,0 +1,92 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { Request } from 'express';
+import { BadRequest } from 'http-errors';
+
+import { doesNotErrorWith, errorsWith } from './util';
+import { validateBooleanMiddleware } from './validateBooleanMiddleware';
+
+describe('validaeBooleanMiddleware', () => {
+	doesNotErrorWith(
+		'no query params in path',
+		{
+			query: {},
+		} as unknown as Request,
+		validateBooleanMiddleware
+	);
+
+	doesNotErrorWith(
+		'valid true and false query params',
+		{
+			query: {
+				finalized: 'true',
+				eventDocs: 'false',
+			},
+		} as unknown as Request,
+		validateBooleanMiddleware
+	);
+
+	doesNotErrorWith(
+		'Non specified invalid query params',
+		{
+			query: {
+				invalid: 'truee',
+			},
+		} as unknown as Request,
+		validateBooleanMiddleware
+	);
+
+	errorsWith(
+		'an invalid true query param',
+		{
+			query: {
+				finalized: 'truee',
+			},
+		} as unknown as Request,
+		new BadRequest(
+			'Query parameter: finalized has an invalid boolean value of truee'
+		),
+		validateBooleanMiddleware
+	);
+
+	errorsWith(
+		'an invalid false query param',
+		{
+			query: {
+				finalized: 'falsee',
+			},
+		} as unknown as Request,
+		new BadRequest(
+			'Query parameter: finalized has an invalid boolean value of falsee'
+		),
+		validateBooleanMiddleware
+	);
+
+	errorsWith(
+		'multiple invalid query params',
+		{
+			query: {
+				finalized: 'notTrue',
+				eventDocs: 'notFalse',
+			},
+		} as unknown as Request,
+		new BadRequest(
+			'Query parameter: finalized has an invalid boolean value of notTrue - Query parameter: eventDocs has an invalid boolean value of notFalse'
+		),
+		validateBooleanMiddleware
+	);
+});

--- a/src/middleware/validate/validateBooleanMiddleware.spec.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.spec.ts
@@ -26,7 +26,7 @@ describe('validaeBooleanMiddleware', () => {
 		{
 			query: {},
 		} as unknown as Request,
-		validateBooleanMiddleware
+		validateBooleanMiddleware([])
 	);
 
 	doesNotErrorWith(
@@ -37,7 +37,7 @@ describe('validaeBooleanMiddleware', () => {
 				eventDocs: 'false',
 			},
 		} as unknown as Request,
-		validateBooleanMiddleware
+		validateBooleanMiddleware(['finalized', 'eventDocs'])
 	);
 
 	doesNotErrorWith(
@@ -47,7 +47,7 @@ describe('validaeBooleanMiddleware', () => {
 				invalid: 'truee',
 			},
 		} as unknown as Request,
-		validateBooleanMiddleware
+		validateBooleanMiddleware(['invalid'])
 	);
 
 	errorsWith(
@@ -60,7 +60,7 @@ describe('validaeBooleanMiddleware', () => {
 		new BadRequest(
 			'Query parameter: finalized has an invalid boolean value of truee'
 		),
-		validateBooleanMiddleware
+		validateBooleanMiddleware(['finalized'])
 	);
 
 	errorsWith(
@@ -73,7 +73,7 @@ describe('validaeBooleanMiddleware', () => {
 		new BadRequest(
 			'Query parameter: finalized has an invalid boolean value of falsee'
 		),
-		validateBooleanMiddleware
+		validateBooleanMiddleware(['finalized'])
 	);
 
 	errorsWith(
@@ -87,6 +87,6 @@ describe('validaeBooleanMiddleware', () => {
 		new BadRequest(
 			'Query parameter: finalized has an invalid boolean value of notTrue - Query parameter: eventDocs has an invalid boolean value of notFalse'
 		),
-		validateBooleanMiddleware
+		validateBooleanMiddleware(['finalized', 'eventDocs'])
 	);
 });

--- a/src/middleware/validate/validateBooleanMiddleware.spec.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.spec.ts
@@ -47,7 +47,7 @@ describe('validaeBooleanMiddleware', () => {
 				invalid: 'truee',
 			},
 		} as unknown as Request,
-		validateBooleanMiddleware(['invalid'])
+		validateBooleanMiddleware([])
 	);
 
 	errorsWith(

--- a/src/middleware/validate/validateBooleanMiddleware.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.ts
@@ -19,16 +19,16 @@ import { BadRequest } from 'http-errors';
 
 // Query Params used in controllers
 const queryParams = [
-	'eventDocs',
-	'extrinsicDocs',
-	'finalized',
-	'denominated',
-	'unclaimedOnly',
-	'actions',
-	'includeFee',
-	'adjustMetadataV13',
-	'currentLeaseHolders',
-	'noMeta',
+	'eventDocs', // BlocksController
+	'extrinsicDocs', // BlocksController
+	'finalized', // BlocksController
+	'denominated', // AccountsBalanceController
+	'unclaimedOnly', // AccountsStakingPayoutsController
+	'actions', // BlocksTraceController
+	'includeFee', // NodeTransactionPoolController
+	'adjustMetadataV13', // PalletsStorageController
+	'currentLeaseHolders', // ParasController
+	'noMeta', // TransactionMaterialController
 ];
 
 export const validateBooleanMiddleware: RequestHandler = (req, _res, next) => {

--- a/src/middleware/validate/validateBooleanMiddleware.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.ts
@@ -26,23 +26,21 @@ export const validateBooleanMiddleware = (
 	queryParams: string[]
 ): RequestHandler => {
 	return (req, _res, next) => {
-		const queryKeys = Object.keys(req.query);
 		const errQueryParams: string[] = [];
-		queryKeys
-			.filter((queryParam) => queryParams.includes(queryParam))
-			.forEach((queryParam) => {
-				const queryParamVal =
-					typeof req.query[queryParam] === 'string'
-						? (req.query[queryParam] as string).toLowerCase()
-						: '';
-				if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
-					errQueryParams.push(
-						`Query parameter: ${queryParam} has an invalid boolean value of ${
-							req.query[queryParam] as string
-						}`
-					);
-				}
-			});
+
+		for (const key of queryParams) {
+			const queryParamVal =
+				typeof req.query[key] === 'string'
+					? (req.query[key] as string).toLowerCase()
+					: '';
+			if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
+				errQueryParams.push(
+					`Query parameter: ${key} has an invalid boolean value of ${
+						req.query[key] as string
+					}`
+				);
+			}
+		}
 
 		if (errQueryParams.length > 0) {
 			return next(new BadRequest(errQueryParams.join(' - ')));

--- a/src/middleware/validate/validateBooleanMiddleware.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.ts
@@ -1,0 +1,58 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { RequestHandler } from 'express';
+import { BadRequest } from 'http-errors';
+
+// Query Params used in controllers
+const queryParams = [
+	'eventDocs',
+	'extrinsicDocs',
+	'finalized',
+	'denominated',
+	'unclaimedOnly',
+	'actions',
+	'includeFee',
+	'adjustMetadataV13',
+	'currentLeaseHolders',
+	'noMeta',
+];
+
+export const validateBooleanMiddleware: RequestHandler = (req, _res, next) => {
+	const queryKeys = Object.keys(req.query);
+	const errQueryParams: string[] = [];
+	queryKeys
+		.filter((queryParam) => queryParams.includes(queryParam))
+		.forEach((queryParam) => {
+			const queryParamVal =
+				typeof req.query[queryParam] === 'string'
+					? (req.query[queryParam] as string).toLowerCase()
+					: '';
+			if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
+				errQueryParams.push(
+					`Query parameter: ${queryParam} has an invalid boolean value of ${
+						req.query[queryParam] as string
+					}`
+				);
+			}
+		});
+
+	if (errQueryParams.length > 0) {
+		return next(new BadRequest(errQueryParams.join(' - ')));
+	}
+
+	return next();
+};

--- a/src/middleware/validate/validateBooleanMiddleware.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.ts
@@ -17,42 +17,37 @@
 import { RequestHandler } from 'express';
 import { BadRequest } from 'http-errors';
 
-// Query Params used in controllers
-const queryParams = [
-	'eventDocs', // BlocksController
-	'extrinsicDocs', // BlocksController
-	'finalized', // BlocksController
-	'denominated', // AccountsBalanceController
-	'unclaimedOnly', // AccountsStakingPayoutsController
-	'actions', // BlocksTraceController
-	'includeFee', // NodeTransactionPoolController
-	'adjustMetadataV13', // PalletsStorageController
-	'currentLeaseHolders', // ParasController
-	'noMeta', // TransactionMaterialController
-];
+/**
+ * Validate that the given query params that are expected to be booleans are correct.
+ *
+ * @param queryParams An array of queryParams to check for. These are passed in at the controller level.
+ */
+export const validateBooleanMiddleware = (
+	queryParams: string[]
+): RequestHandler => {
+	return (req, _res, next) => {
+		const queryKeys = Object.keys(req.query);
+		const errQueryParams: string[] = [];
+		queryKeys
+			.filter((queryParam) => queryParams.includes(queryParam))
+			.forEach((queryParam) => {
+				const queryParamVal =
+					typeof req.query[queryParam] === 'string'
+						? (req.query[queryParam] as string).toLowerCase()
+						: '';
+				if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
+					errQueryParams.push(
+						`Query parameter: ${queryParam} has an invalid boolean value of ${
+							req.query[queryParam] as string
+						}`
+					);
+				}
+			});
 
-export const validateBooleanMiddleware: RequestHandler = (req, _res, next) => {
-	const queryKeys = Object.keys(req.query);
-	const errQueryParams: string[] = [];
-	queryKeys
-		.filter((queryParam) => queryParams.includes(queryParam))
-		.forEach((queryParam) => {
-			const queryParamVal =
-				typeof req.query[queryParam] === 'string'
-					? (req.query[queryParam] as string).toLowerCase()
-					: '';
-			if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
-				errQueryParams.push(
-					`Query parameter: ${queryParam} has an invalid boolean value of ${
-						req.query[queryParam] as string
-					}`
-				);
-			}
-		});
+		if (errQueryParams.length > 0) {
+			return next(new BadRequest(errQueryParams.join(' - ')));
+		}
 
-	if (errQueryParams.length > 0) {
-		return next(new BadRequest(errQueryParams.join(' - ')));
-	}
-
-	return next();
+		return next();
+	};
 };

--- a/src/middleware/validate/validateBooleanMiddleware.ts
+++ b/src/middleware/validate/validateBooleanMiddleware.ts
@@ -29,16 +29,18 @@ export const validateBooleanMiddleware = (
 		const errQueryParams: string[] = [];
 
 		for (const key of queryParams) {
-			const queryParamVal =
-				typeof req.query[key] === 'string'
-					? (req.query[key] as string).toLowerCase()
-					: '';
-			if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
-				errQueryParams.push(
-					`Query parameter: ${key} has an invalid boolean value of ${
-						req.query[key] as string
-					}`
-				);
+			if (req.query[key]) {
+				const queryParamVal =
+					typeof req.query[key] === 'string'
+						? (req.query[key] as string).toLowerCase()
+						: '';
+				if (!(queryParamVal === 'true' || queryParamVal === 'false')) {
+					errQueryParams.push(
+						`Query parameter: ${key} has an invalid boolean value of ${
+							req.query[key] as string
+						}`
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Summary

This adds validation for boolean middleware inputs. It checks specifically for `true`, and `false` for known query params that expect booleans. It will error with a 400 BadRequest. For query params that are not part of the API, as normal we just ignore them as the API should not handle those query params. 

### Extra

I cleaned up the validation tests and utils for both validateBoolean and validateAddress by creating a util folder that handles that functionality. 

closes: https://github.com/paritytech/substrate-api-sidecar/issues/398