### PR TITLE
fix: add asset conversion pallet to Kusama Asset Hub

### DIFF
--- a/src/chains-config/assetHubKusamaControllers.ts
+++ b/src/chains-config/assetHubKusamaControllers.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify

--- a/src/chains-config/assetHubKusamaControllers.ts
+++ b/src/chains-config/assetHubKusamaControllers.ts
@@ -32,6 +32,7 @@ export const assetHubKusamaControllers: ControllerConfig = {
 		'NodeTransactionPool',
 		'NodeVersion',
 		'PalletsAssets',
+		'PalletsAssetConversion',
 		'PalletsConsts',
 		'PalletsErrors',
 		'PalletsEvents',


### PR DESCRIPTION
### Description
Now that the asset-conversion pallet is available on KAH, this is just adding the endpoints for that chain.

Related to #1322 