### PR TITLE
chore: updated to new version of confmgr

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@polkadot/util-crypto": "^10.2.6",
     "@substrate/calc": "^0.3.1",
     "argparse": "^2.0.1",
-    "confmgr": "1.0.9",
+    "confmgr": "^1.0.10",
     "express": "^4.18.1",
     "express-winston": "^4.2.0",
     "http-errors": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,16 +356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.17.9":
-  version: 7.17.9
-  resolution: "@babel/runtime@npm:7.17.9"
-  dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: 4d56bdb82890f386d5a57c40ef985a0ed7f0a78f789377a2d0c3e8826819e0f7f16ba0fe906d9b2241c5f7ca56630ef0653f5bb99f03771f7b87ff8af4bf5fe3
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7":
+"@babel/runtime@npm:7.20.13, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7":
   version: 7.20.13
   resolution: "@babel/runtime@npm:7.20.13"
   dependencies:
@@ -1260,7 +1251,7 @@ __metadata:
     "@types/morgan": 1.9.3
     "@types/triple-beam": ^1.3.2
     argparse: ^2.0.1
-    confmgr: 1.0.9
+    confmgr: ^1.0.10
     express: ^4.18.1
     express-winston: ^4.2.0
     http-errors: ^2.0.0
@@ -2426,16 +2417,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"confmgr@npm:1.0.9":
-  version: 1.0.9
-  resolution: "confmgr@npm:1.0.9"
+"confmgr@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "confmgr@npm:1.0.10"
   dependencies:
-    "@babel/runtime": 7.17.9
+    "@babel/runtime": 7.20.13
     chalk: ~4
-    dotenv: 16.0.0
-    typescript: 4.6.3
-    yaml: 2.0.1
-  checksum: 0f48790bce9ffa90a12719d4dca32123df80a0b73920f65f397cd80e546a06416cbf1274c17d7229ce356cb46bb039232d91ce788f2c8a9caea2a5f01da707a0
+    dotenv: 16.0.3
+    yaml: 2.2.1
+  checksum: 742d467361ecd435de1a167f1a95ea8db7219feb9a8f5a61b9bcb3cee9caa6333c6aad839be5192b089994e322ea8d53fb12d1df05e15124488e01edfe8c9d07
   languageName: node
   linkType: hard
 
@@ -2688,10 +2678,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:16.0.0":
-  version: 16.0.0
-  resolution: "dotenv@npm:16.0.0"
-  checksum: 664cebb51f0a9a1d1b930f51f0271e72e26d62feaecc9dc03df39453dd494b4e724809ca480fb3ec3213382b1ed3f791aaeb83569a137f9329ce58efd4853dbf
+"dotenv@npm:16.0.3":
+  version: 16.0.3
+  resolution: "dotenv@npm:16.0.3"
+  checksum: afcf03f373d7a6d62c7e9afea6328e62851d627a4e73f2e12d0a8deae1cd375892004f3021883f8aec85932cd2834b091f568ced92b4774625b321db83b827f8
   languageName: node
   linkType: hard
 
@@ -5532,7 +5522,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.4":
+"regenerator-runtime@npm:^0.13.11":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -6711,10 +6701,10 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.0.1":
-  version: 2.0.1
-  resolution: "yaml@npm:2.0.1"
-  checksum: 23f95ff0d646c894048ac5072b5b6d393a398af1b2553916f0de276d62dbb3279ae3c969d7fcefe7a213be4efc9b4aa3ae1439c97095d3d3765fc6bc424807ac
+"yaml@npm:2.2.1":
+  version: 2.2.1
+  resolution: "yaml@npm:2.2.1"
+  checksum: 84f68cbe462d5da4e7ded4a8bded949ffa912bc264472e5a684c3d45b22d8f73a3019963a32164023bdf3d83cfb6f5b58ff7b2b10ef5b717c630f40bd6369a23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes: #1196 

As an additional note, the `confmgr` repo was moved from Gitlab to Github and below are the corresponding links : 
-   repo: [https://github.com/chevdor/confmgr](https://github.com/chevdor/confmgr)
-   doc: [https://chevdor.github.io/confmgr/](https://chevdor.github.io/confmgr/)
-   package: [https://www.npmjs.com/package/confmgr](https://www.npmjs.com/package/confmgr)