### PR TITLE
fix: add new staking storage items

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -564,23 +564,15 @@ export class AccountsStakingPayoutsService extends AbstractService {
 
 				validators[validatorId] = exposure;
 
-				if (exposure.others) {
-					exposure.others.forEach(({ who }, validatorIndex): void => {
-						const nominatorId = who.toString();
+				const individualExposure = exposure.others
+					? exposure.others
+					: (exposure as unknown as Option<SpStakingExposurePage>).unwrap().others;
+				individualExposure.forEach(({ who }, validatorIndex): void => {
+					const nominatorId = who.toString();
 
-						nominators[nominatorId] = nominators[nominatorId] || [];
-						nominators[nominatorId].push({ validatorId, validatorIndex });
-					});
-				} else {
-					(exposure as unknown as Option<SpStakingExposurePage>)
-						.unwrap()
-						.others.forEach(({ who }, validatorIndex): void => {
-							const nominatorId = who.toString();
-
-							nominators[nominatorId] = nominators[nominatorId] || [];
-							nominators[nominatorId].push({ validatorId, validatorIndex });
-						});
-				}
+					nominators[nominatorId] = nominators[nominatorId] || [];
+					nominators[nominatorId].push({ validatorId, validatorIndex });
+				});
 			});
 			if (Object.keys(validatorIndex).length > 0) {
 				return { era, nominators, validators, validatorIndex, validatorsOverview };


### PR DESCRIPTION
Rel: https://github.com/paritytech/substrate-api-sidecar/issues/1411

### Related Endpoint `/accounts/{accountId}/staking-payouts`
The changes in this PR are affecting the responses returned by `/accounts/{accountId}/staking-payouts` endpoint.

### Description
After the runtime upgrade of Polkadot to [v1.2.0](https://github.com/polkadot-fellows/runtimes/releases/tag/v1.2.0), the new storage items `erasStakersPaged` and `erasStakersOverview` are used instead of `erasStakersClipped`. 
More information regarding this change can be found: 
- https://github.com/paritytech/polkadot-sdk/pull/1189
- https://github.com/polkadot-js/apps/issues/10004

Hence, as mentioned [here](https://github.com/paritytech/polkadot-sdk/issues/433), to get the rewards: 
- in Kusama after era 6514 (Apr 18) and
- in Polkadot after era 1420 (Apr 21)

we need to make use of the new storage items instead of relying on [erasStakersClipped](https://github.com/paritytech/substrate-api-sidecar/blob/80571f840f1f62789a9b2ee0c41486ae2c46c24d/src/services/accounts/AccountsStakingPayoutsService.ts#L562), as it currently returns empty results for eras > than the eras mentioned previously. We still use `erasStakersClipped` for eras before the runtime upgrade until it is removed completely which we would need to also remove.

### Implementation Notes
- Since now the information is split into 2 storage items ([link](https://forum.polkadot.network/t/staking-update-paged-staking-reward-to-avoid-validator-oversubscription-issue-is-live-on-westend/5215/2#erasstakers-changes-total-and-value-in-overview-others-in-paged-3)), `validatorsOverview` was added in `IAdjustedDeriveEraExposure` so we can store and use the information from the additional call.
- Sidecar's response item `totalValidatorExposure` is retrieved from `query.staking.erasStakersOverview` > `total` 
    - which is aligned with the old [logic](https://github.com/paritytech/substrate-api-sidecar/blob/80571f840f1f62789a9b2ee0c41486ae2c46c24d/src/services/accounts/AccountsStakingPayoutsService.ts#L628) but using the new call.

    **IMPORTANT NOTE**
    There is also available `query.staking.erasStakersPaged` > `pageTotal` but based on manual testing and quoting this [part](https://forum.polkadot.network/t/staking-update-paged-staking-reward-to-avoid-validator-oversubscription-issue-is-live-on-westend/5215/2#erasstakers-changes-total-and-value-in-overview-others-in-paged-3) of the forum post : 
   > _ErasStakers Changes: total and value in Overview, others in Paged_
  
     I believe the more complete information is found in `...Overview` - `total` since there are cases when these 2 fields differ.

- Sidecar's response item `nominatorExposure` when the validator is also the nominator,  is retrieved from `query.staking.erasStakersOverview` > `own` 
    - which is aligned with the old [logic](https://github.com/paritytech/substrate-api-sidecar/blob/80571f840f1f62789a9b2ee0c41486ae2c46c24d/src/services/accounts/AccountsStakingPayoutsService.ts#L635) but using the new call.

### Sample Responses
Sidecar endpoint while connected to Polkadot chain : 
```
http://127.0.0.1:8080/accounts/15CosmEmAfQAhnxwan18e5TueAe6bDzrqqxg13dToDWr7A8M/staking-payouts?depth=1&era=1420&unclaimedOnly=false
```

returns
```
{
  "at": {
    "height": "20480919",
    "hash": "0xc163f6e3182542699f89e78c95298579fd86168cc73370814f6dce6628747f6b"
  },
  "erasPayouts": [
    {
      "era": "1420",
      "totalEraRewardPoints": "27466000",
      "totalEraPayout": "3579344121756224",
      "payouts": [
        {
          "validatorId": "15CosmEmAfQAhnxwan18e5TueAe6bDzrqqxg13dToDWr7A8M",
          "nominatorStakingPayout": "633147762128",
          "claimed": false,
          "totalValidatorRewardPoints": "93760",
          "validatorCommission": "50000000",
          "totalValidatorExposure": "26454213023677507",
          "nominatorExposure": "50621054502286"
        }
      ]
    }
  ]
}
```

**Cross checked results**
- `totalValidatorRewardPoints` with [subscan](https://polkadot.subscan.io/validator/15CosmEmAfQAhnxwan18e5TueAe6bDzrqqxg13dToDWr7A8M?tab=era)
- `totalValidatorExposure` with [pjs-apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.dotters.network%2Fpolkadot#/chainstate) (`staking.erasStakersOverview` - `total` for the specified account and erra)
- `nominatorExposure` with [pjs-apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.dotters.network%2Fpolkadot#/chainstate) (`staking.erasStakersOverview` - `own` for the specified account and erra)
- The current version of [public sidecar](https://polkadot-public-sidecar.parity-chains.parity.io/accounts/15CosmEmAfQAhnxwan18e5TueAe6bDzrqqxg13dToDWr7A8M/staking-payouts?depth=1&era=1420&unclaimedOnly=false) does not return any results.


