### PR TITLE
chore(deps): dedupe deps

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -365,16 +365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.18.9":
-  version: 7.19.0
-  resolution: "@babel/runtime@npm:7.19.0"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.19.4":
+"@babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.19.4":
   version: 7.19.4
   resolution: "@babel/runtime@npm:7.19.4"
   dependencies:


### PR DESCRIPTION
Dependabot doesn't dedupe deps, so given https://github.com/paritytech/substrate-api-sidecar/pull/1098 we need to dedupe the deps. 