### PR TITLE
fix: adjust historyDepth to a consts

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.spec.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.spec.ts
@@ -58,10 +58,7 @@ import { AccountsStakingPayoutsService } from './AccountsStakingPayoutsService';
  */
 const era = polkadotRegistryV9122.createType('EraIndex', 532);
 
-const historyDepthAt = (): Promise<u32> =>
-	Promise.resolve().then(() => {
-		return polkadotRegistryV9122.createType('u32', 84);
-	});
+const historyDepthAt = polkadotRegistryV9122.createType('u32', 84);
 
 const erasRewardPointsAt = (
 	_eraIndex: EraIndex
@@ -125,12 +122,16 @@ const deriveEraExposure = (_eraIndex: EraIndex): Promise<DeriveEraExposure> =>
 
 const mockHistoricApi = {
 	registry: polkadotRegistryV9122,
+	consts: {
+		staking: {
+			historyDepth: historyDepthAt,
+		},
+	},
 	query: {
 		staking: {
 			ledger: ledgerAt,
 			erasRewardPoints: erasRewardPointsAt,
 			erasValidatorReward: erasValidatorRewardAt,
-			historyDepth: historyDepthAt,
 			erasValidatorPrefs: erasValidatorPrefsAt,
 			bonded: bondedAt,
 		},

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -20,7 +20,7 @@ import {
 	DeriveEraExposure,
 	DeriveEraExposureNominating,
 } from '@polkadot/api-derive/staking/types';
-import { Option, u32 } from '@polkadot/types';
+import { Option } from '@polkadot/types';
 import {
 	BalanceOf,
 	BlockHash,
@@ -91,10 +91,8 @@ export class AccountsStakingPayoutsService extends AbstractService {
 		const { api } = this;
 		const historicApi = await api.at(hash);
 
-		const [{ number }, historyDepth] = await Promise.all([
-			api.rpc.chain.getHeader(hash),
-			historicApi.query.staking.historyDepth<u32>(),
-		]);
+		const { number } = await api.rpc.chain.getHeader(hash);
+		const historyDepth = historicApi.consts.staking.historyDepth;
 
 		// Information is kept for eras in `[current_era - history_depth; current_era]`
 		if (depth > historyDepth.toNumber()) {

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -20,7 +20,7 @@ import {
 	DeriveEraExposure,
 	DeriveEraExposureNominating,
 } from '@polkadot/api-derive/staking/types';
-import { Option } from '@polkadot/types';
+import { Option, u32 } from '@polkadot/types';
 import {
 	BalanceOf,
 	BlockHash,
@@ -92,7 +92,19 @@ export class AccountsStakingPayoutsService extends AbstractService {
 		const historicApi = await api.at(hash);
 
 		const { number } = await api.rpc.chain.getHeader(hash);
-		const historyDepth = historicApi.consts.staking.historyDepth;
+
+		/**
+		 * Given https://github.com/polkadot-js/api/issues/5232,
+		 * polkadot-js, and substrate treats historyDepth as a consts. In order
+		 * to maintain historical integrity we need to make a check to cover both the
+		 * storage query and the consts.
+		 */
+		let historyDepth: u32;
+		if (historicApi.consts.staking.historyDepth) {
+			historyDepth = historicApi.consts.staking.historyDepth;
+		} else {
+			historyDepth = await historicApi.query.staking.historyDepth<u32>();
+		}
 
 		// Information is kept for eras in `[current_era - history_depth; current_era]`
 		if (depth > historyDepth.toNumber()) {


### PR DESCRIPTION
closes: https://github.com/paritytech/substrate-api-sidecar/issues/1104

This PR takes in account that historyDepth is no longer a storage query and a consts instead. This takes into account both historic integrity and future runtimes. 

ref: https://github.com/polkadot-js/api/issues/5232