### PR TITLE
fix: generated a custom key for the cache in blocks endpoint

### DIFF
--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -112,8 +112,18 @@ export class BlocksService extends AbstractService {
 	): Promise<IBlock> {
 		const { api } = this;
 
+		// Create a key for the cache that is a concatenation of the block hash and all the query params/options included in the request
+		const cacheKey =
+			hash.toString() +
+			Number(eventDocs) +
+			Number(extrinsicDocs) +
+			Number(checkFinalized) +
+			Number(queryFinalizedHead) +
+			Number(omitFinalizedTag) +
+			Number(noFees);
+
 		// Before making any api calls check the cache if the queried block exists
-		const isBlockCached = this.blockStore.get(hash.toString());
+		const isBlockCached = this.blockStore.get(cacheKey);
 
 		if (isBlockCached && isBlockCached.finalized !== false) {
 			return isBlockCached;
@@ -203,7 +213,7 @@ export class BlocksService extends AbstractService {
 		};
 
 		// Store the block in the cache
-		this.blockStore.set(hash.toString(), response);
+		this.blockStore.set(cacheKey, response);
 
 		return response;
 	}

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -112,15 +112,9 @@ export class BlocksService extends AbstractService {
 	): Promise<IBlock> {
 		const { api } = this;
 
-		// Create a key for the cache that is a concatenation of the block hash and all the query params/options included in the request
+		// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
 		const cacheKey =
-			hash.toString() +
-			Number(eventDocs) +
-			Number(extrinsicDocs) +
-			Number(checkFinalized) +
-			Number(queryFinalizedHead) +
-			Number(omitFinalizedTag) +
-			Number(noFees);
+			hash.toString() + Number(eventDocs) + Number(extrinsicDocs) + Number(checkFinalized) + Number(noFees);
 
 		// Before making any api calls check the cache if the queried block exists
 		const isBlockCached = this.blockStore.get(cacheKey);


### PR DESCRIPTION
### Issue
When we request a block in Sidecar with a query param set to a specific value, e.g. :
`/blocks/1820744?extrinsicDocs=false` : _return block and show the docs in each extrinsic_
and right away I request again the same block but now with the query param set to a different value, e.g. :
`/blocks/1820744?extrinsicDocs=true` : _return block and do **not** show the docs in each extrinsic_

the response is not updated so it still doesn't show me the docs in each extrinsic.

### Root Cause
This happens because of how we cache the response. Wen we cache the block [here](https://github.com/paritytech/substrate-api-sidecar/blob/aef22fe4bb1660058b71c302b7ee15068ef64d32/src/services/blocks/BlocksService.ts#L206) we set the key in the cache "array" equal to the block hash. So when we request again the same block it will only check [here](https://github.com/paritytech/substrate-api-sidecar/blob/aef22fe4bb1660058b71c302b7ee15068ef64d32/src/services/blocks/BlocksService.ts#L116) if it finds this block hash and it will ignore the different query params. It will then find that this block was requested before and it will return the saved response. The problem is that this saved response has `extrinsicDocs` false so it will still not show me the docs.

### Proposed Solution
Create a key that is a combination of the block hash (request param) and the query params of the request. This key will then be used to save/retrieve responses to/from the cache. 
- The query params values were concatenated as `0` or `1`s (since they are boolean indicating `false` or `true`values).
- For the generation of the key, only the query params 
   - eventDocs
   - extrinsicDocs
   - checkFinalized, 
   - noFees
  
  are used since those are the ones that can be changed by the user. The options `queryFinalizedHead` and `omitFinalizedTag` are not included since they depend on the params set above.

### Testing
This solution was tested while running sidecar connected to Polkadot. For example, the requested block : 
- `http://127.0.0.1:8080/blocks/1820747?extrinsicDocs=false&eventDocs=true`
is updated when changing the query param `extrinsicDocs` and `eventDocs` to different boolean values.