### PR TITLE
fix: replace rpc calls for fees and give support for weight v1 and v2

### DIFF
--- a/src/services/node/NodeTransactionPoolService.spec.ts
+++ b/src/services/node/NodeTransactionPoolService.spec.ts
@@ -22,8 +22,6 @@ import {
 	// blockHash789629,
 	defaultMockApi,
 	pendingExtrinsics,
-	queryInfoBalancesTransfer,
-	queryInfoCouncilVote,
 } from '../test-helpers/mock';
 import transactionPoolResponse from '../test-helpers/responses/node/transactionPool.json';
 import transactionPoolWithTipResponse from '../test-helpers/responses/node/transactionPoolWithTip.json';
@@ -99,7 +97,6 @@ describe('NodeTransactionPoolService', () => {
 			]);
 			(defaultMockApi.rpc.author as any).pendingExtrinsics = () =>
 				Promise.resolve().then(() => pool);
-			(defaultMockApi.rpc.payment as any).queryInfo = queryInfoCouncilVote;
 
 			expect(
 				sanitizeNumbers(
@@ -108,7 +105,6 @@ describe('NodeTransactionPoolService', () => {
 			).toStrictEqual(transactionPoolWithTipOperationalResponse);
 
 			(defaultMockApi.rpc.author as any).pendingExtrinsics = pendingExtrinsics;
-			(defaultMockApi.rpc.payment as any).queryInfo = queryInfoBalancesTransfer;
 		});
 	});
 });

--- a/src/services/node/NodeTransactionPoolService.ts
+++ b/src/services/node/NodeTransactionPoolService.ts
@@ -14,7 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { DispatchClass, Extrinsic, Weight } from '@polkadot/types/interfaces';
+import { u64 } from '@polkadot/types';
+import {
+	DispatchClass,
+	Extrinsic,
+	Weight,
+	WeightV2,
+} from '@polkadot/types/interfaces';
 import BN from 'bn.js';
 
 import { INodeTransactionPool } from '../../types/responses';
