### PR TITLE
feat: add metadata versions endpoints

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1153,6 +1153,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /transaction/material/v14:
+    get:
+      tags:
+      - transaction
+      summary: Get all the network information needed to construct a transaction offline and
+        the v14 of metadata.
+      description: Returns the material that is universal to constructing any
+        signed transaction offline and the v14 of metadata. Replaces `/tx/artifacts`
+        from versions < v1.0.0.
+      operationId: getTransactionMaterial
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve the transaction construction
+          material.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: metadata
+        in: query
+        description: Specifies the format of the metadata to be returned. Accepted values are
+          'json', and 'scale'. 'json' being the decoded metadata, and 'scale' being the SCALE encoded metadata.
+          When `metadata` is not inputted, the `metadata` field will be absent.
+        schema:
+          type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionMaterial'
+        "400":
+          description: invalid blockId supplied for at query param
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /transaction/material/v15:
+    get:
+      tags:
+      - transaction
+      summary: Get all the network information needed to construct a transaction offline and
+        the v15 of metadata.
+      description: Returns the material that is universal to constructing any
+        signed transaction offline and the v15 of metadata. Replaces `/tx/artifacts`
+        from versions < v1.0.0.
+      operationId: getTransactionMaterial
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve the transaction construction
+          material.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: metadata
+        in: query
+        description: Specifies the format of the metadata to be returned. Accepted values are
+          'json', and 'scale'. 'json' being the decoded metadata, and 'scale' being the SCALE encoded metadata.
+          When `metadata` is not inputted, the `metadata` field will be absent.
+        schema:
+          type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionMaterial'
+        "400":
+          description: invalid blockId supplied for at query param
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /pallets/assets/{assetId}/asset-info:
     get:
       tags:
@@ -1753,6 +1833,89 @@ paths:
               schema:
                 type: object
                 description: Response is dependent on the runtime metadata contents.
+  /runtime/metadata/v14:
+    get:
+      tags:
+      - runtime
+      summary: Get the version 14 of runtime metadata in decoded, JSON form.
+      description: >-
+       Returns the version 14 of runtime metadata as a JSON object.
+       Substrate Reference:
+       - FRAME Support: https://crates.parity.io/frame_support/metadata/index.html
+       - Knowledge Base: https://substrate.dev/docs/en/knowledgebase/runtime/metadata
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve the metadata at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Response is dependent on the runtime metadata contents.
+  /runtime/metadata/v15:
+    get:
+      tags:
+      - runtime
+      summary: Get the version 15 of runtime metadata in decoded, JSON form.
+      description: >-
+       Returns the version 15 of runtime metadata as a JSON object.
+       Substrate Reference:
+       - FRAME Support: https://crates.parity.io/frame_support/metadata/index.html
+       - Knowledge Base: https://substrate.dev/docs/en/knowledgebase/runtime/metadata
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve the metadata at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Response is dependent on the runtime metadata contents.
+  /runtime/metadata/versions:
+    get:
+      tags:
+      - runtime
+      summary: Get the available versions of runtime metadata.
+      description: >-
+       Returns the available versions of runtime metadata.
+       Substrate Reference:
+       - FRAME Support: https://crates.parity.io/frame_support/metadata/index.html
+       - Knowledge Base: https://substrate.dev/docs/en/knowledgebase/runtime/metadata
+      parameters:
+      - name: at
+        in: query
+        description: Block at which to retrieve the metadata versions at.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                description: An array with the available metadata versions.
   /runtime/code:
     get:
       tags:

--- a/src/services/transaction/TransactionMaterialService.ts
+++ b/src/services/transaction/TransactionMaterialService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { BlockHash } from '@polkadot/types/interfaces';
+import { Metadata } from '@polkadot/types';
+import type { Option } from '@polkadot/types/codec';
+import type { BlockHash, OpaqueMetadata } from '@polkadot/types/interfaces';
+import { InternalServerError } from 'http-errors';
 import { ITransactionMaterial } from 'src/types/responses';
 
 import { MetadataOpts } from '../../controllers/transaction/TransactionMaterialController';
