### PR TITLE
fix: bifrost type issue & small fixes in tests

### DIFF
--- a/e2e-tests/historical/endpoints/kusama/runtime/spec/10000.json
+++ b/e2e-tests/historical/endpoints/kusama/runtime/spec/10000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "2",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/kusama/runtime/spec/100000.json
+++ b/e2e-tests/historical/endpoints/kusama/runtime/spec/100000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "2",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/kusama/runtime/spec/2000000.json
+++ b/e2e-tests/historical/endpoints/kusama/runtime/spec/2000000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "2",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/kusama/runtime/spec/4000000.json
+++ b/e2e-tests/historical/endpoints/kusama/runtime/spec/4000000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "2",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/kusama/runtime/spec/8000000.json
+++ b/e2e-tests/historical/endpoints/kusama/runtime/spec/8000000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "2",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/polkadot/runtime/spec/1000.json
+++ b/e2e-tests/historical/endpoints/polkadot/runtime/spec/1000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "0",
         "tokenDecimals": [
             "10"

--- a/e2e-tests/historical/endpoints/polkadot/runtime/spec/200000.json
+++ b/e2e-tests/historical/endpoints/polkadot/runtime/spec/200000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "0",
         "tokenDecimals": [
             "10"

--- a/e2e-tests/historical/endpoints/polkadot/runtime/spec/3000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/runtime/spec/3000000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "0",
         "tokenDecimals": [
             "10"

--- a/e2e-tests/historical/endpoints/polkadot/runtime/spec/6877002.json
+++ b/e2e-tests/historical/endpoints/polkadot/runtime/spec/6877002.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "0",
         "tokenDecimals": [
             "10"

--- a/e2e-tests/historical/endpoints/westend/runtime/spec/10000.json
+++ b/e2e-tests/historical/endpoints/westend/runtime/spec/10000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "42",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/westend/runtime/spec/2000000.json
+++ b/e2e-tests/historical/endpoints/westend/runtime/spec/2000000.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "42",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/historical/endpoints/westend/runtime/spec/7417678.json
+++ b/e2e-tests/historical/endpoints/westend/runtime/spec/7417678.json
@@ -12,6 +12,7 @@
         "live": null
     },
     "properties": {
+        "isEthereum": false,
         "ss58Format": "42",
         "tokenDecimals": [
             "12"

--- a/e2e-tests/jest.config.js
+++ b/e2e-tests/jest.config.js
@@ -6,9 +6,14 @@ module.exports = {
     testEnvironment: 'node',
 	maxConcurrency: 3,
 	maxWorkers: '50%',
-    globals: {
-        'ts-jest': {
-            isloatedModules: true
-        }
-    }
+    transform: {
+        // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+        // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+        '^.+\\.tsx?$': [
+          'ts-jest',
+          {
+            isolatedModules: true
+          },
+        ],
+    },
 };

--- a/src/sanitize/sanitizeNumbers.ts
+++ b/src/sanitize/sanitizeNumbers.ts
@@ -236,7 +236,10 @@ function mapTypeSanitizeKeyValue(
 	const jsonMap: AnyJson = {};
 
 	map.forEach((value: unknown, key: unknown) => {
-		const nonCodecKey = sanitizeNumbers(key, options);
+		let nonCodecKey = sanitizeNumbers(key, options);
+		if (typeof nonCodecKey === 'object') {
+			nonCodecKey = JSON.stringify(nonCodecKey);
+		}
 		if (!(typeof nonCodecKey === 'string' || typeof nonCodecKey === 'number')) {
 			throw new InternalServerError(
 				'Unexpected non-string and non-number key while sanitizing a Map-like type'


### PR DESCRIPTION
### Description
This PR includes 3 separate fixes :
1. Add check in sanitize numbers for Bifrost object type
2. Add entry `isEthereum` in test results
3. Small fix in jest config

### 1. Bifrost Object Type
Relates to issue https://github.com/paritytech/substrate-api-sidecar/issues/1082

#### Issue
When connected to `wss://bifrost-rpc.liebi.com/ws` and requesting one of the following blocks
- `2652989`
- `3460065`
-  [5296330](https://bifrost-kusama.subscan.io/block/5296330) 
- [5296335](https://bifrost-kusama.subscan.io/block/5296335) 

Sidecar returns the message : 
```
"Unexpected non-string and non-number key while sanitizing a Map-like type"
```

This is because the `delegations` entry have as `key` a `Multilocation` object and in Sidecar code when we sanitize [here](https://github.com/paritytech/substrate-api-sidecar/blob/8fa49aaa93cfdad36fe8126262409832033bba89/src/sanitize/sanitizeNumbers.ts#L240) we expect a key only of type `string` or `number`. 

#### Suggested Solution
Solution suggested from @hqwangningbo in this [comment](https://github.com/paritytech/substrate-api-sidecar/issues/1082#issuecomment-1683587120) which checks if the `key` is of type `object` and makes it a `string`. With this change, when requesting one of the affected blocks it returns (e.g. for block `5296335`) the object :
```
...
    "delegations": {
                              "{\"parents\":\"1\",\"interior\":{\"x2\":[{\"parachain\":\"2023\"},{\"accountKey20\":{\"network\":null,\"key\":\"0x5d9bc481749420cffb2bf5aef5c5e2a0ffe04e88\"}}]}}": "1148554603043768874193",
                              "{\"parents\":\"1\",\"interior\":{\"x2\":[{\"parachain\":\"2023\"},{\"accountKey20\":{\"network\":null,\"key\":\"0xd8b890aaaf926adc863f04c9223164afa5ea3388\"}}]}}": "3944544267848663635461",
                              "{\"parents\":\"1\",\"interior\":{\"x2\":[{\"parachain\":\"2023\"},{\"accountKey20\":{\"network\":null,\"key\":\"0xf971c8f8d2437234733814b40e7dfef75e219545\"}}]}}": "1445924498529099301246"
...
```

This result aligns also with what we see in :
- pjs apps at the same [block](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fbifrost-parachain.api.onfinality.io%2Fpublic-ws#/explorer/query/5296335) when connected to Bifrost
```
delegations: BTreeMap<XcmV3MultiLocation, u128>

{
  {parents:1,interior:{x2:[{parachain:2023},{accountKey20:{network:null,key:0x5d9bc481749420cffb2bf5aef5c5e2a0ffe04e88}}]}}: 1,148,554,603,043,768,874,193
  {parents:1,interior:{x2:[{parachain:2023},{accountKey20:{network:null,key:0xd8b890aaaf926adc863f04c9223164afa5ea3388}}]}}: 3,944,544,267,848,663,635,461
  {parents:1,interior:{x2:[{parachain:2023},{accountKey20:{network:null,key:0xf971c8f8d2437234733814b40e7dfef75e219545}}]}}: 1,445,924,498,529,099,301,246
}
```
- subscan [here](https://bifrost-kusama.subscan.io/extrinsic/5296335-4) > entry `delegations`


### 2. Fix in tests by adding `isEthereum` entry
Added the missing entry `isEthereum` in the corresponding json files.

### 3. Fix in jest config
#### Issue
When running 
```
yarn test:historical-e2e-tests
```
we are receiving the warning :
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```

#### Suggested Solution
Removed entry in `globals` [source](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules/) and added it in `transform`.

### Todos
- [x] Run tests, historical tests and latest tests
- [x] Checked/Tested manually that the endpoints for the affected blocks in Bifrost are working now
- [x] Run linter
- [x] Checked docs. No need to update for the `isEthereum` entry
