### PR TITLE
perf: add additional high load benchmarks for `/blocks`

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -77,6 +77,8 @@ sudo cp wrk /usr/local/bin
 
 In order to run each benchmark you should `cd` into the appropriate directory you want to run, set the `WRK_TIME_LENGTH` env var (ex: `export WRK_TIME_LENGTH=30s`) and then `sh init.sh`. You are required to have sidecar running, as well as a fully synced archive node.
 
+NOTE: Some benchmarks might have multiple `sh` scripts with different names in order to run specific benchmarks.
+
 ### Running via Scripts (Root)
 
 Below are flags, and examples on how to run these benchmarks from the root of the repository. See <root>/scripts/README.md for more information. 

--- a/benchmarks/blocksBlockId/benchHighLoadBlocks.lua
+++ b/benchmarks/blocksBlockId/benchHighLoadBlocks.lua
@@ -1,0 +1,25 @@
+-- Copyright 2017-2023 Parity Technologies (UK) Ltd.
+-- This file is part of Substrate API Sidecar.
+--
+-- Substrate API Sidecar is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package.path = package.path .. ";../util/util.lua"
+local util = require('util')
+local highLoadBlocks = require('highLoadBlocks')
+
+request = util.request(highLoadBlocks, '/blocks/%s')
+
+delay = util.delay
+
+done = util.done()

--- a/benchmarks/blocksBlockId/blocks.lua
+++ b/benchmarks/blocksBlockId/blocks.lua
@@ -14,6 +14,8 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+local highLoadBlocks = require('highLoadBlocks')
+
 local blocks = {
     '28831', -- Sudo setKey(0, -> 1)
     '29258', -- sudo.sudo(forceTransfer)
@@ -58,6 +60,7 @@ local blocks = {
     '1603025', -- staking.withdrawUnbonded
     '6800002', -- blocks.transfer
     '11873016', -- vesting.vest
+    unpack(highLoadBlocks)
 }
 
 return blocks

--- a/benchmarks/blocksBlockId/highLoadBlocks.lua
+++ b/benchmarks/blocksBlockId/highLoadBlocks.lua
@@ -1,0 +1,50 @@
+-- Copyright 2017-2023 Parity Technologies (UK) Ltd.
+-- This file is part of Substrate API Sidecar.
+--
+-- Substrate API Sidecar is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+local highLoadBlocks = {
+    '18687076', -- 414 extrinsics
+    '18687064', -- 404 extrinsics
+    '18687053', -- 402 extrinsics
+    '18687063', -- 435 extrinsics
+    '18687111', -- 460 extrinsics
+    '18687104', -- 274 extrinsics
+    '18687099', -- 288 extrinsics
+    '18687162', -- 436 extrinsics
+    '18687150', -- 409 extrinsics
+    '18687146', -- 358 extrinsics
+    '18687186', -- 416 extrinsics
+    '18687181', -- 306 extrinsics
+    '18687219', -- 458 extrinsics
+    '18687214', -- 292 extrinsics
+    '18687212', -- 341 extrinsics
+    '18687264', -- 401 extrinsics
+    '18687255', -- 437 extrinsics
+    '18687246', -- 276 extrinsics
+    '18687338', -- 488 extrinsics
+    '18687370', -- 512 extrinsics
+    '18687387', -- 484 extrinsics
+    '18687436', -- 352 extrinsics
+    '18687425', -- 372 extrinsics
+    '18687507', -- 402 extrinsics
+    '18687526', -- 266 extrinsics
+    '18687604', -- 348 extrinsics
+    '18687639', -- 489 extrinsics
+    '18687630', -- 524 extrinsics
+    '18687692', -- 377 extrinsics
+    '18687712', -- 349 extrinsics
+}
+
+return highLoadBlocks

--- a/benchmarks/blocksBlockId/highLoadInit.sh
+++ b/benchmarks/blocksBlockId/highLoadInit.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+wrk -d$WRK_TIME_LENGTH -t4 -c6 --timeout 120s --latency -s ./benchHighLoadBlocks.lua http://127.0.0.1:8080


### PR DESCRIPTION
This PR adds the ability for us to measure how sidecar reacts to highloads for the `/blocks` endpoint. High load in this context specifically refers to a large amount of extrinsics.