### PR TITLE
chore(tech-debt): cleanup type assignment for `consoleOverride`

### DIFF
--- a/src/logging/consoleOverride.ts
+++ b/src/logging/consoleOverride.ts
@@ -18,7 +18,7 @@
 /* eslint-disable prefer-rest-params */
 
 import { format } from 'util';
-import { Logger } from 'winston';
+import { LeveledLogMethod, Logger } from 'winston';
 
 /**
  * Override console methods with a winston.Logger.
@@ -33,19 +33,12 @@ export function consoleOverride(logger: Logger): void {
 		['error', 'error'],
 		['debug', 'debug'],
 	].forEach(([consoleLevel, winstonLevel]) => {
-		// Sacrereligious typecasting explained:
-		//
-		// `args as [string]`: format @types dictate that it needs an array of at least length 1. However,
-		// from testing this is not neccesary, so we override the type as a string tuple.
-		//
-		// `(format.apply(format, args as [string]) as unknown) as object`: TS incorrectly says the we
-		// need a object as an argument to `info.call`. However, it will accept a string perfectly fine,
-		// which is what `format.apply` returns.
 		console[consoleLevel] = function (...args: unknown[]) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-			logger[winstonLevel].call(
+			// We typecast here because the typescript compiler is not sure what we are keying into.
+			// The type within the logger of any of the following log levels is `LeveledLogMethod`.
+			(logger[winstonLevel] as LeveledLogMethod).call<Logger, string[], Logger>(
 				logger,
-				format.apply(format, args as [string]) as unknown as object
+				format.apply(format, args)
 			);
 		};
 	});


### PR DESCRIPTION
This cleans up some technical debt around type assignment for our `consoleOverride`.