### PR TITLE
fix: incorrect finalization when head blocks are cached and polled

### DIFF
--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -111,7 +111,7 @@ export class BlocksService extends AbstractService {
 		// Before making any api calls check the cache if the queried block exists
 		const isBlockCached = this.blockStore.get(hash.toString());
 
-		if (isBlockCached) {
+		if (isBlockCached && isBlockCached.finalized !== false) {
 			return isBlockCached;
 		}
 


### PR DESCRIPTION
closes: https://github.com/paritytech/substrate-api-sidecar/issues/1264

For more detail please refer the issue above:

Summary: Our caching mechanism was storing unfinalized block heads and once they were finalized returning the older value which is incorrect, so in this PR we are ensuring that if the cached block is not finalized to re-query the block. NOTE: there is room for optimization but for now this is a solution to get rid of the bug.