### PR TITLE
fix: current leases undefined bug

### DIFF
--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -360,7 +360,7 @@ export class ParasService extends AbstractService {
 			blockNumber = number.unwrap();
 
 			currentLeaseHolders = leaseEntries
-				.filter(([_k, leases]) => leases[0].isSome)
+				.filter(([_k, leases]) => leases[0]?.isSome)
 				.map(([key, _l]) => key.args[0]);
 		}
 


### PR DESCRIPTION
When filtering through leases we need to make sure we check if there is no items in the array before we key into it as a valid polkadot-js type. This adds a fix to `/paras/leases/current`