### PR TITLE
fix: added `staking.claimed()` in replacement of `staking.ledger().legacyClaimedRewards`

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.spec.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.spec.ts
@@ -30,7 +30,7 @@ import {
 	erasValidatorPrefsAt,
 	erasValidatorRewardAt,
 	ledgerAt,
-	palletVersionAt
+	palletVersionAt,
 } from '../test-helpers/mock/accounts';
 import { AccountsStakingPayoutsService } from './AccountsStakingPayoutsService';
 

--- a/src/services/accounts/AccountsStakingPayoutsService.spec.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.spec.ts
@@ -30,6 +30,7 @@ import {
 	erasValidatorPrefsAt,
 	erasValidatorRewardAt,
 	ledgerAt,
+	palletVersionAt
 } from '../test-helpers/mock/accounts';
 import { AccountsStakingPayoutsService } from './AccountsStakingPayoutsService';
 
@@ -59,6 +60,7 @@ const mockHistoricApi = {
 			erasStakersClipped: {
 				entries: erasStakersClippedAt,
 			},
+			palletVersion: palletVersionAt,
 		},
 	},
 } as unknown as ApiDecoration<'promise'>;

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -524,13 +524,17 @@ export class AccountsStakingPayoutsService extends AbstractService {
 				return {
 					commission,
 				};
-			} else if (stakingVersion < 14) {
-				validatorLedger = validatorLedgerOption.unwrap();
 			} else {
 				validatorLedger = validatorLedgerOption.unwrap();
-				const claimed = await historicApi.query.staking.claimedRewards(era, validatorControllerOption.unwrap());
-				if (claimed.length > 0) {
-					validatorLedger.legacyClaimedRewards.push(era as unknown as u32);
+				if (
+					14 >= stakingVersion &&
+					(await historicApi.query.staking.claimedRewards(era, validatorControllerOption.unwrap())).length ===
+						(await historicApi.query.staking.erasStakersOverview(era, validatorControllerOption.unwrap()))
+							.unwrap()
+							.pageCount.toNumber()
+				) {
+					const eraVal: u32 = historicApi.registry.createType('u32', era);
+					validatorLedger.legacyClaimedRewards.push(eraVal);
 				}
 			}
 

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -341,13 +341,7 @@ export class AccountsStakingPayoutsService extends AbstractService {
 			}
 
 			const singleEraCommissions = nominatedExposures.map(({ validatorId }) =>
-				this.fetchCommissionAndLedger(
-					historicApi,
-					validatorId,
-					currEra,
-					validatorLedgerCache,
-					isKusama,
-				),
+				this.fetchCommissionAndLedger(historicApi, validatorId, currEra, validatorLedgerCache, isKusama),
 			);
 
 			return Promise.all(singleEraCommissions);

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -532,15 +532,21 @@ export class AccountsStakingPayoutsService extends AbstractService {
 			} else if (stakingVersion < 14) {
 				validatorLedger = validatorLedgerOption.unwrap();
 			} else {
-				const validatorLedgerOpts = validatorLedgerOption.unwrap();
 				const claimed = await historicApi.query.staking.claimedRewards(era, validatorControllerOption.unwrap());
-				validatorLedger = {
-					stash: validatorLedgerOpts.stash,
-					total: validatorLedgerOpts.total,
-					active: validatorLedgerOpts.active,
-					unlocking: validatorLedgerOpts.unlocking,
-					legacyClaimedRewards: claimed,
-				} as PalletStakingStakingLedger;
+				if (claimed.length > 0) {
+					const validatorLedgerOpts = validatorLedgerOption.unwrap();
+					validatorLedger = {
+						stash: validatorLedgerOpts.stash,
+						total: validatorLedgerOpts.total,
+						active: validatorLedgerOpts.active,
+						unlocking: validatorLedgerOpts.unlocking,
+						legacyClaimedRewards: claimed,
+					} as PalletStakingStakingLedger;
+				} else {
+					return {
+						commission,
+					};
+				}
 			}
 
 			validatorLedgerCache[validatorId] = validatorLedger;

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -424,7 +424,7 @@ export class AccountsStakingPayoutsService extends AbstractService {
 			let indexOfEra: number;
 			if (validatorLedger.legacyClaimedRewards && stakingVersion < 14) {
 				indexOfEra = validatorLedger.legacyClaimedRewards.indexOf(eraIndex);
-			} else if (validatorLedger.legacyClaimedRewards && stakingVersion >= 14) {
+			} else if (stakingVersion >= 14) {
 				indexOfEra = 0;
 			} else if ((validatorLedger as unknown as StakingLedger).claimedRewards) {
 				indexOfEra = (validatorLedger as unknown as StakingLedger).claimedRewards.indexOf(eraIndex);

--- a/src/services/test-helpers/mock/accounts/stakingPayouts.ts
+++ b/src/services/test-helpers/mock/accounts/stakingPayouts.ts
@@ -83,6 +83,13 @@ export const erasRewardPointsAt = (_: EraIndex) =>
 		),
 	);
 
+export const palletVersionAt = () => Promise.resolve().then(() =>
+	api.registry.createType(
+		'u16',
+		'13',
+	),
+);
+
 export const deriveEraExposureParam = {
 	era: api.registry.createType('EraIndex', ERA),
 	nominators: {

--- a/src/services/test-helpers/mock/accounts/stakingPayouts.ts
+++ b/src/services/test-helpers/mock/accounts/stakingPayouts.ts
@@ -83,12 +83,7 @@ export const erasRewardPointsAt = (_: EraIndex) =>
 		),
 	);
 
-export const palletVersionAt = () => Promise.resolve().then(() =>
-	api.registry.createType(
-		'u16',
-		'13',
-	),
-);
+export const palletVersionAt = () => Promise.resolve().then(() => api.registry.createType('u16', '13'));
 
 export const deriveEraExposureParam = {
 	era: api.registry.createType('EraIndex', ERA),


### PR DESCRIPTION
### Description

After the staking pallet was upgraded to v14 in Polkadot, `legacyClaimedRewards` is no longer used, so any for any eras after 1418, the era is no longer stored there but in `staking.claimed(Era, Account)`, so querying the former would make it look like the rewards weren't claimed when in turn they were, as you can see [here](https://polkadot-public-sidecar.parity-chains.parity.io/accounts/1VrKDfXunzstY5uxPpjArUbZekirGXcpMDYvCBJmjV1KdEm/staking-payouts?era=1419&unclaimedOnly=false): 
![imagen](https://github.com/paritytech/substrate-api-sidecar/assets/74352651/8aa63992-f0a2-4d63-918d-9f26b6db8fac)

With this PR it checks the staking pallet version, and if it's less than 14, it sticks to the old logic, otherwise `staking.claimed` takes the place of `legacyClaimedRewards`, as seen [here](https://github.com/paritytech/substrate-api-sidecar/blob/b62cb787b70b25b0a0d0dabeb53eb96dc602b5f9/src/services/accounts/AccountsStakingPayoutsService.ts#L532C1-L543C37).

With this fix, it returns the correct status:
![imagen](https://github.com/paritytech/substrate-api-sidecar/assets/74352651/ebfd1859-a4ad-4214-824b-b758049b465d)

**NOTE** `staking.claimed()` returns the page of the claimed reward, while `legacyClaimedRewards` instead contains the list of eras claimed. So we assume that if `staking.claimed()` returns anything other than an empty array, the era was claimed.

Edit: added image of response after fix
Edit 2: wrong era