### PR TITLE
fix: define query param depth in Staking Payouts for all chains

### DIFF
--- a/src/controllers/accounts/AccountsStakingPayoutsController.ts
+++ b/src/controllers/accounts/AccountsStakingPayoutsController.ts
@@ -115,6 +115,8 @@ export default class AccountsStakingPayoutsController extends AbstractController
 		let sanitizedDepth: string | undefined;
 		if (depth && isKusama) {
 			sanitizedDepth = Math.min(Number(depth), currentEra - 518).toString();
+		} else if (depth) {
+			sanitizedDepth = depth as string;
 		}
 		if (currentEra < 518 && isKusama) {
 			const eraStartBlock: number = earlyErasBlockInfo[currentEra].start;


### PR DESCRIPTION
Closes #1421 

### Description
In #1415 a new variable `isKusama` was added to ensure that Kusama specific calculations are _activated_ / _taking effect_ only if we are connected to the Kusama chain. 
However, with this change the variable `sanitizedDepth` was left `undefined` if 
- the query param `depth` had a valid value and
- we were connected to any other chain

The reason is this [line](https://github.com/paritytech/substrate-api-sidecar/blob/master/src/controllers/accounts/AccountsStakingPayoutsController.ts#L116) of code:
```
if (depth && isKusama) {
	sanitizedDepth = Math.min(Number(depth), currentEra - 518).toString();
}
```
where `sanitizedDepth` is defined only is `depth` has a value and we are connected to the Kusama chain.

Added a small fix to correct this.
