### PR TITLE
ci: update node version in docker, and wasm-pack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn install && \
 
 # ---------------------------------
 
-FROM docker.io/library/node:16.15.1-alpine
+FROM docker.io/library/node:18.12.1-alpine
 
 # metadata
 ARG VERSION=""

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/morgan": "1.9.3",
     "@types/triple-beam": "^1.3.2",
     "ts-node-dev": "^2.0.0",
-    "wasm-pack": "^0.10.3"
+    "wasm-pack": "^0.12.1"
   },
   "keywords": [
     "substrate",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,7 +1404,7 @@ __metadata:
     prom-client: ^14.2.0
     rxjs: ^7.5.6
     ts-node-dev: ^2.0.0
-    wasm-pack: ^0.10.3
+    wasm-pack: ^0.12.1
     winston: ^3.8.1
   bin:
     substrate-api-sidecar: ./build/src/main.js
@@ -2133,12 +2133,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
+"axios@npm:^0.26.1":
+  version: 0.26.1
+  resolution: "axios@npm:0.26.1"
   dependencies:
-    follow-redirects: ^1.14.0
-  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
+    follow-redirects: ^1.14.8
+  checksum: d9eb58ff4bc0b36a04783fc9ff760e9245c829a5a1052ee7ca6013410d427036b1d10d04e7380c02f3508c5eaf3485b1ae67bd2adbfec3683704745c8d7a6e1a
   languageName: node
   linkType: hard
 
@@ -2239,14 +2239,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-install@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "binary-install@npm:0.1.1"
+"binary-install@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "binary-install@npm:1.1.0"
   dependencies:
-    axios: ^0.21.1
+    axios: ^0.26.1
     rimraf: ^3.0.2
-    tar: ^6.1.0
-  checksum: a3df9c07a3ab81533cff610527263181c4c34a44efb115555be910b6011ac047bf875ad57469cc2259dfaba58e971c7ba2958038e9d222c546eef7b58b826ecc
+    tar: ^6.1.11
+  checksum: 271344b49f42460f5e3ec29d681cd4b749aaf9592040d49f6ae86d267b997b5fd094fd7a710df4d477fc299a51833b8cb94206595db6c46edea3f1603266a0d2
   languageName: node
   linkType: hard
 
@@ -3428,13 +3428,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0":
-  version: 1.15.2
-  resolution: "follow-redirects@npm:1.15.2"
+"follow-redirects@npm:^1.14.8":
+  version: 1.15.3
+  resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  checksum: 584da22ec5420c837bd096559ebfb8fe69d82512d5585004e36a3b4a6ef6d5905780e0c74508c7b72f907d1fa2b7bd339e613859e9c304d0dc96af2027fd0231
   languageName: node
   linkType: hard
 
@@ -6088,7 +6088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.0, tar@npm:^6.1.11, tar@npm:^6.1.2":
+"tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.15
   resolution: "tar@npm:6.1.15"
   dependencies:
@@ -6478,14 +6478,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wasm-pack@npm:^0.10.3":
-  version: 0.10.3
-  resolution: "wasm-pack@npm:0.10.3"
+"wasm-pack@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "wasm-pack@npm:0.12.1"
   dependencies:
-    binary-install: ^0.1.0
+    binary-install: ^1.0.1
   bin:
     wasm-pack: run.js
-  checksum: b980b33fc8adcd208556a1f5c4656b02d1ae584792259874f09ab5647dd52d0cdd3179d970ba99eed72ac1a422445c3c81122a3e9d7c05ebb2a3ff83bd7ec7db
+  checksum: 497abceb48b15329bb30f614b9ed7b07d82554ff225b93485794fb91b074a98aeda8091146aafe969c7f9615d106c770d215cf916bebf65451978f7222fcbe0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates the node version to 18.12.1, and wasm-pack to 0.12.1.

The minimum version for node in sidecar is 18.x.x.

This will help resolve: https://github.com/paritytech/substrate-api-sidecar/pull/1358