### PR TITLE
fix: Add BlockTraces to Westend config

### DIFF
--- a/src/chains-config/westendControllers.ts
+++ b/src/chains-config/westendControllers.ts
@@ -30,6 +30,7 @@ export const westendControllers: ControllerConfig = {
 		'AccountsVestingInfo',
 		'Blocks',
 		'BlocksExtrinsics',
+		'BlocksTrace',
 		'NodeNetwork',
 		'NodeTransactionPool',
 		'NodeVersion',


### PR DESCRIPTION
Add `BlockTraces` to westend config