### PR TITLE
fix: add asset conversion pallet to Polkadot Asset Hub

### DIFF
--- a/src/chains-config/assetHubPolkadotControllers.ts
+++ b/src/chains-config/assetHubPolkadotControllers.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -33,6 +33,7 @@ export const assetHubPolkadotControllers: ControllerConfig = {
 		'NodeTransactionPool',
 		'NodeVersion',
 		'PalletsAssets',
+		'PalletsAssetConversion',
 		'PalletsDispatchables',
 		'PalletsConsts',
 		'PalletsEvents',


### PR DESCRIPTION
### Description

Now that the asset-conversion pallet is available on PAH, this is just adding the endpoints for that chain.

Closes #1322 