### PR TITLE
fix: add deprecation note for paras endpoints

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2128,7 +2128,7 @@ paths:
       tags:
       - paras
       summary: |
-        List all registered paras (parathreads & parachains).
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] List all registered paras (parathreads & parachains).
       description: Returns all registered parachains and parathreads with lifecycle info.
       parameters:
       - name: at
@@ -2151,7 +2151,7 @@ paths:
       tags:
       - paras
       summary: |
-        Get general information about the current lease period.
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] Get general information about the current lease period.
       description: |
         Returns an overview of the current lease period, including lease holders.
       parameters:
@@ -2185,7 +2185,7 @@ paths:
       tags:
       - paras
       summary: |
-        Get the status of the current auction.
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] Get the status of the current auction.
       description: |
         Returns an overview of the current auction. There is only one auction
         at a time. If there is no auction most fields will be `null`. If the current
@@ -2214,7 +2214,7 @@ paths:
       tags:
       - paras
       summary: |
-        List all stored crowdloans.
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] List all stored crowdloans.
       description: |
         Returns a list of all the crowdloans and their associated paraIds.
       parameters:
@@ -2238,7 +2238,7 @@ paths:
       tags:
       - paras
       summary: |
-        Get crowdloan information for a `paraId`.
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] Get crowdloan information for a `paraId`.
       description: |
         Returns crowdloan's `fundInfo` and the set of `leasePeriods` the crowdloan`
         covers.
@@ -2269,7 +2269,7 @@ paths:
       tags:
       - paras
       summary: |
-        Get current and future leases as well as the lifecycle stage for a given `paraId`.
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] Get current and future leases as well as the lifecycle stage for a given `paraId`.
       description: |
         Returns a list of leases that belong to the `paraId` as well as the
         `paraId`'s current lifecycle stage.
@@ -2300,7 +2300,7 @@ paths:
       tags:
       - paras
       summary: |
-        Get the heads of the included (backed and considered available) parachain candidates at the 
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] Get the heads of the included (backed and considered available) parachain candidates at the
         specified block height or at the most recent finalized head otherwise.
       description: |
         Returns an object with all the parachain id's as keys, and their headers as values.
@@ -2325,7 +2325,7 @@ paths:
       tags:
       - paras
       summary: |
-        Get the heads of the backed parachain candidates at the specified block height or at the most recent finalized head otherwise.
+        [DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME] Get the heads of the backed parachain candidates at the specified block height or at the most recent finalized head otherwise.
       description: |
         Returns an object with all the parachain id's as keys, and their headers as values.
       parameters:

--- a/src/controllers/paras/ParasController.ts
+++ b/src/controllers/paras/ParasController.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -28,6 +28,9 @@ export default class ParasController extends AbstractController<ParasService> {
 		this.initRoutes();
 	}
 
+	// ***************************************************************
+	// DEPRECATION NOTE: PHASED OUT CONTROLLERS IN FAVOR OF CORETIME
+	// ***************************************************************
 	protected initRoutes(): void {
 		this.router.use(this.path + '/paras/leases/current', validateBoolean(['currentLeaseHolders']));
 		this.safeMountAsyncGetHandlers([

--- a/src/services/paras/ParasService.ts
+++ b/src/services/paras/ParasService.ts
@@ -55,6 +55,10 @@ const LEASE_PERIODS_PER_SLOT_FALLBACK = 4;
 
 export class ParasService extends AbstractService {
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT SERVICE IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * Get crowdloan information for a `paraId`.
 	 *
 	 * @param hash `BlockHash` to make call at
@@ -101,6 +105,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT SERVICE IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * List all available crowdloans.
 	 *
 	 * @param hash `BlockHash` to make call at
@@ -134,6 +142,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT SERVICE IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * Get current and future lease info + lifecycle stage for a given `paraId`.
 	 *
 	 * @param hash Get lease info at this `BlockHash`
@@ -196,6 +208,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT SERVICE IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * Get the status of the current auction.
 	 *
 	 * Note: most fields will be null if there is no ongoing auction.
@@ -306,6 +322,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT SERVICE IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * Get general information about the current lease period.
 	 *
 	 * @param hash `BlockHash` to make call at
@@ -351,6 +371,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT SERVICE IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * List all registered paras (parathreads & parachains).
 	 *
 	 * @param hash `BlockHash` to make call at
@@ -392,6 +416,10 @@ export class ParasService extends AbstractService {
 	}
 
 	/**
+	 * ***********************************************************
+	 * DEPRECATION NOTE: PHASED OUT ENDPOINT IN FAVOR OF CORETIME
+	 * ***********************************************************
+	 *
 	 * Get the heads of the included (backed or considered available) parachain candidates
 	 * at the specified block height or at the most recent finalized head otherwise.
 	 *


### PR DESCRIPTION
Rel: #1413 

### Description
With the introduction of Coretime, all endpoints related to parachains (`paras`): crowdloans, leases, auctions, etc. will be phased out. Hence, a deprecation note has been added (docs, controller and service file) to the following endpoints:
- `/paras`
- `/paras/leases/current`
- `/paras/auctions/current`
- `/paras/crowdloans`
- `/paras/{paraId}/crowdloan-info`
- `/paras/{paraId}/lease-info`
- `/paras/head/included-candidates`
- `/paras/head/backed-candidates`


