### PR TITLE
test: optimize test runner for e2e-tests and ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
         run: yarn install
 
       - name: Unit tests.
-        run: yarn test
+        run: yarn test:ci
 
   build:
     # The type of runner that the job will run on

--- a/e2e-tests/jest.config.js
+++ b/e2e-tests/jest.config.js
@@ -3,4 +3,12 @@ const base = require('@substrate/dev/config/jest')
 module.exports = {
     ...base,
     testPathIgnorePatterns: ['/build/', '/node_modules/', '/src/'],
+    testEnvironment: 'node',
+	maxConcurrency: 3,
+	maxWorkers: '50%',
+    globals: {
+        'ts-jest': {
+            isloatedModules: true
+        }
+    }
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dev": "tsc-watch --onSuccess \"yarn run main\"",
     "test": "NODE_ENV=test substrate-exec-jest --detectOpenHandles",
     "test:watch": "NODE_ENV=test substrate-exec-jest --watch",
+    "test:ci": "NODE_ENV=test substrate-exec-jest --runInBand",
     "lint:e2e-tests": "cd e2e-tests && substrate-dev-run-lint",
     "build:e2e-tests": "substrate-exec-tsc --project e2e-tests/tsconfig.json",
     "test:e2e-tests": "yarn build:e2e-tests && node ./e2e-tests/build/index.js --config=./e2e-tests/jest.config.js",


### PR DESCRIPTION
1. This optimizes the test runner for the e2e tests by assigning the max concurrent workers, and the allotted CPU that is available. It also uses a trick to isolateModules since our test runner utilizes `ts-jest` (And by nature is slow).

2. Use `--runInBand` for running CI tests to not abuse CPU usage in the github actions runner. 