### PR TITLE
Added env vars for logging to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,13 @@ export SAS_SUBSTRATE_TYPES=/path/to/my-chains-types.json
 
 - `SAS_LOG_LEVEL`: the lowest priority log level to surface, defaults to `info`. Tip: set to `http`
     to see all HTTP requests.
-- `SAS_LOG_JSON`: wether or not to have logs formatted as JSON, defaults to `false`.
+- `SAS_LOG_JSON`: whether or not to have logs formatted as JSON, defaults to `false`.
     Useful when using `stdout` to programmatically process Sidecar log data.
-- `SAS_LOG_FILTER_RPC`: wether or not to filter polkadot-js API-WS RPC logging, defaults to `false`.
-- `SAS_LOG_STRIP_ANSI`: wether or not to strip ANSI characters from logs, defaults
+- `SAS_LOG_FILTER_RPC`: whether or not to filter polkadot-js API-WS RPC logging, defaults to `false`.
+- `SAS_LOG_STRIP_ANSI`: whether or not to strip ANSI characters from logs, defaults
     to `false`. Useful when logging RPC calls with JSON written to transports.
+- `SAS_LOG_TO_FILE`: whether or not to export logs to files, defaults to `false`.
+- `SAS_PATH_TO_LOG_FILES`: to specify a custom path for log files, defaults to `build/src/logging/transports/logs`.
 
 #### Log levels
 

--- a/src/logging/Log.ts
+++ b/src/logging/Log.ts
@@ -35,11 +35,14 @@ export class Log {
 			return this._logger;
 		}
 
-		this._transports = [
-			consoleTransport(),
-			fileTransport('error', 'errors.log'),
-			fileTransport('info', 'logs.log'),
-		];
+		this._transports = [consoleTransport()];
+
+		if (process.env.SAS_LOG_TO_FILE === 'true') {
+			this._transports.push(
+				fileTransport('error', 'errors.log'),
+				fileTransport('info', 'logs.log')
+			);
+		}
 
 		this._logger = createLogger({
 			transports: this._transports,

--- a/src/logging/transports/fileTransport.ts
+++ b/src/logging/transports/fileTransport.ts
@@ -4,9 +4,15 @@ export const fileTransport = (
 	level: string,
 	fileName: string
 ): transports.FileTransportInstance => {
+
+  let logsDirectory = __dirname;
+  if (process.env.SAS_PATH_TO_LOG_FILES) {
+    logsDirectory = process.env.SAS_PATH_TO_LOG_FILES;
+  }
+
 	return new transports.File({
 		level,
-		filename: `${__dirname}/logs/${fileName}`,
+		filename: `${logsDirectory}/logs/${fileName}`,
 		handleExceptions: true,
 		maxsize: 5242880, // 5MB
 		maxFiles: 5,


### PR DESCRIPTION
### Description
- Added the necessary env vars as described in #1189  : 
  - One env var `SAS_LOG_TO_FILE` to give the option to log to files or not.
  - One env var `SAS_PATH_TO_LOG_FILES` to specify a custom path where file logs are saved.
- Updated the README.
