### PR TITLE
fix: queryInfo call in fee-estimate endpoint

### DIFF
--- a/src/services/transaction/TransactionFeeEstimateService.ts
+++ b/src/services/transaction/TransactionFeeEstimateService.ts
@@ -39,7 +39,7 @@ export class TransactionFeeEstimateService extends AbstractService {
 				const ext = api.registry.createType('Extrinsic', transaction);
 				const u8a = ext.toU8a();
 
-				return await apiAt.call.transactionPaymentApi.queryInfo(ext, u8a.length);
+				return await apiAt.call.transactionPaymentApi.queryInfo(u8a, u8a.length);
 			} else {
 				return await api.rpc.payment.queryInfo(transaction, hash);
 			}


### PR DESCRIPTION
### Description
Rel https://github.com/paritytech/substrate-api-sidecar/issues/1504

### Test
Tested it while running SIdecar locally connected to Polkadot chain and calling the `fee-estimate` endpoint with a test transaction as shown below : 
```
curl -X 'POST' \
  'http://127.0.0.1:8080/transaction/fee-estimate' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "tx": "0x59028400d172a74cda4c865912c32ba0a80a57ae69abae410e5ccb59dee84e2f4432db4f00411581e00421c087e27123c781bf9c287aae4a3b58f649d31fb3b587094c9bfc99e65ed1e91ca2bfa7e1c2f8e95e2cbdff29fa16bd092c8b2bb39be3ca696b0d00040208af2f000503005665ef9894f68738853586822941e372b30a1e621bda3f5698effd4a5e581f31137cf0010c343237a8"
```

which returns
```
{"weight":{"refTime":"145570000","proofSize":"3593"},"class":"Normal","partialFee":"163154905"}
```