### PR TITLE
test: add acala & karura to e2e tests and some improvements

### DIFF
--- a/e2e-tests/latest/endpoints/acala.ts
+++ b/e2e-tests/latest/endpoints/acala.ts
@@ -75,6 +75,6 @@ export const acala: IConfig = {
 	},
 	'/transaction/material': {
 		path: '/transaction/material',
-		queryParams: ['noMeta=true'],
+		queryParams: [],
 	},
 };

--- a/e2e-tests/latest/endpoints/acala.ts
+++ b/e2e-tests/latest/endpoints/acala.ts
@@ -18,7 +18,7 @@ import { IConfig } from '../types/endpoints';
 
 export const acala: IConfig = {
 	'/blocks': {
-		path: '/blocks?range=1-5',
+		path: '/blocks?range=3000000-3000005',
 		queryParams: [],
 	},
 	'/blocks/{blockId}': {

--- a/e2e-tests/latest/endpoints/acala.ts
+++ b/e2e-tests/latest/endpoints/acala.ts
@@ -1,0 +1,80 @@
+// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { IConfig } from '../types/endpoints';
+
+export const acala: IConfig = {
+	'/blocks': {
+		path: '/blocks?range=1-5',
+		queryParams: [],
+	},
+	'/blocks/{blockId}': {
+		path: '/blocks/{blockId}',
+		queryParams: ['eventDocs=true', 'extrinsicDocs=true'],
+	},
+	'/blocks/{blockId}/header': {
+		path: '/blocks/{blockId}/header',
+		queryParams: [],
+	},
+	'/blocks/{blockId}/extrinsics/{extrinsicIndex}': {
+		path: `/blocks/{blockId}/extrinsics/0`,
+		queryParams: ['eventDocs=true', 'extrinsicDocs=true'],
+	},
+	'/blocks/head': {
+		path: `/blocks/head`,
+		queryParams: ['eventDocs=true', 'extrinsicDocs=true'],
+	},
+	'/blocks/head/header': {
+		path: '/blocks/head',
+		queryParams: [],
+	},
+	'/node/network': {
+		path: '/node/network',
+		queryParams: [],
+	},
+	'/node/transaction-pool': {
+		path: '/node/transaction-pool',
+		queryParams: ['includeFee=true'],
+	},
+	'/node/version': {
+		path: '/node/version',
+		queryParams: [],
+	},
+	'/pallets/{palletId}/storage': {
+		path: '/pallets/System/storage',
+		queryParams: ['onlyIds=true', 'at={blockId}'],
+	},
+	'/pallets/{palletId}/storage/{storageItemId}': {
+		path: '/pallets/System/storage/BlockWeight',
+		queryParams: ['metadata=true', 'at={blockId}'],
+	},
+	'/runtime/metadata': {
+		path: '/runtime/metadata',
+		queryParams: ['at={blockId}'],
+	},
+	'/runtime/code': {
+		path: '/runtime/code',
+		queryParams: ['at={blockId}'],
+	},
+	'/runtime/spec': {
+		path: '/runtime/spec',
+		queryParams: ['at={blockId}'],
+	},
+	'/transaction/material': {
+		path: '/transaction/material',
+		queryParams: ['noMeta=true'],
+	},
+};

--- a/e2e-tests/latest/endpoints/index.ts
+++ b/e2e-tests/latest/endpoints/index.ts
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+export * from './acala';
 export * from './kusama';
 export * from './polkadot';
 export * from './statemint';

--- a/e2e-tests/latest/endpoints/karura.ts
+++ b/e2e-tests/latest/endpoints/karura.ts
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-export * from './acala';
-export * from './karura';
-export * from './kusama';
-export * from './polkadot';
-export * from './statemint';
-export * from './westend';
+import { acala } from './acala';
+
+export const karura = acala;

--- a/e2e-tests/latest/endpoints/statemint.ts
+++ b/e2e-tests/latest/endpoints/statemint.ts
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-export const statemint = {
+import { IConfig } from '../types/endpoints';
+
+export const statemint: IConfig = {
 	'/accounts/{accountId}/asset-balances': {
 		path: '/accounts/1ULZhwpUPLLg5VRYiq6rBHY8XaShAmBW7kqGBfvHBqrgBcN/asset-balances',
 		queryParams: ['at={blockId}', 'assets[]=100&assets[]=123'],

--- a/e2e-tests/latest/index.ts
+++ b/e2e-tests/latest/index.ts
@@ -26,6 +26,7 @@ enum StatusCode {
 }
 
 interface ILatestE2eParser {
+	url: string;
 	chain: keyof typeof endpoints;
 }
 
@@ -68,7 +69,10 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 		}
 	}
 
-	const responses = await Promise.all(urls.map((u) => request(u, HOST, PORT)));
+	const url = new URL(args.url);
+	const responses = await Promise.all(
+		urls.map((u) => request(u, url.host, Number(url.port)))
+	);
 	const errors: IRequest[] = [];
 	responses.forEach((res) => {
 		if (res.statusCode && res.statusCode >= 400) {
@@ -105,6 +109,9 @@ const parser = new ArgumentParser();
 parser.add_argument('--chain', {
 	choices: Object.keys(endpoints),
 	default: 'polkadot',
+});
+parser.add_argument('--url', {
+	default: `${HOST}:${PORT}}`,
 });
 
 const args = parser.parse_args() as ILatestE2eParser;

--- a/e2e-tests/latest/index.ts
+++ b/e2e-tests/latest/index.ts
@@ -40,9 +40,13 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 
 	const config = endpoints[args.chain] ?? endpoints.polkadot;
 
+	const url = new URL(args.url);
+	const host = url.host;
+	const port = Number(url.port);
+
 	let blockId: string;
 	try {
-		const res = await request('/blocks/head', HOST, PORT);
+		const res = await request('/blocks/head', host, port);
 		blockId = (JSON.parse(res.data) as IBlockResponse).number;
 	} catch (err) {
 		throw `Error fetching the latest block: ${err as string}`;
@@ -69,10 +73,7 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 		}
 	}
 
-	const url = new URL(args.url);
-	const responses = await Promise.all(
-		urls.map((u) => request(u, url.host, Number(url.port)))
-	);
+	const responses = await Promise.all(urls.map((u) => request(u, host, port)));
 	const errors: IRequest[] = [];
 	responses.forEach((res) => {
 		if (res.statusCode && res.statusCode >= 400) {

--- a/e2e-tests/latest/index.ts
+++ b/e2e-tests/latest/index.ts
@@ -93,7 +93,7 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 			errors.push(res);
 		}
 	});
-	logErrors(errors);
+	logResults(errors);
 
 	if (errors.length > 0) {
 		console.log(`Finished with a status code of ${Failed}`);
@@ -104,14 +104,18 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 	}
 };
 
-const logErrors = (errors: IRequest[]) => {
-	console.log('Received the following errors:');
-	errors.forEach((err) => {
-		console.log('----------------------------------------------');
-		console.log(`Queried Endpoint: ${err.path}`);
-		console.log(`Status Code: ${err.statusCode as number}`);
-		console.log(`Received logging: ${err.data}`);
-	});
+const logResults = (errors: IRequest[]) => {
+	if (errors.length > 0) {
+		console.log('Received the following errors:');
+		errors.forEach((err) => {
+			console.log('----------------------------------------------');
+			console.log(`Queried Endpoint: ${err.path}`);
+			console.log(`Status Code: ${err.statusCode as number}`);
+			console.log(`Received logging: ${err.data}`);
+		});
+	} else {
+		console.log('No errors were received');
+	}
 };
 
 const parser = new ArgumentParser();

--- a/e2e-tests/latest/index.ts
+++ b/e2e-tests/latest/index.ts
@@ -41,7 +41,7 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 	const config = endpoints[args.chain] ?? endpoints.polkadot;
 
 	const url = new URL(args.url);
-	const host = url.host;
+	const host = url.hostname;
 	const port = Number(url.port);
 
 	let blockId: string;
@@ -84,10 +84,10 @@ const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 
 	if (errors.length > 0) {
 		console.log(`Finished with a status code of ${Failed}`);
-		return Failed;
+		process.exit(Failed);
 	} else {
 		console.log(`Finished with a status code of ${Success}`);
-		return Success;
+		process.exit(Success);
 	}
 };
 
@@ -112,9 +112,12 @@ parser.add_argument('--chain', {
 	default: 'polkadot',
 });
 parser.add_argument('--url', {
-	default: `${HOST}:${PORT}}`,
+	default: `http://${HOST}:${PORT}`,
 });
 
 const args = parser.parse_args() as ILatestE2eParser;
 
-main(args).finally(() => process.exit());
+main(args).catch((e) => {
+	console.error('Error', e);
+	process.exit(1);
+});

--- a/e2e-tests/latest/index.ts
+++ b/e2e-tests/latest/index.ts
@@ -18,7 +18,7 @@ import { ArgumentParser } from 'argparse';
 
 import { HOST, PORT } from '../helpers/consts';
 import { IRequest, request } from '../helpers/request';
-import { kusama, polkadot, statemint, westend } from './endpoints';
+import * as endpoints from './endpoints';
 import { IConfig } from './types/endpoints';
 
 enum StatusCode {
@@ -27,7 +27,7 @@ enum StatusCode {
 }
 
 interface ILatestE2eParser {
-	chain: string;
+	chain: keyof typeof endpoints;
 }
 
 // This is a shallow mock of the actual response from `/blocks/head`. We only need the number field.
@@ -38,24 +38,7 @@ interface IBlockResponse {
 const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 	const { Success, Failed } = StatusCode;
 
-	let config: IConfig;
-	switch (args.chain) {
-		case 'polkadot':
-			config = polkadot;
-			break;
-		case 'kusama':
-			config = kusama;
-			break;
-		case 'westend':
-			config = westend;
-			break;
-		case 'statemint':
-			config = statemint;
-			break;
-		default:
-			config = polkadot;
-			break;
-	}
+	const config: IConfig = endpoints[args.chain] ?? endpoints.polkadot;
 
 	let blockId: string;
 	try {
@@ -121,7 +104,7 @@ const logResults = (errors: IRequest[]) => {
 const parser = new ArgumentParser();
 
 parser.add_argument('--chain', {
-	choices: ['polkadot', 'statemint', 'westend', 'kusama'],
+	choices: Object.keys(endpoints),
 	default: 'polkadot',
 });
 

--- a/e2e-tests/latest/index.ts
+++ b/e2e-tests/latest/index.ts
@@ -19,7 +19,6 @@ import { ArgumentParser } from 'argparse';
 import { HOST, PORT } from '../helpers/consts';
 import { IRequest, request } from '../helpers/request';
 import * as endpoints from './endpoints';
-import { IConfig } from './types/endpoints';
 
 enum StatusCode {
 	Success = 0,
@@ -38,7 +37,7 @@ interface IBlockResponse {
 const main = async (args: ILatestE2eParser): Promise<StatusCode> => {
 	const { Success, Failed } = StatusCode;
 
-	const config: IConfig = endpoints[args.chain] ?? endpoints.polkadot;
+	const config = endpoints[args.chain] ?? endpoints.polkadot;
 
 	let blockId: string;
 	try {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/lru-cache": "^7.10.10",
     "@types/morgan": "1.9.3",
     "@types/triple-beam": "^1.3.2",
+    "ts-node": "^10.9.1",
     "tsc-watch": "^4.6.2",
     "wasm-pack": "^0.10.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,6 +439,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": 0.3.9
+  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
 "@dabh/diagnostics@npm:^2.0.2":
   version: 2.0.2
   resolution: "@dabh/diagnostics@npm:2.0.2"
@@ -785,6 +794,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:^3.0.3":
+  version: 3.1.1
+  resolution: "@jridgewell/resolve-uri@npm:3.1.1"
+  checksum: f5b441fe7900eab4f9155b3b93f9800a916257f4e8563afbcd3b5a5337b55e52bd8ae6735453b1b745457d9f6cdb16d74cd6220bbdd98cf153239e13f6cbb653
+  languageName: node
+  linkType: hard
+
 "@jridgewell/set-array@npm:^1.0.1":
   version: 1.1.2
   resolution: "@jridgewell/set-array@npm:1.1.2"
@@ -796,6 +812,16 @@ __metadata:
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 
@@ -1343,6 +1369,7 @@ __metadata:
     http-errors: ^2.0.0
     lru-cache: ^7.13.1
     rxjs: ^7.5.6
+    ts-node: ^10.9.1
     tsc-watch: ^4.6.2
     wasm-pack: ^0.10.3
     winston: ^3.8.1
@@ -1416,6 +1443,34 @@ __metadata:
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
   checksum: e1fb1bbbc12089a0cb9433dc290f97bddd062deadb6178ce9bcb93bb7c1aecde5e60184bc7065aec42fe1663622a213493c48bbd4972d931aae48315f18e1be9
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.9
+  resolution: "@tsconfig/node10@npm:1.0.9"
+  checksum: a33ae4dc2a621c0678ac8ac4bceb8e512ae75dac65417a2ad9b022d9b5411e863c4c198b6ba9ef659e14b9fb609bbec680841a2e84c1172df7a5ffcf076539df
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@tsconfig/node16@npm:1.0.3"
+  checksum: 3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
   languageName: node
   linkType: hard
 
@@ -1823,6 +1878,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.4.1":
+  version: 8.8.2
+  resolution: "acorn@npm:8.8.2"
+  bin:
+    acorn: bin/acorn
+  checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.8.0":
   version: 8.8.0
   resolution: "acorn@npm:8.8.0"
@@ -1953,6 +2024,13 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^2.0.6
   checksum: 9a746b1dbce4122f44002b0c39fbba5b2c6f52c00e88b6ccba6fc68652323f8a1355a20e8ab94846995626d8de3bf67669a3b4a037dff0885db14607168f2b15
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
   languageName: node
   linkType: hard
 
@@ -2480,6 +2558,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -2579,6 +2664,13 @@ __metadata:
   version: 29.4.3
   resolution: "diff-sequences@npm:29.4.3"
   checksum: 28b265e04fdddcf7f9f814effe102cc95a9dec0564a579b5aed140edb24fc345c611ca52d76d725a3cab55d3888b915b5e8a4702e0f6058968a90fa5f41fcde7
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -4397,7 +4489,7 @@ fsevents@^2.3.2:
   languageName: node
   linkType: hard
 
-"make-error@npm:1.x":
+"make-error@npm:1.x, make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
@@ -5815,6 +5907,44 @@ resolve@^1.20.0:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.9.1":
+  version: 10.9.1
+  resolution: "ts-node@npm:10.9.1"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
 "tsc-watch@npm:^4.6.2":
   version: 4.6.2
   resolution: "tsc-watch@npm:4.6.2"
@@ -5976,6 +6106,13 @@ resolve@^1.20.0:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: c81095493225ecfc28add49c106ca4f09cdf56bc66731aa8dabc2edbbccb1e1bfe2de6a115e5c6a380d3ea166d1636410b62ef216bb07b3feb1cfde1d95d5080
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
   languageName: node
   linkType: hard
 
@@ -6171,6 +6308,13 @@ resolve@^1.20.0:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 - Added `ts-node` to dev deps so I can run it with `yarn ts-node src/main.ts` and run e2e tests with `yarn ts-node e2e-tests/latest/index.ts`. There is no reason to build before run if we can just run it.
- Updated the e2e tests output so it is less confusing.
- Some code refactoring
- Added Acala & Karura e2e tests
- Allow config sidecar url for e2e test
- Fix exit code