### PR TITLE
fix: add nominations in staking-info endpoint

### DIFF
--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/10819301.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/10819301.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "2",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11000000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "2",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11100000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11100000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "3",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11500000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11500000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "3",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11800000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/11800000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "3",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/1500000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/1500000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "3",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/3000000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/3000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "2",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/5000000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/5000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "2",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/8000000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/8000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "3",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/9500000.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/9500000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "2",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/kusama/accounts/staking-info/9894877.json
+++ b/e2e-tests/historical/endpoints/kusama/accounts/staking-info/9894877.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "2",
+    "nominations": null,
     "staking": {
         "stash": "HP8qJ8P4u4W2QgsJ8jzVuSsjfFTT6orQomFD6eTRSGEbiTK",
         "total": "497576923500",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/1000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/1000000.json
@@ -8,6 +8,7 @@
         "staked": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "146275200613711",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/3000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/3000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "155514320103496",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/350000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/350000.json
@@ -8,6 +8,7 @@
         "staked": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "138910737119627",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/6000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/6000000.json
@@ -8,6 +8,7 @@
         "staked": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "155902410746517",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/7000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/7000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "161445433495009",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/7472552.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/7472552.json
@@ -8,6 +8,7 @@
         "account": "12imiRFgMGpPPVRiXLhQixuk1jMeTrQbzSJcZ4Bj7a3idmWT"
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "13HtFCrxyz55KgkPWcnhHPwE8f8GmZrfXR3uC6jNrihGzmqz",
         "total": "200000000000",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/8000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/8000000.json
@@ -8,6 +8,7 @@
         "account": "12imiRFgMGpPPVRiXLhQixuk1jMeTrQbzSJcZ4Bj7a3idmWT"
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "13HtFCrxyz55KgkPWcnhHPwE8f8GmZrfXR3uC6jNrihGzmqz",
         "total": "200000000000",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/8320000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/8320000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "10000000495009",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/8500000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/8500000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "10000000495009",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/9000000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/9000000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "10000000495009",

--- a/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/9500000.json
+++ b/e2e-tests/historical/endpoints/polkadot/accounts/staking-info/9500000.json
@@ -8,6 +8,7 @@
         "stash": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "16SpacegeUTft9v3ts27CEC3tJaxgvE4uZeCctThFH3Vb24p",
         "total": "10000000495009",

--- a/e2e-tests/historical/endpoints/westend/accounts/staking-info/6000000.json
+++ b/e2e-tests/historical/endpoints/westend/accounts/staking-info/6000000.json
@@ -8,6 +8,7 @@
         "staked": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "5Ek5JCnrRsyUGYNRaEvkufG1i1EUxEE9cytuWBBjA9oNZVsf",
         "total": "10199950300000000",

--- a/e2e-tests/historical/endpoints/westend/accounts/staking-info/8041521.json
+++ b/e2e-tests/historical/endpoints/westend/accounts/staking-info/8041521.json
@@ -8,6 +8,7 @@
         "staked": null
     },
     "numSlashingSpans": "0",
+    "nominations": null,
     "staking": {
         "stash": "5ENXqYmc5m6VLMm5i1mun832xAv2Qm9t3M4PWAFvvyCJLNoR",
         "total": "42423015315073767",

--- a/src/services/accounts/AccountsStakingInfoService.ts
+++ b/src/services/accounts/AccountsStakingInfoService.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -68,11 +68,18 @@ export class AccountsStakingInfoService extends AbstractService {
 
 		const numSlashingSpans = slashingSpansOption.isSome ? slashingSpansOption.unwrap().prior.length + 1 : 0;
 
+		let nominations = null;
+		if (historicApi.query.staking.nominators) {
+			const nominationsOption = await historicApi.query.staking.nominators(stash);
+			nominations = nominationsOption.unwrapOr(null);
+		}
+
 		return {
 			at,
 			controller,
 			rewardDestination,
 			numSlashingSpans,
+			nominations,
 			staking: stakingLedger,
 		};
 	}

--- a/src/services/test-helpers/responses/accounts/stakingInfo789629.json
+++ b/src/services/test-helpers/responses/accounts/stakingInfo789629.json
@@ -8,6 +8,7 @@
     "controller": null
   },
   "numSlashingSpans": "0",
