### PR TITLE
fix: changed how claimed variable is set in staking-payouts

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -272,12 +272,13 @@ export class AccountsStakingPayoutsService extends AbstractService {
 				continue;
 			}
 			// Check if the reward has already been claimed
-			let claimed: boolean;
+			let indexOfEra: number;
 			if (validatorLedger.legacyClaimedRewards) {
-				claimed = validatorLedger.legacyClaimedRewards.includes(eraIndex);
+				indexOfEra = validatorLedger.legacyClaimedRewards.indexOf(eraIndex);
 			} else {
-				claimed = (validatorLedger as unknown as StakingLedger).claimedRewards.includes(eraIndex);
+				indexOfEra = (validatorLedger as unknown as StakingLedger).claimedRewards.indexOf(eraIndex);
 			}
+			const claimed: boolean = Number.isInteger(indexOfEra) && indexOfEra !== -1;
 			if (unclaimedOnly && claimed) {
 				continue;
 			}


### PR DESCRIPTION
#### Description
In `staking-payouts` endpoint, the `claimed` field is returning `false` even when rewards are actually claimed.

#### Testing
The `claimed` variable is set in this [line](https://github.com/paritytech/substrate-api-sidecar/blob/b2aab7dd5ae93b1270e8baba4e2ac7e0c8d3e8ed/src/services/accounts/AccountsStakingPayoutsService.ts#L279) of code where we check if the requested `eraIndex` is included in the `claimedRewards` vector. After testing, it shows that the `includes` function does not work as expected and does not return `true` when the `eraIndex` is included in the array. The reason might be related to types because I tried to use `includes` when changed the type of the eraIndex and it returned `true`. However this is still weird because if I check :
- `validatorLedger.claimedRewards.toRawType()` -> it returns `'Vec<u32>'` and
- `eraIndex.toRawType()` -> it returns `'u32'`
so I would expect `includes` to work even if I do not change anything.

#### Proposed Solution
On the other hand, if we use the `indexOf` function it returns correctly the index where `era` is found in the array.
This works and we have to make sure to add the query param `unclaimedOnly=false`.
