### PR TITLE
fix: Moves the LRUcache to Controller level

### DIFF
--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -50,6 +50,7 @@ type SidecarRequestHandler =
  */
 export default abstract class AbstractController<T extends AbstractService> {
 	private _router: Router = express.Router();
+
 	constructor(
 		protected api: ApiPromise,
 		private _path: string,

--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -207,12 +207,12 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
 		const cacheKey =
 			hash.toString() +
-			Number(eventDocs) +
-			Number(extrinsicDocs) +
+			Number(options.eventDocs) +
+			Number(options.extrinsicDocs) +
 			Number(options.checkFinalized) +
-			Number(noFees) +
+			Number(options.noFees) +
 			Number(options.checkDecodedXcm) +
-			Number(paraId);
+			Number(options.paraId);
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -284,12 +284,12 @@ export default class BlocksController extends AbstractController<BlocksService> 
 
 		const cacheKey =
 			hash.toString() +
-			Number(eventDocs) +
-			Number(extrinsicDocs) +
+			Number(options.eventDocs) +
+			Number(options.extrinsicDocs) +
 			Number(options.checkFinalized) +
-			Number(noFees) +
+			Number(options.noFees) +
 			Number(options.checkDecodedXcm) +
-			Number(paraId);
+			Number(options.paraId);
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 

--- a/src/controllers/blocks/BlocksExtrinsicsController.ts
+++ b/src/controllers/blocks/BlocksExtrinsicsController.ts
@@ -68,10 +68,10 @@ export default class BlocksExtrinsicsController extends AbstractController<Block
 
 		const cacheKey =
 			hash.toString() +
-			Number(eventDocs) +
-			Number(extrinsicDocs) +
+			Number(options.eventDocs) +
+			Number(options.extrinsicDocs) +
 			Number(options.checkFinalized) +
-			Number(noFees) +
+			Number(options.noFees) +
 			Number(options.checkDecodedXcm);
 
 		const isBlockCached = this.blockStore.get(cacheKey);

--- a/src/controllers/blocks/BlocksExtrinsicsController.ts
+++ b/src/controllers/blocks/BlocksExtrinsicsController.ts
@@ -16,6 +16,8 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express';
+import { LRUCache } from 'lru-cache';
+import { IBlock } from 'src/types/responses';
 
 import { BlocksService } from '../../services';
 import type { ControllerOptions } from '../../types/chains-config';
@@ -23,13 +25,15 @@ import type { INumberParam } from '../../types/requests';
 import AbstractController from '../AbstractController';
 
 export default class BlocksExtrinsicsController extends AbstractController<BlocksService> {
+	private blockStore: LRUCache<string, IBlock>;
 	constructor(api: ApiPromise, options: ControllerOptions) {
 		super(
 			api,
 			'/blocks/:blockId/extrinsics',
-			new BlocksService(api, options.minCalcFeeRuntime, options.blockStore, options.hasQueryFeeApi),
+			new BlocksService(api, options.minCalcFeeRuntime, options.hasQueryFeeApi),
 		);
 		this.initRoutes();
+		this.blockStore = options.blockStore;
 	}
 
 	protected initRoutes(): void {
@@ -62,10 +66,23 @@ export default class BlocksExtrinsicsController extends AbstractController<Block
 			paraId: undefined,
 		};
 
+		const cacheKey =
+			hash.toString() +
+			Number(eventDocs) +
+			Number(extrinsicDocs) +
+			Number(options.checkFinalized) +
+			Number(noFees) +
+			Number(options.checkDecodedXcm);
+
+		const isBlockCached = this.blockStore.get(cacheKey);
+
 		const historicApi = await this.api.at(hash);
 
-		const block = await this.service.fetchBlock(hash, historicApi, options);
+		const block = isBlockCached ? isBlockCached : await this.service.fetchBlock(hash, historicApi, options);
 
+		if (!isBlockCached) {
+			this.blockStore.set(cacheKey, block);
+		}
 		/**
 		 * Verify our param `extrinsicIndex` is an integer represented as a string
 		 */

--- a/src/controllers/blocks/BlocksRawExtrinsicsController.ts
+++ b/src/controllers/blocks/BlocksRawExtrinsicsController.ts
@@ -27,7 +27,7 @@ export default class BlocksRawExtrinsicsController extends AbstractController<Bl
 		super(
 			api,
 			'/blocks/:blockId/extrinsics-raw',
-			new BlocksService(api, options.minCalcFeeRuntime, options.blockStore, options.hasQueryFeeApi),
+			new BlocksService(api, options.minCalcFeeRuntime, options.hasQueryFeeApi),
 		);
 		this.initRoutes();
 	}

--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -21,7 +21,6 @@ import type { GenericExtrinsic } from '@polkadot/types';
 import type { GenericCall } from '@polkadot/types/generic';
 import type { BlockHash, Hash, SignedBlock } from '@polkadot/types/interfaces';
 import { BadRequest } from 'http-errors';
-import { LRUCache } from 'lru-cache';
 
 import { QueryFeeDetailsCache } from '../../chains-config/cache';
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
@@ -33,10 +32,7 @@ import {
 	polkadotRegistry,
 	polkadotRegistryV1000001,
 } from '../../test-helpers/registries';
-import { IBlock } from '../../types/responses/';
 import {
-	blockHash20000,
-	blockHash100000,
 	blockHash789629,
 	blockHash3356195,
 	blockHash6202603,
@@ -129,19 +125,12 @@ const mockApi = {
  */
 type GetBlock = PromiseRpcResult<(hash?: string | BlockHash | Uint8Array | undefined) => Promise<SignedBlock>>;
 
-// LRU cache used to cache blocks
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-const cache = new LRUCache({ max: 2 }) as LRUCache<string, IBlock>;
-
 // Block Service
-const blocksService = new BlocksService(mockApi, 0, cache, new QueryFeeDetailsCache(null, null));
+const blocksService = new BlocksService(mockApi, 0, new QueryFeeDetailsCache(null, null));
 
 describe('BlocksService', () => {
 	describe('fetchBlock', () => {
 		it('works when ApiPromise works (block 789629)', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -160,8 +149,6 @@ describe('BlocksService', () => {
 		});
 
 		it('throws when an extrinsic is undefined', async () => {
-			// Reset LRU cache
-			cache.clear();
 			// Create a block with undefined as the first extrinisic and the last extrinsic removed
 			const mockBlock789629BadExt = polkadotRegistry.createType('Block', block789629);
 
@@ -194,8 +181,6 @@ describe('BlocksService', () => {
 		});
 
 		it('Returns the finalized tag as undefined when omitFinalizedTag equals true', async () => {
-			// Reset LRU cache
-			cache.clear();
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -215,9 +200,6 @@ describe('BlocksService', () => {
 	});
 
 	describe('BlocksService.parseGenericCall', () => {
-		// Reset LRU cache
-		cache.clear();
-
 		const transfer = createCall('balances', 'transfer', {
 			value: 12,
 			dest: kusamaRegistry.createType('AccountId', '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3'), // Bob
@@ -351,9 +333,6 @@ describe('BlocksService', () => {
 		const blockNumber = polkadotRegistry.createType('Compact<BlockNumber>', 789629);
 
 		it('Returns false when queried blockId is not canonical', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			const getHeader = (_hash: Hash) => Promise.resolve().then(() => mockForkedBlock789629.header);
 
 			const getBlockHash = (_zero: number) => Promise.resolve().then(() => finalizedHead);
@@ -378,12 +357,7 @@ describe('BlocksService', () => {
 		});
 
 		it('Returns true when queried blockId is canonical', async () => {
-			const blocksService = new BlocksService(
-				mockApi,
-				0,
-				new LRUCache({ max: 2 }),
-				new QueryFeeDetailsCache(null, null),
-			);
+			const blocksService = new BlocksService(mockApi, 0, new QueryFeeDetailsCache(null, null));
 			expect(await blocksService['isFinalizedBlock'](mockApi, blockNumber, finalizedHead, finalizedHead, true)).toEqual(
 				true,
 			);
@@ -404,9 +378,6 @@ describe('BlocksService', () => {
 		};
 
 		it('Returns the correct extrinisics object for block 789629', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			const block = await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
 
 			/**
@@ -419,9 +390,6 @@ describe('BlocksService', () => {
 		});
 
 		it("Throw an error when `extrinsicIndex` doesn't exist", async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			const block = await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
 
 			expect(() => {
@@ -460,57 +428,15 @@ describe('BlocksService', () => {
 			},
 		};
 		it('Returns the correct summary for the latest block', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			const blockSummary = await blocksService.fetchBlockHeader(blockHash789629);
 
 			expect(sanitizeNumbers(blockSummary)).toStrictEqual(expectedResponse);
 		});
 
 		it('Returns the correct summary for the given block number', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			const blockSummary = await blocksService.fetchBlockHeader();
 
 			expect(sanitizeNumbers(blockSummary)).toStrictEqual(expectedResponse);
-		});
-	});
-
-	describe('Block LRUcache', () => {
-		// fetchBlock options
-		const options = {
-			eventDocs: true,
-			extrinsicDocs: true,
-			checkFinalized: false,
-			queryFinalizedHead: false,
-			omitFinalizedTag: false,
-			noFees: false,
-			checkDecodedXcm: false,
-			paraId: undefined,
-		};
-
-		it('Should correctly store the most recent queried blocks', async () => {
-			// Reset LRU cache
-			cache.clear();
-
-			await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
-			await blocksService.fetchBlock(blockHash20000, mockHistoricApi, options);
-
-			expect(cache.size).toBe(2);
-		});
-
-		it('Should have a max of 2 blocks within the LRUcache, and should save the most recent and remove the oldest block', async () => {
-			// Reset LRU cache
-			cache.clear();
-
-			await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
-			await blocksService.fetchBlock(blockHash20000, mockHistoricApi, options);
-			await blocksService.fetchBlock(blockHash100000, mockHistoricApi, options);
-
-			expect(cache.get(blockHash789629.toString())).toBe(undefined);
-			expect(cache.size).toBe(2);
 		});
 	});
 
@@ -521,9 +447,6 @@ describe('BlocksService', () => {
 	});
 
 	describe('BlockService.decodedXcmMsgsArg', () => {
-		// Reset LRU cache
-		cache.clear();
-
 		const validatorsAt = (_hash: Hash) =>
 			Promise.resolve().then(() => polkadotRegistryV1000001.createType('Vec<ValidatorId>', validators18468942Hex));
 
@@ -578,7 +501,7 @@ describe('BlocksService', () => {
 		} as unknown as ApiPromise;
 
 		// Block Service
-		const blocksServiceXCM = new BlocksService(mockApiXCM, 0, cache, new QueryFeeDetailsCache(null, null));
+		const blocksServiceXCM = new BlocksService(mockApiXCM, 0, new QueryFeeDetailsCache(null, null));
 
 		it('Should give back two decoded upward XCM messages for Polkadot block 18468942, one for paraId=2000 and one for paraId=2012', async () => {
 			// fetchBlock options
@@ -599,9 +522,6 @@ describe('BlocksService', () => {
 		});
 
 		it('Should give back one decoded upward XCM message for Polkadot block 18468942 only for paraId=2000', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -620,9 +540,6 @@ describe('BlocksService', () => {
 		});
 
 		it('Should give back two decoded XCM messages, one horizontal and one downward, for Kusama Asset Hub block 3356195', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -691,15 +608,13 @@ describe('BlocksService', () => {
 			} as unknown as ApiPromise;
 
 			// Block Service
-			const blocksServiceXCM = new BlocksService(mockApiXCM, 0, cache, new QueryFeeDetailsCache(null, null));
+			const blocksServiceXCM = new BlocksService(mockApiXCM, 0, new QueryFeeDetailsCache(null, null));
 			const block = await blocksServiceXCM.fetchBlock(blockHash3356195, mockHistoricApiXCM, options);
 
 			expect(sanitizeNumbers(block)).toMatchObject(block3356195Response);
 		});
 
 		it('Should give back one of the two available horizontal messages, the one for paraId 2087 for Kusama Asset Hub block 6202603', async () => {
-			// Reset LRU cache
-			cache.clear();
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -767,16 +682,13 @@ describe('BlocksService', () => {
 			} as unknown as ApiPromise;
 
 			// Block Service
-			const blocksServiceXCM = new BlocksService(mockApiXCM, 0, cache, new QueryFeeDetailsCache(null, null));
+			const blocksServiceXCM = new BlocksService(mockApiXCM, 0, new QueryFeeDetailsCache(null, null));
 			const block = await blocksServiceXCM.fetchBlock(blockHash6202603, mockHistoricApiXCM, options);
 
 			expect(sanitizeNumbers(block)).toMatchObject(block6202603pId2087Response);
 		});
 
 		it('Should give back two decoded horizontal XCM messages (with different origin & destination paraId) that are `in transit` in Polkadot Relay block 19772575', async () => {
-			// Reset LRU cache
-			cache.clear();
-
 			// fetchBlock options
 			const options = {
 				eventDocs: true,
@@ -843,7 +755,7 @@ describe('BlocksService', () => {
 			} as unknown as ApiPromise;
 
 			// Block Service
-			const blocksServiceXCM = new BlocksService(mockApiXCM, 0, cache, new QueryFeeDetailsCache(null, null));
+			const blocksServiceXCM = new BlocksService(mockApiXCM, 0, new QueryFeeDetailsCache(null, null));
 			const block = await blocksServiceXCM.fetchBlock(blockHash19772575, mockHistoricApiXCM, options);
 
 			expect(sanitizeNumbers(block)).toMatchObject(block19772575Response);


### PR DESCRIPTION
This PR decreases the memory consumption produced by the LRU cache in the blocks Service by moving it to the Blocks controllers and use it only for the necessary endpoints, rather than on all fetchBlock calls. It also slightly improves response times on those endpoints by not checking the cache for every single block.

The PR also makes sure that the reference to promises in the arrays are removed by setting the array length to 0. 

Local tests have shown improvement in the Promise store in heap memory which now stays constant.

To test locally, I have run a benchmark script to hit the BlocksController with range queries. It allows to check how the endpoint behaves with large queries.

While the initial LRU Cache was increasing in size as a larger range was queried, with the current set up the cache is bypassed and used only where necessary. The current cache set up only stores the two latest queried blocks, therefore in a range query it would update for each block. 

Using a remote RPC endpoint, the following query http://127.0.0.1:8080/blocks?range=18707756-18707770 went from ~8s to ~4.5s, because we do not constantly read/write into cache

memory usage for the specific query before the change was increasing for each repetition by about 50-100MB while now it stabilises at around 60MB total. 

Partially suporting [issue](https://github.com/paritytech/substrate-api-sidecar/issues/1361)