### PR TITLE
ci: add dependabot for yarn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,23 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "11:00"
+      # EST timezone
+      timezone: "America/New_York"
+    rebase-strategy: "auto"
+    open-pull-requests-limit: 20
+    commit-message:
+      # Prefix all commit messages with "chore"
+      # include a list of updated dependencies
+      prefix: "chore:"
+      include: "scope"
+    allow:
+      - dependency-name: "@polkadot/api"
+      - dependency-name: "@polkadot/util-crypto"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
closes: https://github.com/paritytech/substrate-api-sidecar/issues/1077

Since dependabot now has yarn berry support, we can now re activate it in the repo. 