### PR TITLE
fix: duplicate payouts in staking-payouts endpoint

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.spec.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.spec.ts
@@ -182,7 +182,7 @@ describe('AccountsStakingPayoutsService', () => {
 		it('Should work when the address is a nominator', () => {
 			const nom = '15j4dg5GzsL1bw2U2AWgeyAk6QTxq43V7ZPbXdAmbVLjvDCK';
 			const val = '16hzCDgyqnm1tskDccVWqxDVXYDLgdrrpC4Guxu3gPgLe5ib';
-			const res = stakingPayoutsService['extractExposure'](nom, val, deriveEraExposureParam);
+			const res = stakingPayoutsService['extractExposure'](nom, val, deriveEraExposureParam, 0);
 			expect(sanitizeNumbers(res)).toStrictEqual({
 				nominatorExposure: '21133134966048676',
 				totalExposure: '21133134966048676',
@@ -190,7 +190,7 @@ describe('AccountsStakingPayoutsService', () => {
 		});
 		it('Should work when the address is a validator', () => {
 			const val = '16hzCDgyqnm1tskDccVWqxDVXYDLgdrrpC4Guxu3gPgLe5ib';
-			const res = stakingPayoutsService['extractExposure'](val, val, deriveEraExposureParam);
+			const res = stakingPayoutsService['extractExposure'](val, val, deriveEraExposureParam, 0);
 			expect(sanitizeNumbers(res)).toStrictEqual({
 				nominatorExposure: '0',
 				totalExposure: '21133134966048676',


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1438

This PR fixes duplicate payouts found in the `accounts/<address>/staking-payouts` endpoint when querying some specific cases of nominators.

### Root cause
In certain rare cases (eras `6xx`), a single nominator may have multiple nominations for the same validator and at the same era, each with a different stake amount.

### How Sidecar handles this case
In Sidecar we were not expecting to have this case. We were expecting one stake of a nominator per validator, not multiple. Consequently :
- When we print payouts we iterate through a list that has now 2 entries of the same validator instead of one. That is why we get twice the same validator in the response.
- And then, for these two entries, the payout calculations are based on the first stake that we find and not the second (because we were not expecting to have a second actually). That is why we see the same result. So that is not correct.

### Suggested Fix
The suggested solution includes adding an index with which we can check the right stake amount that we need to retrieve every time and then return its corresponding payout.

### Response (old code)
For some particular cases of nominators (whose addresses we refrain to disclose)
`[http://127.0.0.1:8080/accounts/<nominatorAddress>/staking-payouts?at=1879836&depth=1&era=661&unclaimedOnly=false`

We would have duplicate payouts in the response as shown below:
```
{
  "at": {
    "height": "1879836",
    "hash": "0xcb5d9775f65ad9dd2aec3270a1943f988382de26ca10652e0ed8435624f69d6e"
  },
  "erasPayouts": [
    {
      "era": "664",
      "totalEraRewardPoints": "68960",
      "totalEraPayout": "448038005779728",
      "payouts": [
        {
          "validatorId": "<validatorAddress>",
          "nominatorStakingPayout": "9070...4309",
          ...
          "nominatorExposure": "7197...17645"
        },
        {
          "validatorId": "<validatorAddress>",
          "nominatorStakingPayout": "9070...4309",
          ...
          "nominatorExposure": "7197...17645"
        },

      ]
    }
  ]
}
```

### Response (new code)
For the same cases of nominators
`[http://127.0.0.1:8080/accounts/<nominatorAddress>/staking-payouts?at=1879836&depth=1&era=661&unclaimedOnly=false`

We now have multiple payouts in the response as shown below:
```
{
  "at": {
    "height": "1879836",
    "hash": "0xcb5d9775f65ad9dd2aec3270a1943f988382de26ca10652e0ed8435624f69d6e"
  },
  "erasPayouts": [
    {
      "era": "664",
      "totalEraRewardPoints": "68960",
      "totalEraPayout": "448038005779728",
      "payouts": [
        {
          "validatorId": "<validatorAddress>",
          "nominatorStakingPayout": "9070...4309",
          ...
          "nominatorExposure": "7197...17645"
        },
        {
          "validatorId": "<validatorAddress>",
          "nominatorStakingPayout": "15...07",
          ...
          "nominatorExposure": "16...551"
        },

      ]
    }
  ]
}
```
but with different `nominatorExposure` and `nominatorStakingPayout` in each case. Each payout was calculated based on the stake of each nomination (of that nominator to that validator and at that era).


### Testing
- [x] Tested all the cases provided by the internal team in Parity and for those specific eras and it works as expected
- [x] Tested payouts with no multiple nominations to make sure they are not affected 

### Credits & Thanks
- to @ruiparitydata  for bringing this to our attention. This lead to this Sidecar fix but also a possible fix in the Staking pallet (related [issue](https://github.com/paritytech/polkadot-sdk/issues/4419))
- to @Ank4n  for advising on the most accurate solution among the two options we considered for this issue [here](https://github.com/paritytech/substrate-api-sidecar/issues/1438)
- to my teammate @bee344 for helping debugging, figuring out the root cause of this issue, discussing on the possible solutions and our next steps. 