### PR TITLE
test(e2e): cleanup timeout ms

### DIFF
--- a/e2e-tests/runtimeTests.spec.ts
+++ b/e2e-tests/runtimeTests.spec.ts
@@ -35,9 +35,6 @@ const TIMEOUT_MS = 60000;
 const { blocks, accounts, runtime, paras } = endpoints[chain];
 
 describe('Runtime Tests for blocks', () => {
-	/**
-	 * Allows a timeout of 30 seconds for each response.
-	 */
 	jest.setTimeout(TIMEOUT_MS);
 
 	/**
@@ -57,9 +54,6 @@ describe('Runtime Tests for blocks', () => {
 });
 
 describe('Runtime Tests for accounts', () => {
-	/**
-	 * Allows a timeout of 30 seconds for each response.
-	 */
 	jest.setTimeout(TIMEOUT_MS);
 
 	/**
@@ -79,9 +73,6 @@ describe('Runtime Tests for accounts', () => {
 });
 
 describe('Runtime Tests for `/runtime/*`', () => {
-	/**
-	 * Allows a timeout of 30 seconds for each response.
-	 */
 	jest.setTimeout(TIMEOUT_MS);
 
 	if (runtime.length) {
@@ -98,9 +89,6 @@ describe('Runtime Tests for `/runtime/*`', () => {
 });
 
 describe('Runtime Tests for `/paras/*`', () => {
-	/**
-	 * Allows a timeout of 30 seconds for each response.
-	 */
 	jest.setTimeout(TIMEOUT_MS);
 
 	if (paras.length) {

--- a/e2e-tests/runtimeTests.spec.ts
+++ b/e2e-tests/runtimeTests.spec.ts
@@ -30,6 +30,7 @@ const config = JSON.parse(
 ) as IEnvChainConfig;
 
 const chain = config.chain as ChainSpec;
+const TIMEOUT_MS = 60000;
 
 const { blocks, accounts, runtime, paras } = endpoints[chain];
 
@@ -37,7 +38,7 @@ describe('Runtime Tests for blocks', () => {
 	/**
 	 * Allows a timeout of 30 seconds for each response.
 	 */
-	jest.setTimeout(30000);
+	jest.setTimeout(TIMEOUT_MS);
 
 	/**
 	 * Test runtimes for `/blocks`
@@ -59,7 +60,7 @@ describe('Runtime Tests for accounts', () => {
 	/**
 	 * Allows a timeout of 30 seconds for each response.
 	 */
-	jest.setTimeout(30000);
+	jest.setTimeout(TIMEOUT_MS);
 
 	/**
 	 * Test runtiems for `/accounts/*`
@@ -81,7 +82,7 @@ describe('Runtime Tests for `/runtime/*`', () => {
 	/**
 	 * Allows a timeout of 30 seconds for each response.
 	 */
-	jest.setTimeout(30000);
+	jest.setTimeout(TIMEOUT_MS);
 
 	if (runtime.length) {
 		test.each(runtime)(
@@ -100,7 +101,7 @@ describe('Runtime Tests for `/paras/*`', () => {
 	/**
 	 * Allows a timeout of 30 seconds for each response.
 	 */
-	jest.setTimeout(30000);
+	jest.setTimeout(TIMEOUT_MS);
 
 	if (paras.length) {
 		test.each(paras)(


### PR DESCRIPTION
This sets the timeout to a set const, and raises it. Raising the timeout is just in response to westend's responses being a bit a longer than the other chains. This avoids any testing failing for timeouts. 