@@ -66,6 +69,87 @@ export class TransactionMaterialService extends AbstractService {
 		};
 
 		const formattedMeta = metadataArg === 'scale' ? metadata.toHex() : metadata.toJSON();
+
+		return {
+			at,
+			genesisHash,
+			chainName: name.toString(),
+			specName: version.specName.toString(),
+			specVersion: version.specVersion,
+			txVersion: version.transactionVersion,
+			metadata: formattedMeta,
+		};
+	}
+
+	/**
+	 * Fetch all the network information needed to construct a transaction offline.
+	 *
+	 * @param hash `BlockHash` to make call at
+	 */
+	async fetchTransactionMaterialwithVersionedMetadata(
+		hash: BlockHash,
+		metadataArg: MetadataOpts | false,
+		metadataVersion: number,
+	): Promise<ITransactionMaterial> {
+		const { api } = this;
+
+		if (!metadataArg) {
+			const [header, genesisHash, name, version] = await Promise.all([
+				api.rpc.chain.getHeader(hash),
+				api.rpc.chain.getBlockHash(0),
+				api.rpc.system.chain(),
+				api.rpc.state.getRuntimeVersion(hash),
+			]);
+
+			const at = {
+				hash,
+				height: header.number.toNumber().toString(10),
+			};
+
+			return {
+				at,
+				genesisHash,
+				chainName: name.toString(),
+				specName: version.specName.toString(),
+				specVersion: version.specVersion,
+				txVersion: version.transactionVersion,
+			};
+		}
+
+		const [header, genesisHash, name, version] = await Promise.all([
+			api.rpc.chain.getHeader(hash),
+			api.rpc.chain.getBlockHash(0),
+			api.rpc.system.chain(),
+			api.rpc.state.getRuntimeVersion(hash),
+		]);
+
+		const apiAt = await api.at(hash);
+
+		let metadata: Option<OpaqueMetadata> | undefined;
+		let metadataVersioned: Metadata | undefined;
+		try {
+			if (metadataVersion === 14) {
+				metadata = await apiAt.call.metadata.metadataAtVersion(14);
+			} else if (metadataVersion === 15) {
+				metadata = await apiAt.call.metadata.metadataAtVersion(15);
+			}
+			if (metadata) {
+				metadataVersioned = new Metadata(apiAt.registry, metadata.unwrap());
+			} else {
+				throw new Error(`Metadata for version ${metadataVersion} is not available.`);
+			}
+		} catch {
+			throw new InternalServerError(
+				`An error occured while attempting to fetch ${metadataVersion.toString()} metadata.`,
+			);
+		}
+
+		const at = {
+			hash,
+			height: header.number.toNumber().toString(10),
+		};
+
+		const formattedMeta = metadataArg === 'scale' ? metadata.toHex() : metadataVersioned.toJSON();
 
 		return {
 			at,

--- a/src/types/responses/TransactionMaterial.ts
+++ b/src/types/responses/TransactionMaterial.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { BlockHash } from '@polkadot/types/interfaces';
-import { u32 } from '@polkadot/types/primitive';
-import { AnyJson } from '@polkadot/types/types';
+import type { BlockHash } from '@polkadot/types/interfaces';
+import type { u32 } from '@polkadot/types/primitive';
+import type { AnyJson } from '@polkadot/types/types';
 
 import { IAt } from '.';
 


### PR DESCRIPTION
Closes #1410 

### Description
The current implementation differs from the initial idea outlined in the #1410 issue. We did not add a query param in the existing endpoints in order to maintain the current functionality unchanged. Instead, the following new endpoints were added:
- `/runtime/metadata/:metadataVersion`
- `/runtime/metadata/versions`
- `transaction/material/:metadataVersion`

### Tests
- [x] Tested in Kusama and Polkadot for error cases like providing for the `metadataVersion` param:
    - [x] a non existing metadata version, e.g. : `v25`, `v11`
    - [x] a non number, e.g. : `vJDHS`
    - [x] badly formatted query param, e.g. : `fjhsdjkf`
- [x] Tested the `scale` and `json` format in `transaction/material`

### Todos
- [ ] Fix docs so it does not mention `v14` or `v15` but the generic path param `metadataVersion`