### PR TITLE
fix: how to access router in getRoutes

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -114,7 +114,7 @@ export default class App {
 	 * checked that this works as expected whenever updating Express dependencies.
 	 */
 	private getRoutes() {
-		return (this.app._router as IRegisteredRoutes).stack.reduce(
+		return (this.app.router as unknown as IRegisteredRoutes).stack.reduce(
 			(acc, middleware) => {
 				if (middleware.route) {
 					// This middleware is a route mounted directly on the app (i.e. app.get('/test', fn)


### PR DESCRIPTION
## Description
Rel https://github.com/paritytech/substrate-api-sidecar/issues/1508

Due to the upgrade in Express 5, we need to adjust how the router is accessed. 

## Test
Run Sidecar from the latest release and check  
```
http://127.0.0.1:8080
```
in your browser or with curl from your terminal