### PR TITLE
fix: staking-payouts for legacy kusama node

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -162,8 +162,6 @@ export class AccountsStakingPayoutsService extends AbstractService {
 						...eraCommissions[idx],
 					};
 				});
-				console.log(nominatedExposures);
-				console.log(exposuresWithCommission);
 
 				return {
 					deriveEraExposure,

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -289,8 +289,10 @@ export class AccountsStakingPayoutsService extends AbstractService {
 			let indexOfEra: number;
 			if (validatorLedger.legacyClaimedRewards) {
 				indexOfEra = validatorLedger.legacyClaimedRewards.indexOf(eraIndex);
-			} else {
+			} else if ((validatorLedger as unknown as StakingLedger).claimedRewards) {
 				indexOfEra = (validatorLedger as unknown as StakingLedger).claimedRewards.indexOf(eraIndex);
+			} else {
+				continue;
 			}
 			const claimed: boolean = Number.isInteger(indexOfEra) && indexOfEra !== -1;
 			if (unclaimedOnly && claimed) {

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -294,7 +294,13 @@ export class AccountsStakingPayoutsService extends AbstractService {
 				continue;
 			}
 
-			// Check if the reward has already been claimed
+			/**
+			 * Check if the reward has already been claimed.
+			 *
+			 * It is important to note that the following examines types that are both current and historic.
+			 * When going back far enough in certain chains types such as `StakingLedgerTo240` are necessary for grabbing
+			 * any reward data.
+			 */
 			let indexOfEra: number;
 			if (validatorLedger.legacyClaimedRewards) {
 				indexOfEra = validatorLedger.legacyClaimedRewards.indexOf(eraIndex);

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -294,6 +294,7 @@ export class AccountsStakingPayoutsService extends AbstractService {
 				continue;
 			}
 
+			// Check if the reward has already been claimed
 			let indexOfEra: number;
 			if (validatorLedger.legacyClaimedRewards) {
 				indexOfEra = validatorLedger.legacyClaimedRewards.indexOf(eraIndex);

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -22,7 +22,15 @@ import type {
 	DeriveEraValidatorExposure,
 } from '@polkadot/api-derive/staking/types';
 import type { Option, StorageKey, u32 } from '@polkadot/types';
-import type { AccountId, BalanceOf, BlockHash, EraIndex, Perbill, StakingLedger } from '@polkadot/types/interfaces';
+import type {
+	AccountId,
+	BalanceOf,
+	BlockHash,
+	EraIndex,
+	Perbill,
+	StakingLedger,
+	StakingLedgerTo240,
+} from '@polkadot/types/interfaces';
 import type {
 	PalletStakingEraRewardPoints,
 	PalletStakingExposure,
@@ -154,6 +162,8 @@ export class AccountsStakingPayoutsService extends AbstractService {
 						...eraCommissions[idx],
 					};
 				});
+				console.log(nominatedExposures);
+				console.log(exposuresWithCommission);
 
 				return {
 					deriveEraExposure,
@@ -285,12 +295,19 @@ export class AccountsStakingPayoutsService extends AbstractService {
 			if (!validatorLedger) {
 				continue;
 			}
-			// Check if the reward has already been claimed
+
 			let indexOfEra: number;
 			if (validatorLedger.legacyClaimedRewards) {
 				indexOfEra = validatorLedger.legacyClaimedRewards.indexOf(eraIndex);
 			} else if ((validatorLedger as unknown as StakingLedger).claimedRewards) {
 				indexOfEra = (validatorLedger as unknown as StakingLedger).claimedRewards.indexOf(eraIndex);
+			} else if ((validatorLedger as unknown as StakingLedgerTo240).lastReward) {
+				const lastReward = (validatorLedger as unknown as StakingLedgerTo240).lastReward;
+				if (lastReward.isSome) {
+					indexOfEra = (validatorLedger as unknown as StakingLedgerTo240).lastReward.unwrap().toNumber();
+				} else {
+					continue;
+				}
 			} else {
 				continue;
 			}


### PR DESCRIPTION
This resolves an error where legacy blocks on Kusama would throw an error:

```
{
	"code": 500,
	"message": "Cannot read properties of undefined (reading 'indexOf')",
	"stack": "TypeError: Cannot read properties of undefined (reading 'indexOf')\n    at AccountsStakingPayoutsService.deriveEraPayouts (/Users/tarikgul/Desktop/parity/tools-team/substrate-api-sidecar/src/services/accounts/AccountsStakingPayoutsService.ts:293:79)\n    at /Users/tarikgul/Desktop/parity/tools-team/substrate-api-sidecar/src/services/accounts/AccountsStakingPayoutsService.ts:170:50\n    at Array.map (<anonymous>)\n    at AccountsStakingPayoutsService.fetchAccountStakingPayout (/Users/tarikgul/Desktop/parity/tools-team/substrate-api-sidecar/src/services/accounts/AccountsStakingPayoutsService.ts:170:28)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at AccountsStakingPayoutsController.getStakingPayoutsByAccountId (/Users/tarikgul/Desktop/parity/tools-team/substrate-api-sidecar/src/controllers/accounts/AccountsStakingPayoutsController.ts:110:4)\n    at /Users/tarikgul/Desktop/parity/tools-team/substrate-api-sidecar/src/controllers/AbstractController.ts:116:5",
	"level": "error"
}
```

This fix checks to make sure `validatorLedger.claimedRewards` exists if not we continue with the rest of the logic.

We tested with: `/accounts/FXCgfz7AzQA1fNaUqubSgXxGh77sjWVVkypgueWLmAcwv79/staking-payouts?unclaimedOnly=false&at=1567404&depth=21` and we got accurate results back. 