### PR TITLE
fix: ensure statemine, and statemint are still supported

### DIFF
--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -60,6 +60,8 @@ const specToControllerMap: { [x: string]: ControllerConfig } = {
 	'dock-pos-test-runtime': dockTestnetControllers,
 	'asset-hub-kusama': assetHubKusamaControllers,
 	'asset-hub-polkadot': assetHubPolkadotControllers,
+	statemine: assetHubKusamaControllers,
+	statemint: assetHubPolkadotControllers,
 	westmine: assetHubKusamaControllers,
 	'asset-hub-westend': assetHubWestendControllers,
 	westmint: assetHubWestendControllers,


### PR DESCRIPTION
This ensure all specNames are supported for the asset hub chains. 