### PR TITLE
ci: add docker image description publishing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,6 +162,24 @@ build:
         buildah push --format=v2s2 "$CONTAINER_REPO:$DOCKER_IMAGE_TAG";
       fi
 
+push-docker-image-description:
+  stage:                           build
+  extends:
+    - .kubernetes-env
+    - .publish-refs
+  variables:
+    CI_IMAGE:                      paritytech/dockerhub-description
+    DOCKERHUB_REPOSITORY:          parity/substrate-api-sidecar
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
+    SHORT_DESCRIPTION:             "REST service to interact with blockchain nodes built using Substrate's FRAME framework."
+  rules:
+    - changes:
+      - Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh
+
 # checks that dockerimage can be built without publishing
 build-pr:
   <<:                              *dockerize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,9 +165,7 @@ build:
 push-docker-image-description:
   stage:                           build
   before_script:
-    - ls
-    - pwd
-    - ls $CI_PROJECT_DIR
+    - echo $README_FILEPATH
   extends:
     - .kubernetes-env
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,7 +180,7 @@ push-docker-image-description:
       changes:
       - Dockerfile.README.md
   script:
-    - cd / && sh entrypoint.sh
+    - cd / && node index.js | sed -i '/::add-mask::/d'
 
 # checks that dockerimage can be built without publishing
 build-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,7 +174,7 @@ push-docker-image-description:
     README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
     SHORT_DESCRIPTION:             "REST service to interact with blockchain nodes built using Substrate's FRAME framework."
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "1234"
       changes:
       - Dockerfile.README.md
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,7 +165,9 @@ build:
 push-docker-image-description:
   stage:                           build
   before_script:
-    - echo
+    - ls
+    - pwd
+    - ls /
   extends:
     - .kubernetes-env
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,7 +180,7 @@ push-docker-image-description:
       changes:
       - Dockerfile.README.md
   script:
-    - cd / && node index.js | sed -i '/::add-mask::/d'
+    - cd / && node index.js
 
 # checks that dockerimage can be built without publishing
 build-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,8 +164,6 @@ build:
 
 push-docker-image-description:
   stage:                           build
-  extends:
-    - .kubernetes-env
   variables:
     CI_IMAGE:                      paritytech/dockerhub-description
     DOCKERHUB_REPOSITORY:          parity/substrate-api-sidecar
@@ -179,6 +177,8 @@ push-docker-image-description:
       - Dockerfile.README.md
   script:
     - cd / && sh entrypoint.sh
+  tags:
+    - kubernetes-parity-build
 
 # checks that dockerimage can be built without publishing
 build-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,8 +164,11 @@ build:
 
 push-docker-image-description:
   stage:                           build
-  image:                           paritytech/dockerhub-description
+  before_script:
+  extends:
+    - .kubernetes-env
   variables:
+    CI_IMAGE:                      paritytech/dockerhub-description
     DOCKERHUB_REPOSITORY:          parity/substrate-api-sidecar
     DOCKER_USERNAME:               $Docker_Hub_User_Parity
     DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
@@ -177,8 +180,6 @@ push-docker-image-description:
       - Dockerfile.README.md
   script:
     - cd / && sh entrypoint.sh
-  tags:
-    - kubernetes-parity-build
 
 # checks that dockerimage can be built without publishing
 build-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,8 +164,8 @@ build:
 
 push-docker-image-description:
   stage:                           build
+  image:                           paritytech/dockerhub-description
   variables:
-    CI_IMAGE:                      paritytech/dockerhub-description
     DOCKERHUB_REPOSITORY:          parity/substrate-api-sidecar
     DOCKER_USERNAME:               $Docker_Hub_User_Parity
     DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,7 +165,7 @@ build:
 push-docker-image-description:
   stage:                           build
   before_script:
-    - echo $README_FILEPATH
+    - echo
   extends:
     - .kubernetes-env
   variables:
@@ -176,11 +176,11 @@ push-docker-image-description:
     README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
     SHORT_DESCRIPTION:             "REST service to interact with blockchain nodes built using Substrate's FRAME framework."
   rules:
-    - if: $CI_COMMIT_REF_NAME == "1234"
+    - if: $CI_COMMIT_REF_NAME == "master"
       changes:
       - Dockerfile.README.md
   script:
-    - cd / && node index.js
+    - cd / && sh entrypoint.sh
 
 # checks that dockerimage can be built without publishing
 build-pr:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,7 +167,7 @@ push-docker-image-description:
   before_script:
     - ls
     - pwd
-    - ls /
+    - ls $CI_PROJECT_DIR
   extends:
     - .kubernetes-env
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,6 +165,7 @@ build:
 push-docker-image-description:
   stage:                           build
   before_script:
+    - echo
   extends:
     - .kubernetes-env
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,7 +166,6 @@ push-docker-image-description:
   stage:                           build
   extends:
     - .kubernetes-env
-    - .publish-refs
   variables:
     CI_IMAGE:                      paritytech/dockerhub-description
     DOCKERHUB_REPOSITORY:          parity/substrate-api-sidecar
@@ -175,7 +174,8 @@ push-docker-image-description:
     README_FILEPATH:               $CI_PROJECT_DIR/Dockerfile.README.md
     SHORT_DESCRIPTION:             "REST service to interact with blockchain nodes built using Substrate's FRAME framework."
   rules:
-    - changes:
+    - if: $CI_COMMIT_REF_NAME == "master"
+      changes:
       - Dockerfile.README.md
   script:
     - cd / && sh entrypoint.sh

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -1,0 +1,37 @@
+## substrate-api-sidecar Docker Image
+
+With each release, the maintainers publish a docker image to dockerhub at [parity/substrate-api-sidecar](https://hub.docker.com/r/parity/substrate-api-sidecar/tags?page=1&ordering=last_updated)
+
+### Pull the latest release
+
+```bash
+docker pull docker.io/parity/substrate-api-sidecar:latest
+```
+
+The specific image tag matches the release version.
+
+### Or build from source
+
+```bash
+yarn build:docker
+```
+
+### Run
+
+```bash
+# For default use run:
+docker run --rm -it --read-only -p 8080:8080 substrate-api-sidecar
+
+# Or if you want to use environment variables set in `.env.docker`, run:
+docker run --rm -it --read-only --env-file .env.docker -p 8080:8080 substrate-api-sidecar
+```
+
+**NOTE**: While you could omit the `--read-only` flag, it is **strongly recommended for containers used in production**.
+
+then you can test with:
+
+```bash
+curl -s http://0.0.0.0:8080/blocks/head | jq
+```
+
+**N.B.** The docker flow presented here is just a sample to help get started. Modifications may be necessary for secure usage.

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -35,3 +35,4 @@ curl -s http://0.0.0.0:8080/blocks/head | jq
 ```
 
 **N.B.** The docker flow presented here is just a sample to help get started. Modifications may be necessary for secure usage.
+

--- a/Dockerfile.README.md
+++ b/Dockerfile.README.md
@@ -35,4 +35,3 @@ curl -s http://0.0.0.0:8080/blocks/head | jq
 ```
 
 **N.B.** The docker flow presented here is just a sample to help get started. Modifications may be necessary for secure usage.
-


### PR DESCRIPTION
This PR adds CI job to publish docker image description to hub.docker.com

Dockerfile.README.md content just copy/paste from main README.md docker section. Feel free to propose changes.

Subtask of https://github.com/paritytech/ci_cd/issues/741