### PR TITLE
chore(deps): update polkadot-js deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "test:test-release": "yarn build:scripts && node scripts/build/runYarnPack.js"
   },
   "dependencies": {
-    "@polkadot/api": "^11.0.1",
-    "@polkadot/api-contract": "^11.0.1",
+    "@polkadot/api": "^11.0.2",
+    "@polkadot/api-contract": "^11.0.2",
     "@polkadot/util-crypto": "^12.6.2",
     "@substrate/calc": "^0.3.1",
     "argparse": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "test:test-release": "yarn build:scripts && node scripts/build/runYarnPack.js"
   },
   "dependencies": {
-    "@polkadot/api": "^10.13.1",
-    "@polkadot/api-contract": "^10.13.1",
+    "@polkadot/api": "^11.0.1",
+    "@polkadot/api-contract": "^11.0.1",
     "@polkadot/util-crypto": "^12.6.2",
     "@substrate/calc": "^0.3.1",
     "argparse": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,155 +934,155 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot-api/client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
+"@polkadot-api/json-rpc-provider-proxy@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@polkadot-api/json-rpc-provider-proxy@npm:0.0.1"
+  checksum: 10/6ee0916504ab702ac40eb1f983c21246738c1cd8624b35886a075430271800543d32ba5a7f9e6a0cb078880f9756db1bdc83cb86c42b39d326e780a8cf9bf22a
+  languageName: node
+  linkType: hard
+
+"@polkadot-api/json-rpc-provider@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@polkadot-api/json-rpc-provider@npm:0.0.1"
+  checksum: 10/1f315bdadcba7def7145011132e6127b983c6f91f976be217ad7d555bb96a67f3a270fe4a46e427531822c5d54d353d84a6439d112a99cdfc07013d3b662ee3c
+  languageName: node
+  linkType: hard
+
+"@polkadot-api/metadata-builders@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@polkadot-api/metadata-builders@npm:0.0.1"
   dependencies:
-    "@polkadot-api/metadata-builders": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/substrate-bindings": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/substrate-client": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/utils": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
+    "@polkadot-api/substrate-bindings": "npm:0.0.1"
+    "@polkadot-api/utils": "npm:0.0.1"
+  checksum: 10/e7bf0ad10cbddf75012eaaa1b30060fb1eb142c02f7dfd8edc5a1d78a40ef078b09c85d36bf9f2ac4ab309970ba01dc648ef46745412b006e62e4ddf4f334339
+  languageName: node
+  linkType: hard
+
+"@polkadot-api/observable-client@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@polkadot-api/observable-client@npm:0.1.0"
+  dependencies:
+    "@polkadot-api/metadata-builders": "npm:0.0.1"
+    "@polkadot-api/substrate-bindings": "npm:0.0.1"
+    "@polkadot-api/substrate-client": "npm:0.0.1"
+    "@polkadot-api/utils": "npm:0.0.1"
   peerDependencies:
     rxjs: ">=7.8.0"
-  checksum: 10/cc9cc2e54cbb6956290f07ecede3c086455147fc84b5668482655b6e5e3726e408157bbe92747dd5a551ab42604df93f35bab45e78f28489dc998a75586f855b
+  checksum: 10/822b4b24e8b2522fa2b0d88d68d098862d36e9ef285dba7468a6ac9084a37670ef0782a9b8a00c2c4d5510a0af90b3611ea097f530bdad1b07bef63234341bf5
   languageName: node
   linkType: hard
 
-"@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/json-rpc-provider-proxy@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-  checksum: 10/bdcdf34feefd9b7f4b29e4fe212ca2609455fce53aeac5b3df9bba4cf714022d3266877e00fbdf5d2d24090cfbcd5139d859295e4e2bb15d055e2fb2704b79ec
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/json-rpc-provider@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/json-rpc-provider@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-  checksum: 10/00d4e1f7900a1739e1ba7a3b13d399e5540a27d5c026c985aa4afdf865fb37da4aa4029a3a740932615482cdf18e657011ef05e7e61c2de04016f68fbb343ae7
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/metadata-builders@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/metadata-builders@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-  dependencies:
-    "@polkadot-api/substrate-bindings": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/utils": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-  checksum: 10/0dc59527415b51b9741e95842505cfca788e9fb0e6666be971000b9fe522b7d1a81265d4cab1712c2cc564e14ae8f0e1ef8f32f4023be1261f366edaa1936cc9
-  languageName: node
-  linkType: hard
-
-"@polkadot-api/substrate-bindings@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/substrate-bindings@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
+"@polkadot-api/substrate-bindings@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@polkadot-api/substrate-bindings@npm:0.0.1"
   dependencies:
     "@noble/hashes": "npm:^1.3.1"
-    "@polkadot-api/utils": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
+    "@polkadot-api/utils": "npm:0.0.1"
     "@scure/base": "npm:^1.1.1"
     scale-ts: "npm:^1.6.0"
-  checksum: 10/e14a81197b86314aa8887d7e81cbf3f0c3b9eec0267b128c81bb3bf6d26d93ac75bd113177861789a066b215a72ac03c940d590e769ca3f33a2ac4480c752538
+  checksum: 10/9a1a70bd571f1cf262796b445c7a005b425e8e6f855b11757442c6bbe398d4a90575cd3973c9b1918202d3c7ff7162675c349c014677a31cc70cd84f7f973f90
   languageName: node
   linkType: hard
 
-"@polkadot-api/substrate-client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/substrate-client@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-  checksum: 10/af1dce32d1b52bba5494daef387dcb15694ee57ed394e8ac905430ade7cdbae1c44ef5cdb7d777096ee0a0d8a58d3409e9c0c464f780bbd0286cb06d46390c3c
+"@polkadot-api/substrate-client@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@polkadot-api/substrate-client@npm:0.0.1"
+  checksum: 10/a00521dbda6e87a2d0e860c1608dc164269c62748d60a51326452d3573abfa1d01ed79644f103f1d989c49e8c61169ed04b155d466ec9e6f09f6e424572dea48
   languageName: node
   linkType: hard
 
-"@polkadot-api/utils@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0":
-  version: 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-  resolution: "@polkadot-api/utils@npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-  checksum: 10/99d8c233ad4fe58f5ee993cf76b99689e6d34bc239e24785c60d2bd7cd74e4cc2bb8e0704a041c20bff8866a8151126d04c1be01ba5c1d51b1086cd7a5b55814
+"@polkadot-api/utils@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@polkadot-api/utils@npm:0.0.1"
+  checksum: 10/4bf89955ccf4dafb2ef34f007fc0a12bd6d983a10c4219464a6b1c07e7bfe80ff26f156fa201b3f11ad53adca0abb261fc7ee43b86dcdc10fa0f5325788359ae
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/api-augment@npm:10.13.1"
+"@polkadot/api-augment@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/api-augment@npm:11.0.1"
   dependencies:
-    "@polkadot/api-base": "npm:10.13.1"
-    "@polkadot/rpc-augment": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-augment": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
+    "@polkadot/api-base": "npm:11.0.1"
+    "@polkadot/rpc-augment": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-augment": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/094d5e79d511a44b0a0f5ea10f612a94cd0b423e16803c23847004e1546220ff8e4e90e64a0ccd78387685c9a47687b7ece66347247443aaa86f58e69e25a033
+  checksum: 10/f8eb96c723e548a7cfee13b134e78ef6efead54b2a42baf62ff94a2bc7e3946456e767e8425f9377fafa220ef27e39934bdc2bf94cdc9b44801db51be670dcc4
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/api-base@npm:10.13.1"
+"@polkadot/api-base@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/api-base@npm:11.0.1"
   dependencies:
-    "@polkadot/rpc-core": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
+    "@polkadot/rpc-core": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/e680030a9663ec866715751386edb5deea856e79cba96e9de22ca73dd69244ece78196c74cce2077cad0fbf3bd6638198ac58ec52b9641ccb8fc9a922d6e62d4
+  checksum: 10/9cfbe8d3833984a76ef2cc409b9eb2ea5f1d3292fddd03b02859f1f9d79a0c0e9086c5fb00343b83ff5a286ad89a8197f804efed9b21537f64cf0c086bb1156d
   languageName: node
   linkType: hard
 
-"@polkadot/api-contract@npm:^10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/api-contract@npm:10.13.1"
+"@polkadot/api-contract@npm:^11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/api-contract@npm:11.0.1"
   dependencies:
-    "@polkadot/api": "npm:10.13.1"
-    "@polkadot/api-augment": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
-    "@polkadot/types-create": "npm:10.13.1"
+    "@polkadot/api": "npm:11.0.1"
+    "@polkadot/api-augment": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/types-create": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/ec2b5ea2ab9ad684693edbb53485593639a54c052da2f15b11e2c33caf10f3c4bac9071aa701c15e3d76819d65534319dcf971cfddffbb1b407f48bb5802b19c
+  checksum: 10/bd37b72c82a6506627c6528c709a7b5d3d2422560b3ea931d9248393a1d3ed7d8dcbae20dc0e85040224df732ecdb7b7084d89e2863bf4c4f874c717525b5ff4
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/api-derive@npm:10.13.1"
+"@polkadot/api-derive@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/api-derive@npm:11.0.1"
   dependencies:
-    "@polkadot/api": "npm:10.13.1"
-    "@polkadot/api-augment": "npm:10.13.1"
-    "@polkadot/api-base": "npm:10.13.1"
-    "@polkadot/rpc-core": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
+    "@polkadot/api": "npm:11.0.1"
+    "@polkadot/api-augment": "npm:11.0.1"
+    "@polkadot/api-base": "npm:11.0.1"
+    "@polkadot/rpc-core": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/20b70e34b27ecf787c2898a81d6f6ac209331eb7493494a3156c9905841be4c536c03fa2552bcc918a11a170e41ffc5368fce2c40c41be3b856eaeaf0e0e65bf
+  checksum: 10/471a141ec9d7afc250a4cbeeeb2613a20c5b521fcee64d373bf4857d3faace3e4d8fc517991bc1d089f68e06521a23b566cb8afea75ffc27d4c7286e639ef2b5
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:10.13.1, @polkadot/api@npm:^10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/api@npm:10.13.1"
+"@polkadot/api@npm:11.0.1, @polkadot/api@npm:^11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/api@npm:11.0.1"
   dependencies:
-    "@polkadot/api-augment": "npm:10.13.1"
-    "@polkadot/api-base": "npm:10.13.1"
-    "@polkadot/api-derive": "npm:10.13.1"
+    "@polkadot/api-augment": "npm:11.0.1"
+    "@polkadot/api-base": "npm:11.0.1"
+    "@polkadot/api-derive": "npm:11.0.1"
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/rpc-augment": "npm:10.13.1"
-    "@polkadot/rpc-core": "npm:10.13.1"
-    "@polkadot/rpc-provider": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-augment": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
-    "@polkadot/types-create": "npm:10.13.1"
-    "@polkadot/types-known": "npm:10.13.1"
+    "@polkadot/rpc-augment": "npm:11.0.1"
+    "@polkadot/rpc-core": "npm:11.0.1"
+    "@polkadot/rpc-provider": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-augment": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/types-create": "npm:11.0.1"
+    "@polkadot/types-known": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     eventemitter3: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/4323c7e5a89044b082e98525a6ec8674ac84d6548b14a9d24f5c027a2f1f598e0ea42913afdfb17b28a6822933a42508cd048529ad237c1ce1431107202c9874
+  checksum: 10/24b9eba509dd33ba1ddcf87832643e653e83c68473af75b9fbabe5ca3c6f8bc11e04eddbf2125a20fa6be6a606bbe24452c0514b9181184a3671fb3180791fc9
   languageName: node
   linkType: hard
 
@@ -1111,46 +1111,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/rpc-augment@npm:10.13.1"
+"@polkadot/rpc-augment@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/rpc-augment@npm:11.0.1"
   dependencies:
-    "@polkadot/rpc-core": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
+    "@polkadot/rpc-core": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/136c03295315d4217592dbaae7113eecb1560895e95d3fe369cfd12b8edc5f5f19d1e31c929444c53b27600ca2a17d01448b282bee738cee83307193f645e896
+  checksum: 10/fe68e6e0a8e5f75e23a4a8753d485afdc9bd66368e913d17d2109b476c68cb39e01d768ed17f37a4169307aafa4998e23efdd04058196aa0664e5b41c272920d
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/rpc-core@npm:10.13.1"
+"@polkadot/rpc-core@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/rpc-core@npm:11.0.1"
   dependencies:
-    "@polkadot/rpc-augment": "npm:10.13.1"
-    "@polkadot/rpc-provider": "npm:10.13.1"
-    "@polkadot/types": "npm:10.13.1"
+    "@polkadot/rpc-augment": "npm:11.0.1"
+    "@polkadot/rpc-provider": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/898237861cf770ac99cd0f50cab594ecfa56e2706201c7e35459718f6a1bef7b8e3d2349a62fd7a5e59dad87db32d6f85585c4c85b50e221ce114c4df0a5bfdc
+  checksum: 10/8204ace945f260f4ae95bba45784b16634296a1d4f4473137cf62e085b8d969f59679a7bc380e5f2945f456eef9301c0bda0a0172a2615f6bcaf076ca82f9c43
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/rpc-provider@npm:10.13.1"
+"@polkadot/rpc-provider@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/rpc-provider@npm:11.0.1"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-support": "npm:10.13.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-support": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@polkadot/x-fetch": "npm:^12.6.2"
     "@polkadot/x-global": "npm:^12.6.2"
     "@polkadot/x-ws": "npm:^12.6.2"
-    "@substrate/connect": "npm:0.8.8"
+    "@substrate/connect": "npm:0.8.10"
     eventemitter3: "npm:^5.0.1"
     mock-socket: "npm:^9.3.1"
     nock: "npm:^13.5.0"
@@ -1158,81 +1158,81 @@ __metadata:
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: 10/9a17ccbe302c7104924dafdf829ec6a87303cc9bf86d7d06dae614b5f40550759a404dded427382030fa4fee2a7d0bc8f32a9f7d6b67f966a76a209938bfbc62
+  checksum: 10/9f0234039c40bb7ce7f072a044b14d0b9d87e6da62a49d11de12accfa7ef5a0021477c8553409580bc9261b8f7ad7c34ec8cfabcf5bca77f7ccf022e7a19a8d2
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/types-augment@npm:10.13.1"
+"@polkadot/types-augment@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/types-augment@npm:11.0.1"
   dependencies:
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/41d54340f81dceea864b03e0b2ad7dacd2d6f107c36bb29d74866e7f9ec70348d40e7c847856c5ad84e436d1c6123b951b1c3aefa87df90e772a5128fce3c43c
+  checksum: 10/5b2f75bcb73b290b10889b4e2c8bca1fbe31a261d98b1b9a410db997167c1dcb720d8ab4d0128ffc9b685c80934c3495ef2d7de7e3135096d68448b53a500859
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/types-codec@npm:10.13.1"
+"@polkadot/types-codec@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/types-codec@npm:11.0.1"
   dependencies:
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/x-bigint": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/471fe15559ca880a0bc34ff6e24454a33bef72c82007aa95486c98766993e81dac7b59046927a7d167b1f5c569e08716f26592eef04bd03f809174977aa24f2c
+  checksum: 10/d3f25f63342ab6de85979d4d715f2088a6c3a9b5190a5b3d00a2d76e5d508632575a0fbbd724d556efed464fd90e8ff63e52090b4b784e7f7d983837a14a4f52
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/types-create@npm:10.13.1"
+"@polkadot/types-create@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/types-create@npm:11.0.1"
   dependencies:
-    "@polkadot/types-codec": "npm:10.13.1"
+    "@polkadot/types-codec": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/30e8de4d36fb0760ace5282d7f80e8dc035462df7c26a37d1cac5ac31b8dac8775a9a23eaff9636e470f4f3ea7034ce4ccfe8f6510c51481d47dac7d832b0d58
+  checksum: 10/adf2a813d34514788d35fcdb6d2652ac9e51231c245e304dc20cff4e06ab8e165eb36ac0334ab87ef3d0cbf54dd1e2843e38eaf81fabb76ea51a580072c94899
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/types-known@npm:10.13.1"
+"@polkadot/types-known@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/types-known@npm:11.0.1"
   dependencies:
     "@polkadot/networks": "npm:^12.6.2"
-    "@polkadot/types": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
-    "@polkadot/types-create": "npm:10.13.1"
+    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/types-create": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/b8848cfb97ca7611ee8f368112be1f5d6adf8e9943faa0d3b5ff438e45d28bd9bc18d1b18eb7e643e4e0bbc07f69ea70ad48e4af002ba27ac3cb22df3a4d5472
+  checksum: 10/b2e04c228efb95a39c74d063bd439db7887ef2f3f5c8dd19fdf3eeef32701e87d8c1be833bfbe6d740afa767319d6d2898f9315140749d35e616d6e75d607e28
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/types-support@npm:10.13.1"
+"@polkadot/types-support@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/types-support@npm:11.0.1"
   dependencies:
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/d802bb774ada41d5ce5d5a6b80dab199c671fba08693efde4e3e8e3eb2010eef2c073e75a9e5e9e5775826d0659cd29c824331cec2568e7d4b504240ce9e68bf
+  checksum: 10/71f14b40148aa8de0e07306a41fe84be544d33cf17c7838ac49fcfc12c9d4cfb4a4b2d35125414ff3287c89807a9a7008e315ef0bba1f6a4456dcafa79a6c8b6
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:10.13.1":
-  version: 10.13.1
-  resolution: "@polkadot/types@npm:10.13.1"
+"@polkadot/types@npm:11.0.1":
+  version: 11.0.1
+  resolution: "@polkadot/types@npm:11.0.1"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types-augment": "npm:10.13.1"
-    "@polkadot/types-codec": "npm:10.13.1"
-    "@polkadot/types-create": "npm:10.13.1"
+    "@polkadot/types-augment": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/types-create": "npm:11.0.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/8ae2df5b08dd0b977d39a62a7a70788c7925d5fd9212ab2f1e1011a79971e689cfc9b88b20e671a8c8f834fa38038ab5cb97b8f3a7f6272822796c7bfea74d3f
+  checksum: 10/e779b6652b08616c0180c4c9dba6751f5fda5bdb86174180f0a9fe4a9e16703cc50912db5d9024b031555c39c40960c0cea4b98f5a22373d383aa2a58d34d9ac
   languageName: node
   linkType: hard
 
@@ -1461,8 +1461,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": "npm:^10.13.1"
-    "@polkadot/api-contract": "npm:^10.13.1"
+    "@polkadot/api": "npm:^11.0.1"
+    "@polkadot/api-contract": "npm:^11.0.1"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@substrate/calc": "npm:^0.3.1"
     "@substrate/dev": "npm:^0.7.1"
@@ -1502,22 +1502,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect-known-chains@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "@substrate/connect-known-chains@npm:1.1.2"
-  checksum: 10/9aff94053ee3c5e9c38529258774337716d35ca1b386cc10f1d4ecc1fdc56574d7a233bfb5fe1a9cee9aa6551d6f18c777342607c83dff7d220e0576e63b4098
+"@substrate/connect-known-chains@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@substrate/connect-known-chains@npm:1.1.4"
+  checksum: 10/17fdce09bf2ba042371910a5e1c701d7db7e40b7c021eb67f36ed2d28175b8846e01eb2438be03827e2cd2654d35be5a1a248c36e9588ccdbe4545da0bee5047
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.8.8":
-  version: 0.8.8
-  resolution: "@substrate/connect@npm:0.8.8"
+"@substrate/connect@npm:0.8.10":
+  version: 0.8.10
+  resolution: "@substrate/connect@npm:0.8.10"
   dependencies:
     "@substrate/connect-extension-protocol": "npm:^2.0.0"
-    "@substrate/connect-known-chains": "npm:^1.1.1"
-    "@substrate/light-client-extension-helpers": "npm:^0.0.4"
+    "@substrate/connect-known-chains": "npm:^1.1.4"
+    "@substrate/light-client-extension-helpers": "npm:^0.0.6"
     smoldot: "npm:2.0.22"
-  checksum: 10/056908d641bdbf4a7d8f429e915a7a0519cd9417b6fa46db8591af49f3ac04a631b4a084a30d05a7ae9cfbb70905dc7698452eb252f4e1101c86e82eb4d8ca04
+  checksum: 10/078c08d12eb12b55b2c8ee0e0c335284db07d13b48cc5329db68a6376173f1fb6b2357fb47f8ec4da7b66f4230d9bc2c3873beb66d755c475969d1cdbbec316f
   languageName: node
   linkType: hard
 
@@ -1550,20 +1550,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/light-client-extension-helpers@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "@substrate/light-client-extension-helpers@npm:0.0.4"
+"@substrate/light-client-extension-helpers@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@substrate/light-client-extension-helpers@npm:0.0.6"
   dependencies:
-    "@polkadot-api/client": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/json-rpc-provider": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/json-rpc-provider-proxy": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-    "@polkadot-api/substrate-client": "npm:0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
+    "@polkadot-api/json-rpc-provider": "npm:0.0.1"
+    "@polkadot-api/json-rpc-provider-proxy": "npm:0.0.1"
+    "@polkadot-api/observable-client": "npm:0.1.0"
+    "@polkadot-api/substrate-client": "npm:0.0.1"
     "@substrate/connect-extension-protocol": "npm:^2.0.0"
-    "@substrate/connect-known-chains": "npm:^1.1.1"
+    "@substrate/connect-known-chains": "npm:^1.1.4"
     rxjs: "npm:^7.8.1"
   peerDependencies:
     smoldot: 2.x
-  checksum: 10/f9a3c7775e41223b4e6f2020b4fe17efefebbdd2e7354ded73cac885181e101e7b22e36d47f0f40aec108b5142a9ca895433c51fccae026160a92ed9dbdae600
+  checksum: 10/1a3576019538c8150dd56ddae3ec6ed7b6272af72cd6d17cbb5de76d6ae554af2a0bf72bbb9ffd4b9c64c9eb9ee3f13caaad57e01c5173e35a0cb799fd27574a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,91 +998,91 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/api-augment@npm:11.0.1"
+"@polkadot/api-augment@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/api-augment@npm:11.0.2"
   dependencies:
-    "@polkadot/api-base": "npm:11.0.1"
-    "@polkadot/rpc-augment": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-augment": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/api-base": "npm:11.0.2"
+    "@polkadot/rpc-augment": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-augment": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/f8eb96c723e548a7cfee13b134e78ef6efead54b2a42baf62ff94a2bc7e3946456e767e8425f9377fafa220ef27e39934bdc2bf94cdc9b44801db51be670dcc4
+  checksum: 10/1d0f14149e3c9c972abf45260af44a2a23a7fa0085c0db8039bcd909c1df36c49eb31ab5257a95cf70fb76d36a26a35635a26895a5bc7e4198a1872bd1f38dae
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/api-base@npm:11.0.1"
+"@polkadot/api-base@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/api-base@npm:11.0.2"
   dependencies:
-    "@polkadot/rpc-core": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/rpc-core": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/9cfbe8d3833984a76ef2cc409b9eb2ea5f1d3292fddd03b02859f1f9d79a0c0e9086c5fb00343b83ff5a286ad89a8197f804efed9b21537f64cf0c086bb1156d
+  checksum: 10/c38cdd603ae8015487b1b90459295ac1403a88a69848948696943db7c7429ceaec95a5dc9065d2f050a7373c2f448f106903966ab345ee8f03f2f9eee035f929
   languageName: node
   linkType: hard
 
-"@polkadot/api-contract@npm:^11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/api-contract@npm:11.0.1"
+"@polkadot/api-contract@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/api-contract@npm:11.0.2"
   dependencies:
-    "@polkadot/api": "npm:11.0.1"
-    "@polkadot/api-augment": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
-    "@polkadot/types-create": "npm:11.0.1"
+    "@polkadot/api": "npm:11.0.2"
+    "@polkadot/api-augment": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
+    "@polkadot/types-create": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/bd37b72c82a6506627c6528c709a7b5d3d2422560b3ea931d9248393a1d3ed7d8dcbae20dc0e85040224df732ecdb7b7084d89e2863bf4c4f874c717525b5ff4
+  checksum: 10/88c30ce9771cddb054d3800733424f3939f43d91f4225f9d973af46e43d719144ee839ed96177a64d776897682f5327ec94b8062100d466218482ef5ea50f3c2
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/api-derive@npm:11.0.1"
+"@polkadot/api-derive@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/api-derive@npm:11.0.2"
   dependencies:
-    "@polkadot/api": "npm:11.0.1"
-    "@polkadot/api-augment": "npm:11.0.1"
-    "@polkadot/api-base": "npm:11.0.1"
-    "@polkadot/rpc-core": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/api": "npm:11.0.2"
+    "@polkadot/api-augment": "npm:11.0.2"
+    "@polkadot/api-base": "npm:11.0.2"
+    "@polkadot/rpc-core": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/471a141ec9d7afc250a4cbeeeb2613a20c5b521fcee64d373bf4857d3faace3e4d8fc517991bc1d089f68e06521a23b566cb8afea75ffc27d4c7286e639ef2b5
+  checksum: 10/033e42b0961940249c7dbe13a84c1f1f01804027fd591b56fdead6284600f28d9f863b0f76d9afbfa3b805f46e1ccdb2f7fe873451037876405c03a870e35554
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:11.0.1, @polkadot/api@npm:^11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/api@npm:11.0.1"
+"@polkadot/api@npm:11.0.2, @polkadot/api@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/api@npm:11.0.2"
   dependencies:
-    "@polkadot/api-augment": "npm:11.0.1"
-    "@polkadot/api-base": "npm:11.0.1"
-    "@polkadot/api-derive": "npm:11.0.1"
+    "@polkadot/api-augment": "npm:11.0.2"
+    "@polkadot/api-base": "npm:11.0.2"
+    "@polkadot/api-derive": "npm:11.0.2"
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/rpc-augment": "npm:11.0.1"
-    "@polkadot/rpc-core": "npm:11.0.1"
-    "@polkadot/rpc-provider": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-augment": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
-    "@polkadot/types-create": "npm:11.0.1"
-    "@polkadot/types-known": "npm:11.0.1"
+    "@polkadot/rpc-augment": "npm:11.0.2"
+    "@polkadot/rpc-core": "npm:11.0.2"
+    "@polkadot/rpc-provider": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-augment": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
+    "@polkadot/types-create": "npm:11.0.2"
+    "@polkadot/types-known": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     eventemitter3: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/24b9eba509dd33ba1ddcf87832643e653e83c68473af75b9fbabe5ca3c6f8bc11e04eddbf2125a20fa6be6a606bbe24452c0514b9181184a3671fb3180791fc9
+  checksum: 10/9262c52de7f6f941a6c359821a94edfc087759ae14e630e05f1ee6b228733a31e97174b429b2ac9729dcfe0b76fd9be00479214b8c09f988c2ff7ad6414d046c
   languageName: node
   linkType: hard
 
@@ -1111,40 +1111,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/rpc-augment@npm:11.0.1"
+"@polkadot/rpc-augment@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/rpc-augment@npm:11.0.2"
   dependencies:
-    "@polkadot/rpc-core": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/rpc-core": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/fe68e6e0a8e5f75e23a4a8753d485afdc9bd66368e913d17d2109b476c68cb39e01d768ed17f37a4169307aafa4998e23efdd04058196aa0664e5b41c272920d
+  checksum: 10/568a87e85a3d0ff7711ffef0149f00b9c6a4eb00eaa89802aa9dc77b322eb24fcb09f1cb0d2e6c3a04d650eeb39932425938f659bb24ee32e154fcb9cd628641
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/rpc-core@npm:11.0.1"
+"@polkadot/rpc-core@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/rpc-core@npm:11.0.2"
   dependencies:
-    "@polkadot/rpc-augment": "npm:11.0.1"
-    "@polkadot/rpc-provider": "npm:11.0.1"
-    "@polkadot/types": "npm:11.0.1"
+    "@polkadot/rpc-augment": "npm:11.0.2"
+    "@polkadot/rpc-provider": "npm:11.0.2"
+    "@polkadot/types": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/8204ace945f260f4ae95bba45784b16634296a1d4f4473137cf62e085b8d969f59679a7bc380e5f2945f456eef9301c0bda0a0172a2615f6bcaf076ca82f9c43
+  checksum: 10/52b9793e32eab684bb2bd7617e032da5360b22f58d7b643162b8eebe0c60f86cd3c682a2881996fbcf5ae314e5a6c77cab00c69b950be576fee5bc03f76cc745
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/rpc-provider@npm:11.0.1"
+"@polkadot/rpc-provider@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/rpc-provider@npm:11.0.2"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-support": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-support": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@polkadot/x-fetch": "npm:^12.6.2"
@@ -1158,81 +1158,81 @@ __metadata:
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: 10/9f0234039c40bb7ce7f072a044b14d0b9d87e6da62a49d11de12accfa7ef5a0021477c8553409580bc9261b8f7ad7c34ec8cfabcf5bca77f7ccf022e7a19a8d2
+  checksum: 10/f66d660e2ad990a7f1e5226c7d81f8dcab601ac2b82c9b204594fbddf8a061950d68165fe05c88c962f1a8ac71dbd17d40cfce0943ff4aa494a5825afae30e76
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/types-augment@npm:11.0.1"
+"@polkadot/types-augment@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/types-augment@npm:11.0.2"
   dependencies:
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/5b2f75bcb73b290b10889b4e2c8bca1fbe31a261d98b1b9a410db997167c1dcb720d8ab4d0128ffc9b685c80934c3495ef2d7de7e3135096d68448b53a500859
+  checksum: 10/9759a533f8b702e58b0c1cd0a8fdcea2c8ab72a1afe1bf7fe71334b09507ba1e96b66a3b1bab903e3a0c1156d34e3a94aebba321aaf72b89ea937d428984f14c
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/types-codec@npm:11.0.1"
+"@polkadot/types-codec@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/types-codec@npm:11.0.2"
   dependencies:
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/x-bigint": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/d3f25f63342ab6de85979d4d715f2088a6c3a9b5190a5b3d00a2d76e5d508632575a0fbbd724d556efed464fd90e8ff63e52090b4b784e7f7d983837a14a4f52
+  checksum: 10/82c3ed0678e23a1faa4721547c52d59fd3318b5390a1c338e0b9c9ce46f578b7afd88c01efaa96bddac8531d120bc24338bda18d68188124694f94c2aea4763b
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/types-create@npm:11.0.1"
+"@polkadot/types-create@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/types-create@npm:11.0.2"
   dependencies:
-    "@polkadot/types-codec": "npm:11.0.1"
+    "@polkadot/types-codec": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/adf2a813d34514788d35fcdb6d2652ac9e51231c245e304dc20cff4e06ab8e165eb36ac0334ab87ef3d0cbf54dd1e2843e38eaf81fabb76ea51a580072c94899
+  checksum: 10/cc3560ba4174e8a9e14032c9ae219d943f9b0b819500eaebd60bef421126596268281aefad594e452b5407d87f13b3613ade94707bb4774010f7021ceb125aef
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/types-known@npm:11.0.1"
+"@polkadot/types-known@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/types-known@npm:11.0.2"
   dependencies:
     "@polkadot/networks": "npm:^12.6.2"
-    "@polkadot/types": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
-    "@polkadot/types-create": "npm:11.0.1"
+    "@polkadot/types": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
+    "@polkadot/types-create": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/b2e04c228efb95a39c74d063bd439db7887ef2f3f5c8dd19fdf3eeef32701e87d8c1be833bfbe6d740afa767319d6d2898f9315140749d35e616d6e75d607e28
+  checksum: 10/f5da9cb2adccd3f144febbf217b1391f4569b9bf8b161bd243e7710a8253daddd4f7f32ce3f89b4974791427d7402c5a20972d43ea5e4d607d22da6fbce37af5
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/types-support@npm:11.0.1"
+"@polkadot/types-support@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/types-support@npm:11.0.2"
   dependencies:
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
-  checksum: 10/71f14b40148aa8de0e07306a41fe84be544d33cf17c7838ac49fcfc12c9d4cfb4a4b2d35125414ff3287c89807a9a7008e315ef0bba1f6a4456dcafa79a6c8b6
+  checksum: 10/2f427c67b2f76760cf399d58f1bdebc8b8c73e08a44b6817b0e47f3342eca39fb4a95707ece59f4054cb446b3a1a4db9fb9291be0d47249c9acd50f2e050898e
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:11.0.1":
-  version: 11.0.1
-  resolution: "@polkadot/types@npm:11.0.1"
+"@polkadot/types@npm:11.0.2":
+  version: 11.0.2
+  resolution: "@polkadot/types@npm:11.0.2"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types-augment": "npm:11.0.1"
-    "@polkadot/types-codec": "npm:11.0.1"
-    "@polkadot/types-create": "npm:11.0.1"
+    "@polkadot/types-augment": "npm:11.0.2"
+    "@polkadot/types-codec": "npm:11.0.2"
+    "@polkadot/types-create": "npm:11.0.2"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/e779b6652b08616c0180c4c9dba6751f5fda5bdb86174180f0a9fe4a9e16703cc50912db5d9024b031555c39c40960c0cea4b98f5a22373d383aa2a58d34d9ac
+  checksum: 10/aafdca41a3009fd3bb4fb3263f01759be013f33fb670252d619891fd56ad2696da957e3920f66c4cdfa892b63eb02e1676f74527d22e7709d39a44d308c9458e
   languageName: node
   linkType: hard
 
@@ -1461,8 +1461,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": "npm:^11.0.1"
-    "@polkadot/api-contract": "npm:^11.0.1"
+    "@polkadot/api": "npm:^11.0.2"
+    "@polkadot/api-contract": "npm:^11.0.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@substrate/calc": "npm:^0.3.1"
     "@substrate/dev": "npm:^0.7.1"


### PR DESCRIPTION
### Description
Updated the following polkadot-js dependencies : 
- `@polkadot/api`
- `@polkadot/api-contract`

to latest version [v11.0.2](https://github.com/polkadot-js/api/releases/tag/v11.0.2)