### PR TITLE
ci: break checks ci job into separate jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,11 @@ jobs:
 
       - name: Linter.
         run: yarn lint:ci
+  test:
+      # The type of runner that the job will run on
+    runs-on: ubuntu-latest
 
+    steps:
       - name: Unit tests.
-        run: yarn test
+          run: yarn test
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,17 +37,11 @@ jobs:
 
       - name: Install JS dependencies
         run: yarn install
-
+  lint:
+    steps:
       - name: Linter.
         run: yarn lint:ci
-
+  test:
+    steps:
       - name: Unit tests.
         run: yarn test
-  build_docs:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      - name: Build docs
-        run: yarn build:docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      
+      - name: Install JS dependencies
+        run: yarn install
 
       - name: Linter.
         run: yarn lint:ci
@@ -92,6 +95,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Install JS dependencies
+        run: yarn install
         
       - name: Build
         run: yarn build
@@ -120,6 +126,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Install JS dependencies
+        run: yarn install
         
       - name: Build Docs
         run: yarn build:docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,5 +46,5 @@ jobs:
 
     steps:
       - name: Unit tests.
-          run: yarn test
+        run: yarn test
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,11 +37,9 @@ jobs:
 
       - name: Install JS dependencies
         run: yarn install
-  lint:
-    steps:
+
       - name: Linter.
         run: yarn lint:ci
-  test:
-    steps:
+
       - name: Unit tests.
         run: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  check:
+  lint:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -45,6 +45,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout files
+        uses: actions/checkout@v3
+
+      - name: Install Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install JS dependencies
+        run: yarn install
+
       - name: Unit tests.
         run: yarn test
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout files
+      - name: Checkout files
         uses: actions/checkout@v3
 
       - name: Install Node v16

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,12 +35,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install JS dependencies
-        run: yarn install
-
       - name: Linter.
         run: yarn lint:ci
-  test:
+  tests:
       # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -70,4 +67,61 @@ jobs:
 
       - name: Unit tests.
         run: yarn test
+
+  builds:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v3
+
+      - name: Install Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+        
+      - name: Build
+        run: yarn build
+        
+    builds-docs:
+      # The type of runner that the job will run on
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout files
+          uses: actions/checkout@v3
+
+        - name: Install Node v16
+          uses: actions/setup-node@v3
+          with:
+            node-version: '16.13'
+
+        - name: Get yarn cache directory path
+          id: yarn-cache-dir-path
+          run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+        - uses: actions/cache@v3
+          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+          with:
+            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
+          
+        - name: Build Docs
+          run: yarn build:docs
+
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Unit tests.
         run: yarn test
 
-  builds:
+  build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -102,7 +102,7 @@ jobs:
       - name: Build
         run: yarn build
 
-  builds-docs:
+  build-docs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,33 +95,33 @@ jobs:
         
       - name: Build
         run: yarn build
+
+  builds-docs:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v3
+
+      - name: Install Node v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
         
-    builds-docs:
-      # The type of runner that the job will run on
-      runs-on: ubuntu-latest
-
-      steps:
-        - name: Checkout files
-          uses: actions/checkout@v3
-
-        - name: Install Node v16
-          uses: actions/setup-node@v3
-          with:
-            node-version: '16.13'
-
-        - name: Get yarn cache directory path
-          id: yarn-cache-dir-path
-          run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-        - uses: actions/cache@v3
-          id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-          with:
-            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.os }}-yarn-
-          
-        - name: Build Docs
-          run: yarn build:docs
+      - name: Build Docs
+        run: yarn build:docs
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,3 +43,11 @@ jobs:
 
       - name: Unit tests.
         run: yarn test
+  build_docs:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Build docs
+        run: yarn build:docs


### PR DESCRIPTION
ref: [#1075](https://github.com/paritytech/substrate-api-sidecar/issues/1075)

- breaks checks job into separate jobs for lint, tests, build and build docs