### PR TITLE
docs: update node stability for versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Compatibility:
 |---------------|:-----------:|
 |     v14.x.x   |   Stable    |
 |     v16.x.x   |   Stable    |
-|     v17.x.x   |  Not Stable |
-|     v18.x.x   |   Pending   |
+|     v17.x.x   |   Stable    |
+|     v18.x.x   |   stable    |
+|     v19.x.x   |   Pending   |
 
 NOTE: Node LTS (`long term support`) versions start with an even number, and odd number versions are subject to a 6 month testing period with active support before they are unsupported. It is recommended to use sidecar with a stable actively maintained version of node.js.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Compatibility:
 |     v14.x.x   |   Stable    |
 |     v16.x.x   |   Stable    |
 |     v17.x.x   |   Stable    |
-|     v18.x.x   |   stable    |
+|     v18.x.x   |   Stable    |
 |     v19.x.x   |   Pending   |
 
 NOTE: Node LTS (`long term support`) versions start with an even number, and odd number versions are subject to a 6 month testing period with active support before they are unsupported. It is recommended to use sidecar with a stable actively maintained version of node.js.


### PR DESCRIPTION
This updates the stability chart for Node.js versions, and sidecar support.