### PR TITLE
test(fix-dev): update appropriate type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
   "devDependencies": {
     "@substrate/dev": "^0.6.7",
     "@types/argparse": "2.0.10",
-    "@types/express": "4.17.14",
-    "@types/express-serve-static-core": "4.17.31",
+    "@types/express": "^4.17.17",
+    "@types/express-serve-static-core": "^4.17.35",
     "@types/http-errors": "1.8.2",
     "@types/lru-cache": "^7.10.10",
     "@types/morgan": "1.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,8 +1375,8 @@ __metadata:
     "@substrate/calc": ^0.3.1
     "@substrate/dev": ^0.6.7
     "@types/argparse": 2.0.10
-    "@types/express": 4.17.14
-    "@types/express-serve-static-core": 4.17.31
+    "@types/express": ^4.17.17
+    "@types/express-serve-static-core": ^4.17.35
     "@types/http-errors": 1.8.2
     "@types/lru-cache": ^7.10.10
     "@types/morgan": 1.9.3
@@ -1569,18 +1569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:4.17.31":
-  version: 4.17.31
-  resolution: "@types/express-serve-static-core@npm:4.17.31"
-  dependencies:
-    "@types/node": "*"
-    "@types/qs": "*"
-    "@types/range-parser": "*"
-  checksum: 009bfbe1070837454a1056aa710d0390ee5fb8c05dfe5a1691cc3e2ca88dc256f80e1ca27cb51a978681631d2f6431bfc9ec352ea46dd0c6eb183d0170bde5df
-  languageName: node
-  linkType: hard
-
-"@types/express-serve-static-core@npm:^4.17.18":
+"@types/express-serve-static-core@npm:^4.17.33, @types/express-serve-static-core@npm:^4.17.35":
   version: 4.17.35
   resolution: "@types/express-serve-static-core@npm:4.17.35"
   dependencies:
@@ -1592,15 +1581,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:4.17.14":
-  version: 4.17.14
-  resolution: "@types/express@npm:4.17.14"
+"@types/express@npm:^4.17.17":
+  version: 4.17.17
+  resolution: "@types/express@npm:4.17.17"
   dependencies:
     "@types/body-parser": "*"
-    "@types/express-serve-static-core": ^4.17.18
+    "@types/express-serve-static-core": ^4.17.33
     "@types/qs": "*"
     "@types/serve-static": "*"
-  checksum: 15c1af46d02de834e4a225eccaa9d85c0370fdbb3ed4e1bc2d323d24872309961542b993ae236335aeb3e278630224a6ea002078d39e651d78a3b0356b1eaa79
+  checksum: 0196dacc275ac3ce89d7364885cb08e7fb61f53ca101f65886dbf1daf9b7eb05c0943e2e4bbd01b0cc5e50f37e0eea7e4cbe97d0304094411ac73e1b7998f4da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This solves the current CI errors we are getting with all the dev scripts.

It just updates the types for express.