@@ -62,11 +68,12 @@ export class NodeTransactionPoolService extends AbstractService {
 	private async extractExtrinsicInfo(ext: Extrinsic) {
 		const { api } = this;
 		const { hash, tip } = ext;
+		const u8a = ext.toU8a();
 		const {
 			class: c,
 			partialFee,
 			weight,
-		} = await api.rpc.payment.queryInfo(ext.toHex());
+		} = await api.call.transactionPaymentApi.queryInfo(u8a, u8a.length);
 		const priority = await this.computeExtPriority(ext, c, weight);
 
 		return {
@@ -102,12 +109,22 @@ export class NodeTransactionPoolService extends AbstractService {
 		const BN_ONE = new BN(1);
 		const sanitizedClass = this.defineDispatchClassType(dispatchClass);
 
-		const maxBlockWeight =
-			api.consts.system.blockWeights.maxBlock.refTime.unwrap();
+		// Check which versions of Weight we are using by checking to see if refTime exists.
+		const versionedWeight = weight['refTime']
+			? (weight as unknown as WeightV2).refTime.unwrap().toBn()
+			: weight.toBn();
+		const maxBlockWeight = api.consts.system.blockWeights.maxBlock.refTime
+			? api.consts.system.blockWeights.maxBlock.refTime.unwrap()
+			: (api.consts.system.blockWeights.maxBlock as unknown as u64);
 		const maxLength: BN = new BN(
 			api.consts.system.blockLength.max[sanitizedClass]
 		);
-		const boundedWeight = BN.min(BN.max(weight.toBn(), BN_ONE), maxBlockWeight);
+
+		const boundedWeight = BN.min(
+			BN.max(versionedWeight, BN_ONE),
+			new BN(maxBlockWeight)
+		);
+
 		const boundedLength = BN.min(BN.max(new BN(len), BN_ONE), maxLength);
 		const maxTxPerBlockWeight = maxBlockWeight.toBn().div(boundedWeight);
 		const maxTxPerBlockLength = maxLength.div(boundedLength);
@@ -127,9 +144,9 @@ export class NodeTransactionPoolService extends AbstractService {
 				break;
 			}
 			case 'operational': {
-				const { inclusionFee } = await api.rpc.payment.queryFeeDetails(
-					ext.toHex()
-				);
+				const u8a = ext.toU8a();
+				const { inclusionFee } =
+					await api.call.transactionPaymentApi.queryFeeDetails(u8a, u8a.length);
 				const { operationalFeeMultiplier } = api.consts.transactionPayment;
 
 				if (inclusionFee.isNone) {

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -28,7 +28,6 @@ import {
 	SessionIndex,
 	StakingLedger,
 } from '@polkadot/types/interfaces';
-import {} from '@polkadot/types/types';
 import BN from 'bn.js';
 
 import { polkadotMetadata } from '../../../test-helpers/metadata/metadata';

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ApiPromise } from '@polkadot/api';
-import { Vec } from '@polkadot/types';
+import { GenericExtrinsic, Vec } from '@polkadot/types';
 import { Option } from '@polkadot/types/codec';
 import {
 	AccountId,
@@ -28,6 +28,7 @@ import {
 	SessionIndex,
 	StakingLedger,
 } from '@polkadot/types/interfaces';
+import {} from '@polkadot/types/types';
 import BN from 'bn.js';
 
 import { polkadotMetadata } from '../../../test-helpers/metadata/metadata';
@@ -159,29 +160,23 @@ const queryFeeDetails = () =>
 		});
 	});
 
-export const queryInfoBalancesTransfer = (
-	_extrinsic: string,
-	_hash: Hash
-): Promise<RuntimeDispatchInfo> =>
-	Promise.resolve().then(() =>
-		polkadotRegistry.createType('RuntimeDispatchInfo', {
-			weight: 195000000,
-			class: 'Normal',
-			partialFee: 149000000,
-		})
-	);
+const runtimeDispatchInfo = polkadotRegistry.createType('RuntimeDispatchInfo', {
+	weight: 195000000,
+	class: 'Normal',
+	partialFee: 149000000,
+});
 
-export const queryInfoCouncilVote = (
+export const queryInfoCall = (
+	_extrinsic: GenericExtrinsic,
+	_length: Uint8Array
+): Promise<RuntimeDispatchInfo> =>
+	Promise.resolve().then(() => runtimeDispatchInfo);
+
+export const queryInfoAt = (
 	_extrinsic: string,
 	_hash: Hash
 ): Promise<RuntimeDispatchInfo> =>
-	Promise.resolve().then(() =>
-		polkadotRegistry.createType('RuntimeDispatchInfo', {
-			weight: 158324000,
-			class: 'Operational',
-			partialFee: 153000018,
-		})
-	);
+	Promise.resolve().then(() => runtimeDispatchInfo);
 
 export const submitExtrinsic = (_extrinsic: string): Promise<Hash> =>
 	Promise.resolve().then(() => polkadotRegistry.createType('Hash'));
@@ -251,7 +246,7 @@ export const defaultMockApi = {
 	runtimeVersion,
 	call: {
 		transactionPaymentApi: {
-			queryInfo: queryInfoBalancesTransfer,
+			queryInfo: queryInfoCall,
 			queryFeeDetails,
 		},
 	},
@@ -321,7 +316,7 @@ export const defaultMockApi = {
 			properties,
 		},
 		payment: {
-			queryInfo: queryInfoBalancesTransfer,
+			queryInfo: queryInfoAt,
 			queryFeeDetails,
 		},
 		author: {

--- a/src/services/test-helpers/mock/mockApi.ts
+++ b/src/services/test-helpers/mock/mockApi.ts
@@ -249,6 +249,12 @@ const traceBlock = () =>
  */
 export const defaultMockApi = {
 	runtimeVersion,
+	call: {
+		transactionPaymentApi: {
+			queryInfo: queryInfoBalancesTransfer,
+			queryFeeDetails,
+		},
+	},
 	consts: {
 		system: {
 			blockLength: {
@@ -260,9 +266,7 @@ export const defaultMockApi = {
 			},
 			blockWeights: {
 				baseBlock: new BN(5481991000),
-				maxBlock: {
-					refTime: polkadotRegistry.createType('Compact<u64>', 15),
-				},
+				maxBlock: polkadotRegistry.createType('u64', 15),
 				perClass: {
 					normal: {
 						baseExtrinsic: new BN(85212000),

--- a/src/services/test-helpers/responses/node/transactionPoolWithTipOperational.json
+++ b/src/services/test-helpers/responses/node/transactionPoolWithTipOperational.json
@@ -4,8 +4,8 @@
             "encodedExtrinsic": "0x350284004adf51a47b72795366d52285e329229c836ea7bbfe139dbe8fa0700c4f86fc5601fc44dcd1994c111671b3577b02e391be8aff10f7ccf766f3189859ea343db041779a67f9357cba0ba051f83d63e45e7a88b5e2ca642181592052acd9f4ccc8821501c107000f03f2af187bbc8a4a2b5a28c2a3c2d85bf7e5b1700cbf1207a8e4c1eb7d8e7e4037350301",
             "hash": "0x3275363a9fda2dd41f03689bd47bba64e01fa3e5b558d8b4bbeb0df70cdceb73",
             "tip": "0",
-            "priority": "765000101",
-            "partialFee": "153000018"
+            "priority": "1",
+            "partialFee": "149000000"
         }
     ]
 }

--- a/src/services/transaction/TransactionFeeEstimateService.spec.ts
+++ b/src/services/transaction/TransactionFeeEstimateService.spec.ts
@@ -27,7 +27,7 @@ import {
 	balancesTransferValid,
 	blockHash789629,
 	defaultMockApi,
-	queryInfoBalancesTransfer,
+	queryInfoAt,
 } from '../test-helpers/mock';
 import invalidResponse from '../test-helpers/responses/transaction/feeEstimateInvalid.json';
 import validRpcResponse from '../test-helpers/responses/transaction/feeEstimateValidRpcCall.json';
@@ -112,7 +112,7 @@ describe('TransactionFeeEstimateService', () => {
 				)
 			).rejects.toStrictEqual(invalidResponse);
 
-			(mockApi.rpc.payment as any).queryInfo = queryInfoBalancesTransfer;
+			(mockApi.rpc.payment as any).queryInfo = queryInfoAt;
 			(mockApiAt.call.transactionPaymentApi.queryInfo as unknown) =
 				queryInfoCallAt;
 		});


### PR DESCRIPTION
This replaces the rpc calls with runtime calls, and fizes the bug for weights, regarding both weights v1, and weights v2.

closes: https://github.com/paritytech/substrate-api-sidecar/issues/1153