### PR TITLE
fix: Improve performance of blocks service by dependency injection

### DIFF
--- a/src/services/accounts/AccountsAssetsService.ts
+++ b/src/services/accounts/AccountsAssetsService.ts
@@ -63,12 +63,9 @@ export class AccountsAssetsService extends AbstractService {
 	 */
 	async fetchAssetBalances(hash: BlockHash, address: string, assets: number[]): Promise<IAccountAssetsBalances> {
 		const { api } = this;
-		const historicApi = await api.at(hash);
-
+		const [historicApi, { number }] = await Promise.all([api.at(hash), api.rpc.chain.getHeader(hash)]);
 		// Check if this runtime has the assets pallet
 		this.checkAssetsError(historicApi);
-
-		const { number } = await api.rpc.chain.getHeader(hash);
 
 		let response;
 		if (assets.length === 0) {

--- a/src/services/accounts/AccountsPoolAssetsService.ts
+++ b/src/services/accounts/AccountsPoolAssetsService.ts
@@ -67,12 +67,10 @@ export class AccountsPoolAssetsService extends AbstractService {
 		assets: number[],
 	): Promise<IAccountPoolAssetsBalances> {
 		const { api } = this;
-		const historicApi = await api.at(hash);
+		const [historicApi, { number }] = await Promise.all([api.at(hash), api.rpc.chain.getHeader(hash)]);
 
 		// Check if this runtime has the PoolAssets pallet
 		this.checkPoolAssetsError(historicApi);
-
-		const { number } = await api.rpc.chain.getHeader(hash);
 
 		let response;
 		if (assets.length === 0) {

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -296,10 +296,10 @@ export class AccountsStakingPayoutsService extends AbstractService {
 						: await this.api.rpc.chain.getBlockHash(earlyErasBlockInfo[era - 1].end);
 
 				let reward: Option<u128> = historicApi.registry.createType('Option<u128>');
-
-				const blockInfo = await this.api.rpc.chain.getBlock(nextEraStartBlockHash);
-
-				const allRecords = await historicApi.query.system.events();
+				const [blockInfo, allRecords] = await Promise.all([
+					this.api.rpc.chain.getBlock(nextEraStartBlockHash),
+					historicApi.query.system.events(),
+				]);
 
 				blockInfo.block.extrinsics.forEach((index) => {
 					allRecords

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -196,7 +196,6 @@ export class BlocksService extends AbstractService {
 
 		const previousBlockHash = await this.fetchPreviousBlockHash(number);
 		const prevBlockHistoricApi = await api.at(previousBlockHash);
-		// get previous block hash historic api and inject it where needed to save calls per extrinic
 		/**
 		 * Fee calculation logic. This runs the extrinsics concurrently.
 		 */
@@ -256,7 +255,6 @@ export class BlocksService extends AbstractService {
 		historicApi?: ApiDecoration<'promise'>,
 	) {
 		const { api } = this;
-		// Inject historic api here or undefined if not available
 		if (noFees) {
 			extrinsics[idx].info = {};
 			return;
@@ -420,6 +418,7 @@ export class BlocksService extends AbstractService {
 		historicApi?: ApiDecoration<'promise'>,
 	): Promise<string> {
 		const { api } = this;
+		// Get injected historicApi for previousBlockHash or create a new one
 		const apiAt = historicApi || (await api.at(previousBlockHash));
 
 		let inclusionFee;
@@ -449,7 +448,7 @@ export class BlocksService extends AbstractService {
 		historicApi?: ApiDecoration<'promise'>,
 	): Promise<RuntimeDispatchInfo | RuntimeDispatchInfoV1> {
 		const { api } = this;
-		// mMove historic api to an injection and only if undefined get it
+		// Get injected historicApi for previousBlockHash or create a new one
 		const apiAt = historicApi || (await api.at(previousBlockHash));
 		if (apiAt.call.transactionPaymentApi.queryInfo) {
 			const u8a = ext.toU8a();

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -682,7 +682,7 @@ export class BlocksService extends AbstractService {
 	 * @param registry type registry of the block the call belongs to
 	 */
 	private parseGenericCall(genericCall: GenericCall, registry: Registry): ISanitizedCall {
-		const newArgs = {};
+		const newArgs: Record<string, unknown> = {};
 
 		// Pull out the struct of arguments to this call
 		const callArgs = genericCall.get('args') as Struct;

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -40,7 +40,7 @@ export class PalletsStakingProgressService extends AbstractService {
 			api.rpc.chain.getHeader(hash),
 		]);
 
-		let eraElectionStatus;
+		let eraElectionPromise;
 		/**
 		 * Polkadot runtimes v0.8.30 and above do not support eraElectionStatus, so we check
 		 * to see if eraElectionStatus is mounted to the api, and if were running on a
@@ -48,11 +48,10 @@ export class PalletsStakingProgressService extends AbstractService {
 		 * we do nothing and let `eraElectionStatus` stay undefined.
 		 */
 		if (historicApi.query.staking.eraElectionStatus) {
-			eraElectionStatus = await historicApi.query.staking.eraElectionStatus();
+			eraElectionPromise = await historicApi.query.staking.eraElectionStatus();
 		}
-
-		const { eraLength, eraProgress, sessionLength, sessionProgress, activeEra } =
-			await this.deriveSessionAndEraProgress(historicApi);
+		const [eraElectionStatus, { eraLength, eraProgress, sessionLength, sessionProgress, activeEra }] =
+			await Promise.all([eraElectionPromise, this.deriveSessionAndEraProgress(historicApi)]);
 
 		const unappliedSlashesAtActiveEra = await historicApi.query.staking.unappliedSlashes(activeEra);
 


### PR DESCRIPTION
It slightly improves the performance of the blocks controller by injecting the historic api to calculate the fees removing two extra promises per extrinsic.

It improves the single block query by ~15% (tested on large blocks in different chains) and also improves the response time on range queries by ~10%. On large ranges > 200 blocks, the improvement reduces as I believe it becomes more of a memory issue.

We should probably have a discussion on what to do with the range query, since if extrinsics/block will increase, that specific query will become slower, even if performance is further improved.
