### PR TITLE
ci: allow only security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,8 @@ updates:
       # EST timezone
       timezone: "America/New_York"
     rebase-strategy: "auto"
-    open-pull-requests-limit: 20
+    # Disable versioned updates, and only allow security updates
+    open-pull-requests-limit: 0
     commit-message:
       # Prefix all commit messages with "chore"
       # include a list of updated dependencies


### PR DESCRIPTION
This sets the open pull request limit to 0 to make sure dependabot is only used for security updates. 