### PR TITLE
test(e2e): replace tests pointing to deprecated pallets

### DIFF
--- a/e2e-tests/latest/endpoints/polkadot.ts
+++ b/e2e-tests/latest/endpoints/polkadot.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2023 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -146,27 +146,27 @@ export const polkadot: IConfig = {
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/consts': {
-		path: '/pallets/democracy/consts',
+		path: '/pallets/MessageQueue/consts',
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/consts?onlyIds=true': {
-		path: '/pallets/14/consts',
+		path: '/pallets/100/consts',
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/consts/{constItemId}': {
-		path: '/pallets/democracy/consts/EnactmentPeriod',
+		path: '/pallets/MessageQueue/consts/ServiceWeight',
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/dispatchables': {
-		path: '/pallets/democracy/dispatchables',
+		path: '/pallets/XcmPallet/dispatchables',
 		queryParams: [],
 	},
 	'/pallets/{palletId}/dispatchables?onlyIds=true': {
-		path: '/pallets/14/dispatchables',
+		path: '/pallets/99/dispatchables',
 		queryParams: [],
 	},
 	'/pallets/{palletId}/dispatchables/{dispatchableItemId}': {
-		path: '/pallets/democracy/dispatchables/vote',
+		path: '/pallets/XcmPallet/dispatchables/limitedTeleportAssets',
 		queryParams: [],
 	},
 	'/pallets/{palletId}/dispatchables/{dispatchableItemIdWithMultipleWordName}': {
@@ -178,11 +178,11 @@ export const polkadot: IConfig = {
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/errors?onlyIds=true': {
-		path: '/pallets/17/errors',
+		path: '/pallets/34/errors',
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/errors/{errorItemId}': {
-		path: '/pallets/democracy/errors/ValueLow',
+		path: '/pallets/crowdloan/errors/VrfDelayInProgress',
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/events': {
@@ -190,7 +190,7 @@ export const polkadot: IConfig = {
 		queryParams: ['at={blockId}'],
 	},
 	'/pallets/{palletId}/events/{eventItemId}': {
-		path: '/pallets/democracy/events/Proposed',
+		path: '/pallets/auctions/events/ReserveConfiscated',
 		queryParams: ['at={blockId}', 'metadata=true'],
 	},
 	'/pallets/nominationPoools/info': {

--- a/src/services/pallets/PalletsConstantsService.ts
+++ b/src/services/pallets/PalletsConstantsService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2023 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -42,8 +42,8 @@ export class PalletsConstantsService extends AbstractPalletsService {
 
 		const [palletMeta, palletMetaIdx] = this.findPalletMeta(palletMetadata, palletId, metadataFieldType);
 
-		// Even if `constantItemMeta` is not used, we call this function to ensure it exists. The side effects
-		// of the constant item not existing are that `findConstantItemMeta` will throw.
+		// Even if `constantItemMetadata` is not used, we call this function to ensure it exists. The side effects
+		// of the constant item not existing are that `getConstItemMeta` will throw.
 		const constantItemMetadata = this.findPalletFieldItemMeta(
 			historicApi,
 			palletMeta,

--- a/src/services/pallets/PalletsDispatchablesService.ts
+++ b/src/services/pallets/PalletsDispatchablesService.ts
@@ -42,8 +42,8 @@ export class PalletsDispatchablesService extends AbstractPalletsService {
 
 		const [palletMeta, palletMetaIdx] = this.findPalletMeta(palletMetadata, palletId, metadataFieldType);
 
-		// Even if `dispatchableItemMeta` is not used, we call this function to ensure it exists. The side effects
-		// of the dispatchable item not existing are that `findPalletFieldItemMeta` will throw.
+		// Even if `dispatchableItemMetadata` is not used, we call this function to ensure it exists. The side effects
+		// of the dispatchable item not existing are that `getDispatchablesItemMeta` will throw.
 		const dispatchableItemMetadata = this.findPalletFieldItemMeta(
 			historicApi,
 			palletMeta,

--- a/src/services/pallets/PalletsErrorsService.ts
+++ b/src/services/pallets/PalletsErrorsService.ts
@@ -43,8 +43,8 @@ export class PalletsErrorsService extends AbstractPalletsService {
 
 		const [palletMeta, palletMetaIdx] = this.findPalletMeta(palletMetadata, palletId, metadataFieldType);
 
-		// Even if `errorItemMeta` is not used, we call this function to ensure it exists. The side effects
-		// of the error item not existing are that `findErrorItemMeta` will throw.
+		// Even if `errorItemMetadata` is not used, we call this function to ensure it exists. The side effects
+		// of the error item not existing are that `getErrorItemMeta` will throw.
 		const errorItemMetadata = this.findPalletFieldItemMeta(
 			historicApi,
 			palletMeta,

--- a/src/services/pallets/PalletsEventsService.ts
+++ b/src/services/pallets/PalletsEventsService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2023 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -44,8 +44,8 @@ export class PalletsEventsService extends AbstractPalletsService {
 
 		const [palletMeta, palletMetaIdx] = this.findPalletMeta(palletMetadata, palletId, metadataFieldType);
 
-		// Even if `eventItemMeta` is not used, we call this function to ensure it exists. The side effects
-		// of the event item not existing are that `findPalletFieldItemMeta` will throw.
+		// Even if `eventItemMetadata` is not used, we call this function to ensure it exists. The side effects
+		// of the event item not existing are that `getEventItemMeta` will throw.
 		const eventItemMetadata = this.findPalletFieldItemMeta(
 			historicApi,
 			palletMeta,

--- a/src/services/pallets/PalletsStorageService.ts
+++ b/src/services/pallets/PalletsStorageService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2023 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -45,7 +45,7 @@ export class PalletsStorageService extends AbstractPalletsService {
 		const palletName = stringCamelCase(palletMeta.name);
 
 		// Even if `storageItemMeta` is not used, we call this function to ensure it exists. The side effects
-		// of the storage item not existing are that `findPalletItemMeta` will throw.
+		// of the storage item not existing are that `getStorageItemMeta` will throw.
 		const storageItemMeta = this.findPalletFieldItemMeta(
 			historicApi,
 			palletMeta,


### PR DESCRIPTION
### Description
This PR replaces the `e2e/latest` tests that are pointing to deprecated pallets. 

### Details
The [polkadot runtime](https://github.com/polkadot-fellows/runtimes/blob/5d98c2efcdb61a90e5a325c80b6c5d2b2c1d6625/relay/polkadot/src/lib.rs#L1375) no longer has :
- the `Democracy` pallet with index 14
- the `PhragmenElection` pallet with index 17

The pallets and their indices can be found in previous versions of the polkadot runtime, e.g. [Democracy](https://github.com/paritytech/polkadot/blob/1ed6e2e50a4ce61f6cda46a730efc11a07b6ebb3/runtime/polkadot/src/lib.rs#L1374) and [PhragmenElection](https://github.com/paritytech/polkadot/blob/1ed6e2e50a4ce61f6cda46a730efc11a07b6ebb3/runtime/polkadot/src/lib.rs#L1377C17-L1377C17).

### Solution proposed
Instead of removing completely the tests I replaced them so they point to existing pallets.

### Minor additional fix
Fixed some minor typos in methods names mentioned in the Pallets Services (in comments).