### PR TITLE
fix: filtering in assets endpoint & update guides

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,10 @@
 
 1. Make sure to be in the `master` branch, and `git pull origin master`.
 
+1. Ensure that all CI/CD jobs from the last merged commit are passing. You can verify this by checking the [commits](https://github.com/paritytech/substrate-api-sidecar/commits/master/) on the master branch, where a green check (✅) should be present. If you see a red cross (❌) then you can click on it and do the following checks:
+    - If the failed job is related to benchmarks, e.g. `continuous-integration/gitlab-bench-polkadot` or `continuous-integration/gitlab-push-benchmark`, it is not critical, and you can proceed with the next steps of the release.
+    - If the failed job is related to staging deployment, e.g. `continuous-integration/gitlab-deploy-staging`, this is critical. In this case, you should check with the CI/CD team to get the relevant logs and fix the issue before continuing with the release.
+
 1. Make sure that you've run `yarn` in this folder, and run `cargo install wasm-pack` so that that binary is available on your `$PATH`.
 
 1. Checkout a branch with the format `name-v5-0-1` (with `name` being the name of the person doing the release, e.g. `tarik-v5-0-1`). When deciding what version will be released it is important to look over 1) PRs since the last release and 2) release notes for any updated polkadot-js dependencies as they may affect type definitions.

--- a/guides/MAINTENANCE.md
+++ b/guides/MAINTENANCE.md
@@ -52,6 +52,9 @@ Review the security alerts raised by Dependabot [here](https://github.com/parity
 - Check if there is a new major version of [Express](https://github.com/expressjs/express).
 - Update the version by running the command `yarn add express@^X.X.X`, e.g. `yarn add express@^5.0.0`.
 - After upgrading, we can do the usual sanity checks (e.g. `yarn`, `yarn dedupe`, `yarn build`, `yarn lint --fix`).
+- Changes made due to the upgrade from Express v4 to v5, which should be double checked in next major Express release:
+    - Using `this.app.set('query parser', 'extended')` in `App.ts` to allow `[]` in query params.
+    - Direct access of private members like `_router` is not recommended/allowed in v5 (PR [#1510](https://github.com/paritytech/substrate-api-sidecar/pull/1510)).
 
 **Frequency**: Yearly or longer.
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -44,7 +44,7 @@ export default class App {
 		// Change needed because of upgrading Express v4 to v5
 		// Set query parser to 'extended' to correctly handle [] in query params
 		// Ref: https://github.com/expressjs/express/issues/5060
-		this.app.set('query parser', 'extended')
+		this.app.set('query parser', 'extended');
 		this.port = port;
 		this.host = host;
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -41,6 +41,10 @@ export default class App {
 	 */
 	constructor({ controllers, preMiddleware, postMiddleware, host, port }: IAppConfiguration) {
 		this.app = express();
+		// Change needed because of upgrading Express v4 to v5
+		// Set query parser to 'extended' to correctly handle [] in query params
+		// Ref: https://github.com/expressjs/express/issues/5060
+		this.app.set('query parser', 'extended')
 		this.port = port;
 		this.host = host;
 


### PR DESCRIPTION
### Issue
The endpoint `/accounts/{accountId}/asset-balances` no longer returns results for specific assets which means that the array query param format `?assets[]=1&assets[]=2&assets[]=3`does not work as expected. 
The `assets[]` array query params are also used in: 
- `/accounts/{accountId}/pool-asset-balances`
and other endpoints are using array query params and are probably affected but haven't tested them: 
- `/pallets/{palletId}/storage/{storageItemId}`
- `/contracts/ink/{address}/query`

### Suggested Solution
This issue is due to the upgrade from Express v4 to v5. In order to correctly handle `[]` in query params in `v5`, we need to set the default parser to `extended` (related [resource](https://github.com/expressjs/express/issues/5060)).

### Testing

#### Test `/accounts/{accountId}/asset-balances` in Polkadot Asset Hub
You can test that this change fixes the issue when connected to Polkadot Asset Hub and querying:
`accounts/13Fet2MzBBUbJ2oREa7JJrswGeJPY4p7cY3Z2MC9oash8kzN/asset-balances?assets[]=1337`

It returns 
```
{
  "at": {
    "hash": "0xfb9b662bcc33e303349a640a85ce35044d38f50428284717db9ecf16a44bfc0a",
    "height": "7334813"
  },
  "assets": [
    {
      "assetId": "1337",
      "balance": "1260526400000",
      "isFrozen": "isFrozen does not exist for this runtime",
      "isSufficient": true
    }
  ]
}
```
which is the expected output.

#### Test `/accounts/{accountId}/pool-asset-balances` in Westend Asset Hub
You can test that this change fixes the issue when connected to Westend Asset Hub and querying:
`/accounts/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty/pool-asset-balances?assets[]=55`

It returns 
```
{
  "at": {
    "hash": "0x3853a2bafd9d3eccec5f776bc99caf333fc4f17753f0145b961b23d1fbb89eb9",
    "height": "9357129"
  },
  "poolAssets": [
    {
      "assetId": "55",
      "balance": "0",
      "isFrozen": false,
      "isSufficient": false
    }
  ]
}
```
which is the expected output.
