### PR TITLE
ci: use polkadot node managed by argo-cd

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,7 +174,7 @@ deploy-production:
   <<:                              *kubernetes-env
   before_script:                   []
   variables:
-    POLKADOT_ADDRESS:              "ws://polkadot-node.nodes:9944"
+    POLKADOT_ADDRESS:              "ws://substrate-api-sidecar-benchmark-node.nodes:9944"
     BENCHMARK_DURATION:            "15m"                                   # Tests duration
     BENCHMARK_THREADS:             4                                       # Total number of threads to use
     BENCHMARK_CONNECTIONS:         12                                      # Total number of HTTP connections to keep open with each thread handling N = connections/threads
@@ -206,21 +206,6 @@ benchmark:
   needs:
     - build
 
-
-benchmark-test-new-argo-managed-node:
-  <<:                              *benchmark-template
-  <<:                              *test-refs-manual
-  needs:
-    - build-pr
-  variables:
-    POLKADOT_ADDRESS:              "ws://substrate-api-sidecar-benchmark-node.nodes:9944"
-    BENCHMARK_DURATION:            "15m"                                   # Tests duration
-    BENCHMARK_THREADS:             4                                       # Total number of threads to use
-    BENCHMARK_CONNECTIONS:         12                                      # Total number of HTTP connections to keep open with each thread handling N = connections/threads
-    BENCHMARK_TIMEOUT:             "120s"                                  # Record a timeout if a response is not received within this amount of time
-    BENCHMARK_OPTS:                "--latency"                             # Additional options, --latency:     print detailed latency statistics
-    BENCHMARK_SCRIPT:              "./scripts/ci/benchmarks/lightweight-bench.lua" # https://github.com/wg/wrk/blob/master/SCRIPTING
-    CI_IMAGE:                      "paritytech/node-wrk:latest"
 
 # manual step to run benchmarks in PR pipeline
 benchmark-manual-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,13 @@ benchmark-test-new-argo-managed-node:
   <<:                              *test-refs-manual
   variables:
     POLKADOT_ADDRESS:              "ws://substrate-api-sidecar-benchmark-node.nodes:9944"
+    BENCHMARK_DURATION:            "15m"                                   # Tests duration
+    BENCHMARK_THREADS:             4                                       # Total number of threads to use
+    BENCHMARK_CONNECTIONS:         12                                      # Total number of HTTP connections to keep open with each thread handling N = connections/threads
+    BENCHMARK_TIMEOUT:             "120s"                                  # Record a timeout if a response is not received within this amount of time
+    BENCHMARK_OPTS:                "--latency"                             # Additional options, --latency:     print detailed latency statistics
+    BENCHMARK_SCRIPT:              "./scripts/ci/benchmarks/lightweight-bench.lua" # https://github.com/wg/wrk/blob/master/SCRIPTING
+    CI_IMAGE:                      "paritytech/node-wrk:latest"
   needs:
     - build-pr
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,6 +206,14 @@ benchmark:
   needs:
     - build
 
+
+benchmark-test-new-argo-managed-node:
+  <<:                              *benchmark-template
+  variables:
+    POLKADOT_ADDRESS:              "ws://substrate-api-sidecar-benchmark-node.nodes:9944"
+  needs:
+    - build
+
 # manual step to run benchmarks in PR pipeline
 benchmark-manual-pr:
   <<:                              *benchmark-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -210,6 +210,8 @@ benchmark:
 benchmark-test-new-argo-managed-node:
   <<:                              *benchmark-template
   <<:                              *test-refs-manual
+  needs:
+    - build-pr
   variables:
     POLKADOT_ADDRESS:              "ws://substrate-api-sidecar-benchmark-node.nodes:9944"
     BENCHMARK_DURATION:            "15m"                                   # Tests duration
@@ -219,8 +221,6 @@ benchmark-test-new-argo-managed-node:
     BENCHMARK_OPTS:                "--latency"                             # Additional options, --latency:     print detailed latency statistics
     BENCHMARK_SCRIPT:              "./scripts/ci/benchmarks/lightweight-bench.lua" # https://github.com/wg/wrk/blob/master/SCRIPTING
     CI_IMAGE:                      "paritytech/node-wrk:latest"
-  needs:
-    - build-pr
 
 # manual step to run benchmarks in PR pipeline
 benchmark-manual-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,7 +206,6 @@ benchmark:
   needs:
     - build
 
-
 # manual step to run benchmarks in PR pipeline
 benchmark-manual-pr:
   <<:                              *benchmark-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,10 +209,11 @@ benchmark:
 
 benchmark-test-new-argo-managed-node:
   <<:                              *benchmark-template
+  <<:                              *test-refs-manual
   variables:
     POLKADOT_ADDRESS:              "ws://substrate-api-sidecar-benchmark-node.nodes:9944"
   needs:
-    - build
+    - build-pr
 
 # manual step to run benchmarks in PR pipeline
 benchmark-manual-pr:


### PR DESCRIPTION
This is a CI infrastructure change.
The purpose of this PR is to update the benchmark CI job that uses a polkadot node.
We introduced `argo-cd` as an automation tool to maintain applications deployed on GKE and used a new name for the polkadot node:  [substrate-api-sidecar-benchmark](https://argocd.parity-build.parity.io/applications/substrate-api-sidecar-benchmark?view=tree&orphaned=false&resource=)

This is a job that use the new pod managed by argo: https://gitlab.parity.io/parity/mirrors/substrate-api-sidecar/-/jobs/1818316#L65
There are some [error messages](https://gitlab.parity.io/parity/mirrors/substrate-api-sidecar/-/jobs/1818316#L92)
but I've seen those in other jobs that were using the current polkadot node.