### PR TITLE
fix: dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore"
       # include a list of updated dependencies
-      prefix: "chore:"
-      include: "scope"
+      prefix: "chore(deps):"
     labels:
-      - "dependencies"
+      - "D0 - Dependencies"


### PR DESCRIPTION
### Description
Fix in dependabot yaml file that:
- Adds the prefix `chore(deps):` in the PR title since all dependabot PRs are deps updates
- Removed the `scope` since this often opens a PR with a title prefix `chore:(deps):` instead of `chore(deps):`
- Adds the `D0 - Dependencies` label in the PR 

### Issues
This solves the issues of:
- having to manually change the prefix of the PR's title whenever a PR is not identified as a dependency from dependabot (example found [here](https://github.com/paritytech/substrate-api-sidecar/pull/1451))
- not finding the label `dependencies` (example found [here](https://github.com/paritytech/substrate-api-sidecar/pull/1451#issuecomment-2164675846))

