### PR TITLE
chore(deps): update non pjs deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,23 +56,23 @@
     "@substrate/calc": "^0.3.1",
     "argparse": "^2.0.1",
     "confmgr": "^1.0.10",
-    "express": "^4.18.1",
+    "express": "^4.18.2",
     "express-winston": "^4.2.0",
     "http-errors": "^2.0.0",
     "lru-cache": "^7.13.1",
     "prom-client": "^14.2.0",
-    "rxjs": "^7.5.6",
-    "winston": "^3.8.1"
+    "rxjs": "^7.8.1",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
     "@substrate/dev": "^0.7.1",
-    "@types/argparse": "2.0.10",
-    "@types/express": "^4.17.17",
-    "@types/express-serve-static-core": "^4.17.36",
+    "@types/argparse": "2.0.14",
+    "@types/express": "^4.17.21",
+    "@types/express-serve-static-core": "^4.17.43",
     "@types/http-errors": "1.8.2",
     "@types/lru-cache": "^7.10.10",
-    "@types/morgan": "1.9.3",
-    "@types/triple-beam": "^1.3.2",
+    "@types/morgan": "1.9.9",
+    "@types/triple-beam": "^1.3.5",
     "ts-node-dev": "^2.0.0"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,6 +444,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10/66d00284a3a9a21e5e853b256942e17edbb295f4bd7b9aa7ef06bbb603568d5173eb41b0f64c1e51748bc29d382a23a67d99956e57e7431c64e47e74324182d9
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -1452,23 +1459,23 @@ __metadata:
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@substrate/calc": "npm:^0.3.1"
     "@substrate/dev": "npm:^0.7.1"
-    "@types/argparse": "npm:2.0.10"
-    "@types/express": "npm:^4.17.17"
-    "@types/express-serve-static-core": "npm:^4.17.36"
+    "@types/argparse": "npm:2.0.14"
+    "@types/express": "npm:^4.17.21"
+    "@types/express-serve-static-core": "npm:^4.17.43"
     "@types/http-errors": "npm:1.8.2"
     "@types/lru-cache": "npm:^7.10.10"
-    "@types/morgan": "npm:1.9.3"
-    "@types/triple-beam": "npm:^1.3.2"
+    "@types/morgan": "npm:1.9.9"
+    "@types/triple-beam": "npm:^1.3.5"
     argparse: "npm:^2.0.1"
     confmgr: "npm:^1.0.10"
-    express: "npm:^4.18.1"
+    express: "npm:^4.18.2"
     express-winston: "npm:^4.2.0"
     http-errors: "npm:^2.0.0"
     lru-cache: "npm:^7.13.1"
     prom-client: "npm:^14.2.0"
-    rxjs: "npm:^7.5.6"
+    rxjs: "npm:^7.8.1"
     ts-node-dev: "npm:^2.0.0"
-    winston: "npm:^3.8.1"
+    winston: "npm:^3.11.0"
   bin:
     substrate-api-sidecar: ./build/src/main.js
   languageName: unknown
@@ -1595,10 +1602,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/argparse@npm:2.0.10":
-  version: 2.0.10
-  resolution: "@types/argparse@npm:2.0.10"
-  checksum: 10/6f74560fa300f69ecae339fcb89e82cff0193ba643c05b98b3866e0c7b0dc099aa53821a109bab3c33d48150bd4da9a95b3e186f09de081f2d78e7c005cd8dc1
+"@types/argparse@npm:2.0.14":
+  version: 2.0.14
+  resolution: "@types/argparse@npm:2.0.14"
+  checksum: 10/1eba6ad70904f79a7c475cbdde74fead2db84dbda58e9e7329dbc6df5569812205e844925713175d264b321e0d5908f3a828615528823217775d043ef27cca36
   languageName: node
   linkType: hard
 
@@ -1671,27 +1678,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:^4.17.33, @types/express-serve-static-core@npm:^4.17.36":
-  version: 4.17.36
-  resolution: "@types/express-serve-static-core@npm:4.17.36"
+"@types/express-serve-static-core@npm:^4.17.33, @types/express-serve-static-core@npm:^4.17.43":
+  version: 4.17.43
+  resolution: "@types/express-serve-static-core@npm:4.17.43"
   dependencies:
     "@types/node": "npm:*"
     "@types/qs": "npm:*"
     "@types/range-parser": "npm:*"
     "@types/send": "npm:*"
-  checksum: 10/47d5c30a4a2a6de5dd1ceef6fed61a2e49e50e09ab3bab67a2bfa4375617c54b0397b3397ef4dad80ae3a7e400943464d857b437dabd9fed88b47256f2be774b
+  checksum: 10/9079e137470e0456bb8e77ae66df9505ee12591e94860bde574cfe52c5c60bbc5bf7dd44f5689c3cbb1baf0aa84442d9a21f53dcd921d18745727293cd5a5fd6
   languageName: node
   linkType: hard
 
