### PR TITLE
fix: rename wsurl endpoints to asset hub

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ This script calls the local historical e2e tests helper library in order to test
 
 ### Flags
 
-`--chain`: This sets the specific chain to run the script against. Acceptable values are `['polkadot', 'westend', 'kusama', 'asset-hub-kusama', 'asset-hub-polkadot']`. If no chain is selected it will default to run the e2e-tests against all chains.
+`--chain`: This sets the specific chain to run the script against. Acceptable values are `['polkadot', 'westend', 'kusama', 'kusama-asset-hub', 'polkadot-asset-hub']`. If no chain is selected it will default to run the e2e-tests against all chains.
 
 `--local`: This sets the websocket url for the e2e test. Its to be used along with `--chain`. If `--chain` is not present it will throw an error.
 
@@ -36,7 +36,7 @@ This script calls the local latest e2e tests helper library in order to test the
 
 ### Flags
 
-`--chain`: This sets the specific chain to run the script against. Acceptable values are `['polkadot', 'asset-hub-polkadot']`. If no chain is selected it will default to run the e2e-tests against all chains.
+`--chain`: This sets the specific chain to run the script against. Acceptable values are `['polkadot', 'polkadot-asset-hub']`. If no chain is selected it will default to run the e2e-tests against all chains.
 
 `--local`: This sets the websocket url for the e2e test. Its to be used along with `--chain`. If `--chain` is not present it will throw an error.
 

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -66,16 +66,16 @@ export const historicalE2eConfig: Record<string, IChainConfigE2E> = {
 		},
 		SasStartOpts: defaultSasStartOpts,
 	},
-	'asset-hub-kusama': {
-		wsUrl: 'wss://statemine-rpc.polkadot.io',
+	'kusama-asset-hub': {
+		wsUrl: 'wss://kusama-asset-hub-rpc.polkadot.io',
 		e2eStartOpts: {
 			...defaultJestOpts,
 			args: ['start:historical-e2e-tests', '--chain', 'asset-hub-kusama'],
 		},
 		SasStartOpts: defaultSasStartOpts,
 	},
-	'asset-hub-polkadot': {
-		wsUrl: 'wss://statemint-rpc.polkadot.io',
+	'polkadot-asset-hub': {
+		wsUrl: 'wss://polkadot-asset-hub-rpc.polkadot.io',
 		e2eStartOpts: {
 			...defaultJestOpts,
 			args: ['start:historical-e2e-tests', '--chain', 'asset-hub-polkadot'],
@@ -105,14 +105,14 @@ export const latestE2eConfig: Record<string, IChainConfigE2E> = {
 			args: ['start:latest-e2e-tests', '--chain', 'polkadot'],
 		},
 	},
-	'asset-hub-polkadot': {
-		wsUrl: 'wss://statemint-rpc.polkadot.io',
+	'polkadot-asset-hub': {
+		wsUrl: 'wss://polkadot-asset-hub-rpc.polkadot.io',
 		SasStartOpts: defaultSasStartOpts,
 		e2eStartOpts: {
 			proc: 'latest-e2e',
 			resolver: 'Finished with a status code of 0',
 			resolverFailed: 'Finished with a status code of 1',
-			args: ['start:latest-e2e-tests', '--chain', 'asset-hub-polkadot'],
+			args: ['start:latest-e2e-tests', '--chain', 'assetHubPolkadot'],
 		},
 	},
 	westend: {

--- a/scripts/runHistoricalE2eTests.ts
+++ b/scripts/runHistoricalE2eTests.ts
@@ -108,8 +108,8 @@ parser.add_argument('--chain', {
 		'polkadot',
 		'kusama',
 		'westend',
-		'asset-hub-kusama',
-		'asset-hub-polkadot',
+		'kusama-asset-hub',
+		'polkadot-asset-hub',
 	],
 });
 parser.add_argument('--log-level', {

--- a/scripts/runLatestE2eTests.ts
+++ b/scripts/runLatestE2eTests.ts
@@ -83,7 +83,7 @@ parser.add_argument('--local', {
 	nargs: '?',
 });
 parser.add_argument('--chain', {
-	choices: ['polkadot', 'kusama', 'westend', 'asset-hub-polkadot'],
+	choices: ['polkadot', 'kusama', 'westend', 'polkadot-asset-hub'],
 });
 parser.add_argument('--log-level', {
 	choices: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'],


### PR DESCRIPTION
### Description
The changes in this PR are the following : 
1. Replaced the `wsUrl` endpoints with `asset-hub`
2. Replaced `asset-hub-<relay_chain>` to `<relay_chain>-asset-hub` strictly in the places that is `user-facing`

since : 
1. the `wsUrl` endpoints were also updated in polkadot-js/apps PR [#9526](https://github.com/polkadot-js/apps/pull/9526/files) (so we could replace one of the two exceptions from this PR [#1296](https://github.com/paritytech/substrate-api-sidecar/pull/1296) )
2. based on the feedback from Joe whatever is related to internal structure we keep as `AssetHub<Relay>` or `asset-hub-<relay>` and whatever is related to the "user" should be in the format `<relay>-asset-hub`.

### Assumptions
I made the 2nd change with the assumption that `user` is also someone who is running the tests. If this assumption is not correct then I will rollback that change.

### Tests
Run the following tests : 
- `yarn test:latest-e2e-tests --chain polkadot-asset-hub`
- `yarn test:historical-e2e-tests --chain polkadot-asset-hub`
- `yarn test:historical-e2e-tests --chain kusama-asset-hub`

### ⚠️ Note
I had to update also this [line](https://github.com/paritytech/substrate-api-sidecar/blob/86edf0b058c3effad80ab9d314dff914e2e7aab8/scripts/config.ts#L115) because when I was running 
`yarn test:latest-e2e-tests --chain polkadot-asset-hub` 
I was getting the error : 
```
Launching jest...
rimraf e2e-tests/build/
tsc --project e2e-tests/tsconfig.json
usage: index.js [-h]
                [--chain {acala,assetHubPolkadot,karura,kusama,polkadot,westend}]
                [--url URL]
index.js: error: argument --chain: invalid choice: 'asset-hub-polkadot' (choose from 'acala', 'assetHubPolkadot', 'karura', 'kusama', 'polkadot', 'westend')
Killing all processes...
Killing sidecar
Killing latest-e2e
[PASSED] All Tests Passed!
```
This error is also present in the previous PR [#1296](https://github.com/paritytech/substrate-api-sidecar/pull/1296) so right now in `master` branch (if you run `yarn test:latest-e2e-tests --chain asset-hub-polkadot`) but I didn't catch it and neither did the `CI` because at the end it says `[PASSED] All Tests Passed!`

Taking this into account, I was thinking that maybe we could change how we check the tests results. For example, if 0/10 tests were run, maybe we could throw an error also ? 