### PR TITLE
chore(release): 19.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [19.2.1](https://github.com/paritytech/substrate-api-sidecar/compare/v19.2.0..v19.2.1) (2024-10-09)
+
+### Fix
+
+- fix: queryInfo call in fee-estimate endpoint ([#1505](https://github.com/paritytech/substrate-api-sidecar/pull/1505)) ([68be48b](https://github.com/paritytech/substrate-api-sidecar/commit/68be48b715e1f53abcc91eb54ac447432715f26f))
+
+### Chore
+
+- chore(deps): update express to v5 & jest deprecations ([#1502](https://github.com/paritytech/substrate-api-sidecar/pull/1502)) ([28e039e](https://github.com/paritytech/substrate-api-sidecar/commit/28e039e8cfa54b3080e584f1598ccf8cb9a978bc))
+- chore(deps): update substrate dev package & types ([#1500](https://github.com/paritytech/substrate-api-sidecar/pull/1500)) ([cf2b58b](https://github.com/paritytech/substrate-api-sidecar/commit/cf2b58bff7855bd97c90badc2192cb3f55e1835e))
+- chore(yarn): bump yarn to 4.5.0 ([#1498](https://github.com/paritytech/substrate-api-sidecar/pull/1498)) ([6aac632](https://github.com/paritytech/substrate-api-sidecar/commit/6aac63270701ceb75b2a8cf87cd3f86a9baa1c67))
+
+### Test
+
+- test: add test for fee-estimate fix ([#1506](https://github.com/paritytech/substrate-api-sidecar/pull/1506)) ([c365490](https://github.com/paritytech/substrate-api-sidecar/commit/c3654903f258f5186e648989be1f1f79a5503c33))
+
+
+## Compatibility
+
+Tested against the following node releases:
+- Polkadot v1.15.2 (Polkadot stable2407-2)
+- Kusama v1.15.2 (Polkadot stable2407-2)
+- Westend v1.15.2 (Polkadot stable2407-2)
+
+Tested against the following runtime releases:
+- Polkadot v1003000
+- Kusama v1003000
+- Westend v1016000
+
 ## [19.2.0](https://github.com/paritytech/substrate-api-sidecar/compare/v19.1.0..v19.2.0) (2024-09-23)
 
 ### Feat

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: GPL-3.0-or-later
     url: https://github.com/paritytech/substrate-api-sidecar/blob/master/LICENSE
-  version: 19.2.0
+  version: 19.2.1
 servers:
 - url: https://polkadot-public-sidecar.parity-chains.parity.io/
   description: Polkadot Parity public sidecar

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "19.2.0",
+  "version": "19.2.1",
   "name": "@substrate/api-sidecar",
   "description": "REST service that makes it easy to interact with blockchain nodes built using Substrate's FRAME framework.",
   "homepage": "https://github.com/paritytech/substrate-api-sidecar#readme",


### PR DESCRIPTION
### Description
This is a `patch` release for Sidecar so that we can include the `fee-estimate` endpoint fix (related [PR](https://github.com/paritytech/substrate-api-sidecar/pull/1505)).