-"@types/express@npm:^4.17.17":
-  version: 4.17.17
-  resolution: "@types/express@npm:4.17.17"
+"@types/express@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "@types/express@npm:4.17.21"
   dependencies:
     "@types/body-parser": "npm:*"
     "@types/express-serve-static-core": "npm:^4.17.33"
     "@types/qs": "npm:*"
     "@types/serve-static": "npm:*"
-  checksum: 10/e2959a5fecdc53f8a524891a16e66dfc330ee0519e89c2579893179db686e10cfa6079a68e0fb8fd00eedbcaf3eabfd10916461939f3bc02ef671d848532c37e
+  checksum: 10/7a6d26cf6f43d3151caf4fec66ea11c9d23166e4f3102edfe45a94170654a54ea08cf3103d26b3928d7ebcc24162c90488e33986b7e3a5f8941225edd5eb18c7
   languageName: node
   linkType: hard
 
@@ -1783,12 +1790,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/morgan@npm:1.9.3":
-  version: 1.9.3
-  resolution: "@types/morgan@npm:1.9.3"
+"@types/morgan@npm:1.9.9":
+  version: 1.9.9
+  resolution: "@types/morgan@npm:1.9.9"
   dependencies:
     "@types/node": "npm:*"
-  checksum: 10/1352fa06bc56fe6b2f5511fae9374f38bb8175433d77fb5c74e53ff9bd58be50b80fd59d8ca4c2e8ebe52a2b70a0ca7386f29b18f71f07f613dfa5e46b3afe9a
+  checksum: 10/a6969b4494de964d6b682fce93decd51988ec15a69be0d2766adacd5e942e06d9b4a5cad1708d6698b242edc5dee76ec6f909b81d68e148eb0634a0b6a4efb66
   languageName: node
   linkType: hard
 
@@ -1862,10 +1869,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/triple-beam@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "@types/triple-beam@npm:1.3.2"
-  checksum: 10/dd7b4a563fb710abc992e5d59eac481bed9e303fada2e276e37b00be31c392e03300ee468e57761e616512872e77935f92472877d0704a19688d15a726cee17b
+"@types/triple-beam@npm:^1.3.2, @types/triple-beam@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10/519b6a1b30d4571965c9706ad5400a200b94e4050feca3e7856e3ea7ac00ec9903e32e9a10e2762d0f7e472d5d03e5f4b29c16c0bd8c1f77c8876c683b2231f1
   languageName: node
   linkType: hard
 
@@ -3305,7 +3312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.18.1":
+"express@npm:^4.18.2":
   version: 4.18.2
   resolution: "express@npm:4.18.2"
   dependencies:
@@ -5737,7 +5744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.6, rxjs@npm:^7.8.1":
+"rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -6581,11 +6588,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:^3.8.1":
-  version: 3.10.0
-  resolution: "winston@npm:3.10.0"
+"winston@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "winston@npm:3.11.0"
   dependencies:
-    "@colors/colors": "npm:1.5.0"
+    "@colors/colors": "npm:^1.6.0"
     "@dabh/diagnostics": "npm:^2.0.2"
     async: "npm:^3.2.3"
     is-stream: "npm:^2.0.0"
@@ -6596,7 +6603,7 @@ __metadata:
     stack-trace: "npm:0.0.x"
     triple-beam: "npm:^1.3.0"
     winston-transport: "npm:^4.5.0"
-  checksum: 10/3fe855a9b8185f5c75d485bf4b6889c0c4885e85155b6736f783b08319c201fdae11e876ef87c1d333f9a213a4f7fc413fc8c42c720fefb76c59b3abd4ff6406
+  checksum: 10/8b456bdfbf336898c5a7ca83b5c312fe46f32830c759e231f950378c28a0ddd0780e64ceaf6ea76e0366fb1500b49b9fee80d1045e41efc3b03b51ad31eeb307
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
Updated the following dependencies to new `patch` versions: 
- `express` (dep)
- `@types/argparse` (devDep)
- `@types/express` (devDep)
- `@types/express-serve-static-core` (devDep)
- `@types/morgan` (devDep)
- `@types/triple-beam` (devDep)

Updated the following dependencies to new `minor` versions:
- `rxjs` (dep) - [changes shown in commits](https://github.com/ReactiveX/rxjs/commits/master/)
- `winston` (dep) - [changes mentioned in release notes](https://github.com/winstonjs/winston/releases)