+  "nominations": null,
   "staking": {
     "stash": "1zugcapKRuHy2C1PceJxTvXWiq6FHEDm2xa5XSU7KYP3rJE",
     "total": "100000000000",

--- a/src/types/responses/AccountStakingInfo.ts
+++ b/src/types/responses/AccountStakingInfo.ts
@@ -16,7 +16,11 @@
 
 import type { Option } from '@polkadot/types/codec';
 import type { AccountId } from '@polkadot/types/interfaces/runtime';
-import type { PalletStakingRewardDestination, PalletStakingStakingLedger } from '@polkadot/types/lookup';
+import type {
+	PalletStakingNominations,
+	PalletStakingRewardDestination,
+	PalletStakingStakingLedger,
+} from '@polkadot/types/lookup';
 
 import { IAt } from '.';
 
@@ -25,5 +29,6 @@ export interface IAccountStakingInfo {
 	controller: AccountId;
 	rewardDestination: Option<PalletStakingRewardDestination>;
 	numSlashingSpans: number;
+	nominations: PalletStakingNominations | null;
 	staking: PalletStakingStakingLedger;
 }


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1446

This PR adds the field `nominations` in the `staking-info` endpoint's response which was missing. This information is retrieved from the [api.query.staking.nominators](https://polkadot.js.org/docs/kusama/storage#nominatorsaccountid32-optionpalletstakingnominations) call.

### Response (before the fix)
When connected to the Polkadot chain, the following request

`http://127.0.0.1:8080/accounts/16GMHo9HZv8CcJy4WLoMaU9qusgzx2wxKDLbXStEBvt5274B/staking-info?at=20300500`

results in the response below:

```
{
  "at": {
    "hash": "0xfee9a90faaaa0e29f3feb53360bf8527ffdfa295267602b35ed8990bf01d5493",
    "height": "20300500"
  },
  "controller": "16eM1npMwKzpGy48NDna1jC6P71S783wjpbdeKT8RgzQx8Jd",
  "rewardDestination": {
    "account": "13FzGLWoueKvUqFePiJgvFYWhH5KckHGtVBXvAX7SBtVZbXu"
  },
  "numSlashingSpans": "0",
  "staking": {
    ...
    "claimedRewards": [
      "104",
       ...
      "187"
    ]
  }
}
```

### Response (after the fix)
```
{
  "at": {
    "hash": "0xfee9a90faaaa0e29f3feb53360bf8527ffdfa295267602b35ed8990bf01d5493",
    "height": "20300500"
  },
  "controller": "16eM1npMwKzpGy48NDna1jC6P71S783wjpbdeKT8RgzQx8Jd",
  "rewardDestination": {
    "account": "13FzGLWoueKvUqFePiJgvFYWhH5KckHGtVBXvAX7SBtVZbXu"
  },
  "numSlashingSpans": "0",
  "nominations": {
    "targets": [
      "16CdHjb4nxVwF6uwmPm6A29pc4ubnLiY7UqasMxt7cT9BcoK",
      "12YUDdiZCHE47WqR6etGD4gfdpSUhrRFvASrVhtc1RcbLva8",
      "1AvwyrRcECEWUnkRoqfcyT2oA11uBT66aS4p127Mbs4ocjq",
      "1JoBYyPoUdsuU7vZi3KgQAaQYn6WhKqUDXRDmsaJ8Zgxr4T",
      "13VS9jM2pkKNwd8LFpQNNRPBKUonU9jzGZ5fTEZiuB4nYF6Y"
    ],
    "submittedIn": "1409",
    "suppressed": false
  },
  "staking": {
    ...
    "claimedRewards": [
      "104",
      ....
      "187"
    ]
  }
}
```
The result in nominations was also cross checked with [pjs-apps](https://polkadot.js.org/apps/#/chainstate) call `staking.nominators` for the same account and block (block hash : `0xfee9a90faaaa0e29f3feb53360bf8527ffdfa295267602b35ed8990bf01d5493`)

### Todos
- [x] Docs were **not** updated since the `nominations` information was already included
- [x] Update tests