### PR TITLE
fix: multilocation type in pallets/foreign-assets

### DIFF
--- a/src/services/pallets/PalletsForeignAssetsService.spec.ts
+++ b/src/services/pallets/PalletsForeignAssetsService.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -65,9 +65,9 @@ describe('PalletsForeignAssetsService', () => {
 						},
 						foreignAssetMetadata: {
 							deposit: '0',
-							name: '0x',
-							symbol: '0x',
-							decimals: '0',
+							name: '0x506f6c6b61646f74',
+							symbol: '0x444f54',
+							decimals: '10',
 							isFrozen: false,
 						},
 					},

--- a/src/services/pallets/PalletsForeignAssetsService.ts
+++ b/src/services/pallets/PalletsForeignAssetsService.ts
@@ -18,7 +18,6 @@ import { ApiPromise } from '@polkadot/api';
 import { Option } from '@polkadot/types';
 import { AssetMetadata, BlockHash } from '@polkadot/types/interfaces';
 import { PalletAssetsAssetDetails } from '@polkadot/types/lookup';
-import { InternalServerError } from 'http-errors';
 
 import { IForeignAssetInfo, IForeignAssets } from '../../types/responses';
 import { AbstractService } from '../AbstractService';
@@ -57,25 +56,10 @@ export class PalletsForeignAssetsService extends AbstractService {
 			if (foreignAssetData) {
 				// remove any commas from multilocation key values e.g. Parachain: 2,125 -> Parachain: 2125
 				const foreignAssetMultiLocationStr = JSON.stringify(foreignAssetData[0]).replace(/(\d),/g, '$1');
-				const XcmV3MultiLocation = ['StagingXcmV3MultiLocation', 'XcmV3MultiLocation'];
-				let foreignAssetMultiLocation;
-				try {
-					foreignAssetMultiLocation = api.registry.createType(
-						XcmV3MultiLocation[0],
-						JSON.parse(foreignAssetMultiLocationStr),
-					);
-				} catch (e) {
-					try {
-						foreignAssetMultiLocation = api.registry.createType(
-							XcmV3MultiLocation[1],
-							JSON.parse(foreignAssetMultiLocationStr),
-						);
-					} catch (e) {
-						throw new InternalServerError(`Failed to create MultiLocation type for Foreign Asset`);
-					}
-				}
 
-				const assetMetadata = await api.query.foreignAssets.metadata<AssetMetadata>(foreignAssetMultiLocation);
+				const assetMetadata = await api.query.foreignAssets.metadata<AssetMetadata>(
+					JSON.parse(foreignAssetMultiLocationStr),
+				);
 
 				if (assetInfo.isSome) {
 					items.push({

--- a/src/services/pallets/PalletsForeignAssetsService.ts
+++ b/src/services/pallets/PalletsForeignAssetsService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -18,6 +18,7 @@ import { ApiPromise } from '@polkadot/api';
 import { Option } from '@polkadot/types';
 import { AssetMetadata, BlockHash } from '@polkadot/types/interfaces';
 import { PalletAssetsAssetDetails } from '@polkadot/types/lookup';
+import { InternalServerError } from 'http-errors';
 
 import { IForeignAssetInfo, IForeignAssets } from '../../types/responses';
 import { AbstractService } from '../AbstractService';
@@ -56,10 +57,23 @@ export class PalletsForeignAssetsService extends AbstractService {
 			if (foreignAssetData) {
 				// remove any commas from multilocation key values e.g. Parachain: 2,125 -> Parachain: 2125
 				const foreignAssetMultiLocationStr = JSON.stringify(foreignAssetData[0]).replace(/(\d),/g, '$1');
-				const foreignAssetMultiLocation = api.registry.createType(
-					'XcmV3MultiLocation',
-					JSON.parse(foreignAssetMultiLocationStr),
-				);
+				const XcmV3MultiLocation = ['StagingXcmV3MultiLocation', 'XcmV3MultiLocation'];
+				let foreignAssetMultiLocation;
+				try {
+					foreignAssetMultiLocation = api.registry.createType(
+						XcmV3MultiLocation[0],
+						JSON.parse(foreignAssetMultiLocationStr),
+					);
+				} catch (e) {
+					try {
+						foreignAssetMultiLocation = api.registry.createType(
+							XcmV3MultiLocation[1],
+							JSON.parse(foreignAssetMultiLocationStr),
+						);
+					} catch (e) {
+						throw new InternalServerError(`Failed to create MultiLocation type for Foreign Asset`);
+					}
+				}
 
 				const assetMetadata = await api.query.foreignAssets.metadata<AssetMetadata>(foreignAssetMultiLocation);
 

--- a/src/services/test-helpers/mock/assets/mockAssetHubKusamaData.ts
+++ b/src/services/test-helpers/mock/assets/mockAssetHubKusamaData.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -86,9 +86,9 @@ export const foreignAssetsInfo = [foreignAssetInfoDot, foreignAssetInfoTknr];
 const foreignAssetMetadataDot = (): AssetMetadata => {
 	const responseObj = {
 		deposit: balanceOfDot,
-		name: assetHubKusamaRegistryV9430.createType('Bytes', ''),
-		symbol: assetHubKusamaRegistryV9430.createType('Bytes', ''),
-		decimals: assetHubKusamaRegistryV9430.createType('u8', 0),
+		name: assetHubKusamaRegistryV9430.createType('Bytes', 'Polkadot'),
+		symbol: assetHubKusamaRegistryV9430.createType('Bytes', 'DOT'),
+		decimals: assetHubKusamaRegistryV9430.createType('u8', 10),
 		isFrozen: falseBool,
 	};
 
@@ -110,7 +110,7 @@ const foreignAssetMetadataTknr = (): AssetMetadata => {
 export const foreignAssetsMetadata = (location: string): AssetMetadata => {
 	const foreignAssetMultiLocationStr = JSON.stringify(location).replace(/(\d),/g, '$1');
 
-	if (foreignAssetMultiLocationStr == '{"parents":2"interior":{"x1":{"globalConsensus":{"polkadot":null}}}}')
+	if (foreignAssetMultiLocationStr == '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}')
 		return foreignAssetMetadataDot();
 	else {
 		return foreignAssetMetadataTknr();


### PR DESCRIPTION
### Description of the issue
The endpoint `pallets/foreign-assets` throws the following error:
```
{
  "code": 500,
  "message": "createType(XcmV3MultiLocation):: DoNotConstruct: Cannot construct unknown type XcmV3MultiLocation",
  "stack": "Error: createType(XcmV3MultiLocation):: DoNotConstruct: Cannot construct unknown type XcmV3MultiLocation\n    at createTypeUnsafe ...",
  "level": "error"
}
```

### Root Cause
The error is thrown when it tries to create the `XcmV3MultiLocation` type in this [line](https://github.com/paritytech/substrate-api-sidecar/blob/96c9f11d7c4142c6f8a145eb932fb650941ade50/src/services/pallets/PalletsForeignAssetsService.ts#L60).

### Suggested Solution
First try to create the `StagingXcmV3MultiLocation` type and if it is not successful try the `XcmV3MultiLocation` type.

### Testing
Tested the endpoint by connecting to Polkadot/Kusama/Rococo Asset Hub