### PR TITLE
ci: remove allow from dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,5 @@ updates:
       # include a list of updated dependencies
       prefix: "chore:"
       include: "scope"
-    allow:
-      - dependency-name: "@polkadot/api"
-      - dependency-name: "@polkadot/util-crypto"
     labels:
       - "dependencies"


### PR DESCRIPTION
This will remove the `allow` field in the dependabot config so that all deps are eligible for updates. 