### PR TITLE
feat: update dry run endpoint to use new runtime api call

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1067,7 +1067,7 @@ paths:
       description: Use the dryrun call to practice submission of a transaction.
       operationId: dryrunTransaction
       requestBody:
-        $ref: '#/components/requestBodies/Transaction'
+        $ref: '#/components/requestBodies/TransactionDryRun'
       responses:
         "200":
           description: successful operation
@@ -4494,6 +4494,18 @@ components:
         tx:
           type: string
           format: hex
+    DryRunBody:
+      type: object
+      properties: 
+        at: 
+          type: string
+          format: unsignedInteger
+        tx: 
+          type: string
+          format: hex
+        senderAddress:
+          type: string
+          format: ss58
     TransactionDryRun:
       type: object
       properties:
@@ -4504,32 +4516,20 @@ components:
           - TransactionValidityError
           description: Either `DispatchOutcome` if the transaction is valid or `TransactionValidityError` if the result is invalid.
         result:
-          type: string
-          enum:
-          - Ok
-          - CannotLookup
-          - NoUnsignedValidator
-          - Custom(u8)
-          - Call
-          - Payment
-          - Future
-          - Stale
-          - BadProof
-          - AncientBirthBlock
-          - ExhaustsResources
-          - BadMandatory
-          - MandatoryDispatch
-          description: 'If there was an error it will be the cause of the error. If the
-            transaction executed correctly it will be `Ok: []`'
-        validityErrorType:
-          type: string
-          enum:
-          - InvalidTransaction
-          - UnknownTransaction
+          type: object
+          properties:
+            actualWeight:
+              type: string
+              format: unsignedInteger
+              description: The actual weight of the transaction.
+            paysFee:
+              type: string
+              format: boolean
+              description: Whether the transaction pays a fee.
       description: >-
         References:
-        - `UnknownTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.UnknownTransaction.html
-        - `InvalidTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.InvalidTransaction.html
+          - `PostDispatchInfo`: https://docs.rs/frame-support/38.0.0/frame_support/dispatch/struct.PostDispatchInfo.html
+          - `Error Type`: https://paritytech.github.io/polkadot-sdk/master/xcm_runtime_apis/dry_run/enum.Error.html
     TransactionFailedToParse:
       type: object
       properties:
@@ -4766,6 +4766,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Transaction'
+      required: true
+    TransactionDryRun:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DryRunBody'
       required: true
     ContractMetadata:
       content:

--- a/src/controllers/transaction/TransactionDryRunController.ts
+++ b/src/controllers/transaction/TransactionDryRunController.ts
@@ -65,16 +65,12 @@ export default class TransactionDryRunController extends AbstractController<Tran
 			throw new BadRequest('Missing field `tx` on request body.');
 		}
 
-		if (!at) {
-			throw new BadRequest('Missing field `at` on request body.');
-		}
-
 		if (!senderAddress) {
 			throw new BadRequest('Missing field `senderAddress` on request body.');
 		}
 
-		const hash = await this.getHashFromAt(at);
+		const hash = at ? await this.getHashFromAt(at) : undefined;
 
-		TransactionDryRunController.sanitizedSend(res, await this.service.dryRuntExtrinsic(hash, senderAddress, tx));
+		TransactionDryRunController.sanitizedSend(res, await this.service.dryRuntExtrinsic(senderAddress, tx, hash));
 	};
 }

--- a/src/controllers/transaction/TransactionDryRunController.ts
+++ b/src/controllers/transaction/TransactionDryRunController.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -20,7 +20,7 @@ import { BadRequest } from 'http-errors';
 import { TransactionDryRunService } from '../../services';
 import { IPostRequestHandler, ITx } from '../../types/requests';
 import AbstractController from '../AbstractController';
-
+//  TODO: update this readme
 /**
  * Dry run an transaction.
  *
@@ -54,13 +54,16 @@ export default class TransactionDryRunController extends AbstractController<Tran
 		this.router.post(this.path, TransactionDryRunController.catchWrap(this.dryRunTransaction));
 	}
 
-	private dryRunTransaction: IPostRequestHandler<ITx> = async ({ body: { tx }, query: { at } }, res): Promise<void> => {
+	private dryRunTransaction: IPostRequestHandler<ITx> = ({ body: { tx } }, _res): void => {
 		if (!tx) {
 			throw new BadRequest('Missing field `tx` on request body.');
 		}
 
-		const hash = await this.getHashFromAt(at);
+		// const hash = await this.getHashFromAt(at);
 
-		TransactionDryRunController.sanitizedSend(res, await this.service.dryRuntExtrinsic(hash, tx));
+		// TransactionDryRunController.sanitizedSend(
+		// 	res,
+		// 	await this.service.dryRuntExtrinsic(hash, senderAddress, tx, format),
+		// );
 	};
 }

--- a/src/controllers/transaction/TransactionDryRunController.ts
+++ b/src/controllers/transaction/TransactionDryRunController.ts
@@ -20,25 +20,28 @@ import { BadRequest } from 'http-errors';
 import { TransactionDryRunService } from '../../services';
 import { IPostRequestHandler, ITx } from '../../types/requests';
 import AbstractController from '../AbstractController';
-//  TODO: update this readme
 /**
- * Dry run an transaction.
+ * Dry run a transaction.
  *
  * Returns:
  * - `at`:
  * 		- `hash`: The block's hash.
  * 		- `height`: The block's height.
- * - `dryRunResult`:
- * 		- `resultType`: Either `DispatchOutcome` if the construction is valid
- * 			or `TransactionValidityError` if the transaction has invalid construction.
- * 		- `result`: If there was an error it will be the cause of the error. If the
- * 			transaction executed correctly it will be `Ok: []`.
- * 		- `validityErrorType`: Only present if the `resultType` is
- * 			`TransactionValidityError`. Either `InvalidTransaction` or `UnknownTransaction`.
+ * - `result`:
+ * 		- Successfull dry run:
+ * 			- `actualWeight`: The actual weight of the transaction.
+ * 			- `paysFee`: The fee to be paid.
+ * 		- Failed dry run:
+ * 			- error reason.
+ * 		- Dry run not possible to run:
+ * 			- `isUnimplemented`: The dry run is not implemented.
+ * 			- `isVersionedConversionFailed`: The versioned conversion failed.
+ * 			- `type`: 'Unimplemented' | 'VersionedConversionFailed';.
  *
  * References:
- * - `UnknownTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.UnknownTransaction.html
- * - `InvalidTransaction`: https://crates.parity.io/sp_runtime/transaction_validity/enum.InvalidTransaction.html
+ * - `DispatchError`: https://docs.rs/sp-runtime/39.0.1/sp_runtime/enum.DispatchError.html
+ * - `PostDispatchInfo`: https://docs.rs/frame-support/38.0.0/frame_support/dispatch/struct.PostDispatchInfo.html
+ * - `Error Type`: https://paritytech.github.io/polkadot-sdk/master/xcm_runtime_apis/dry_run/enum.Error.html
  *
  * Note: If you get the error `-32601: Method not found` it means that the node sidecar
  * is connected to does not expose the `system_dryRun` RPC. One way to resolve this
@@ -54,16 +57,24 @@ export default class TransactionDryRunController extends AbstractController<Tran
 		this.router.post(this.path, TransactionDryRunController.catchWrap(this.dryRunTransaction));
 	}
 
-	private dryRunTransaction: IPostRequestHandler<ITx> = ({ body: { tx } }, _res): void => {
+	private dryRunTransaction: IPostRequestHandler<ITx> = async (
+		{ body: { tx, at, senderAddress } },
+		res,
+	): Promise<void> => {
 		if (!tx) {
 			throw new BadRequest('Missing field `tx` on request body.');
 		}
 
-		// const hash = await this.getHashFromAt(at);
+		if (!at) {
+			throw new BadRequest('Missing field `at` on request body.');
+		}
 
-		// TransactionDryRunController.sanitizedSend(
-		// 	res,
-		// 	await this.service.dryRuntExtrinsic(hash, senderAddress, tx, format),
-		// );
+		if (!senderAddress) {
+			throw new BadRequest('Missing field `senderAddress` on request body.');
+		}
+
+		const hash = await this.getHashFromAt(at);
+
+		TransactionDryRunController.sanitizedSend(res, await this.service.dryRuntExtrinsic(hash, senderAddress, tx));
 	};
 }

--- a/src/services/test-helpers/mock/mockAssetHubWestendApi.ts
+++ b/src/services/test-helpers/mock/mockAssetHubWestendApi.ts
@@ -38,6 +38,7 @@ import { localListenAddressesHex } from './data/localListenAddresses';
 import { getMetadata as mockMetaData } from './data/mockNonimationPoolResponseData';
 import traceBlockRPC from './data/traceBlock.json';
 import { defaultMockApi } from './mockApi';
+import { mockDryRunCallResult } from './mockDryRunCall';
 
 const chain = () =>
 	Promise.resolve().then(() => {
@@ -141,10 +142,17 @@ const runtimeDispatchInfo = assetHubWestendRegistryV9435.createType('RuntimeDisp
 	partialFee: 149000000,
 });
 
+const runtimeDryRun = assetHubWestendRegistryV9435.createType(
+	'Result<CallDryRunEffects, XcmDryRunApiError>',
+	mockDryRunCallResult,
+);
+
 export const assetHubWestendQueryInfoCall = (
 	_extrinsic: GenericExtrinsic,
 	_length: Uint8Array,
 ): Promise<RuntimeDispatchInfo> => Promise.resolve().then(() => runtimeDispatchInfo);
+
+const mockDryRunCall = () => Promise.resolve().then(() => runtimeDryRun);
 
 export const assetHubWestendQueryInfoAt = (_extrinsic: string, _hash: Hash): Promise<RuntimeDispatchInfo> =>
 	Promise.resolve().then(() => runtimeDispatchInfo);
@@ -211,6 +219,9 @@ export const mockAssetHubWestendApi = {
 		transactionPaymentApi: {
 			queryInfo: assetHubWestendQueryInfoCall,
 			queryFeeDetails,
+		},
+		dryRunApi: {
+			dryRunCall: mockDryRunCall,
 		},
 	},
 	consts: {

--- a/src/services/test-helpers/mock/mockDryRunCall.ts
+++ b/src/services/test-helpers/mock/mockDryRunCall.ts
@@ -1,0 +1,277 @@
+export const mockDryRunCallResult = {
+	Ok: {
+		executionResult: {
+			Ok: {
+				actualWeight: null,
+				paysFee: 'Yes',
+			},
+		},
+		emittedEvents: [
+			{
+				method: 'Burned',
+				section: 'balances',
+				index: '0x0a0b',
+				data: {
+					who: '5EJWF8s4CEoRU8nDhHBYTT6QGFGqMXTmdQdaQJVEFNrG9sKy',
+					amount: 1,
+				},
+			},
+			{
+				method: 'Issued',
+				section: 'balances',
+				index: '0x0a0f',
+				data: {
+					amount: 0,
+				},
+			},
+			{
+				method: 'Attempted',
+				section: 'polkadotXcm',
+				index: '0x1f00',
+				data: {
+					outcome: {
+						Complete: {
+							used: {
+								refTime: '182,042,000',
+								proofSize: '3,593',
+							},
+						},
+					},
+				},
+			},
+			{
+				method: 'Burned',
+				section: 'balances',
+				index: '0x0a0b',
+				data: {
+					who: '5EJWF8s4CEoRU8nDhHBYTT6QGFGqMXTmdQdaQJVEFNrG9sKy',
+					amount: '30,870,000,000',
+				},
+			},
+			{
+				method: 'Minted',
+				section: 'balances',
+				index: '0x0a0a',
+				data: {
+					who: '5EYCAe5ijiYfyeZ2JJCGq56LmPyNRAKzpG4QkoQkkQNB5e6Z',
+					amount: '30,870,000,000',
+				},
+			},
+			{
+				method: 'FeesPaid',
+				section: 'polkadotXcm',
+				index: '0x1f15',
+				data: {
+					paying: {
+						parents: 0,
+						interior: {
+							X1: [
+								{
+									AccountId32: {
+										network: 'Westend',
+										id: '0x62fecf9c60d8d49d400bd86804558401ec7151fecd440041ca6bf5fd57825177',
+									},
+								},
+							],
+						},
+					},
+					fees: [
+						{
+							id: {
+								parents: 1,
+								interior: 'Here',
+							},
+							fun: {
+								Fungible: '30,870,000,000',
+							},
+						},
+					],
+				},
+			},
+			{
+				method: 'UpwardMessageSent',
+				section: 'parachainSystem',
+				index: ' 0x0105',
+				data: {
+					messageHash: '0x10837cd56154e02f55910ce1f49dffd5d664bb69ddea6782d714c804611afa08',
+				},
+			},
+			{
+				method: 'Sent',
+				section: 'polkadotXcm',
+				index: '0x1f01',
+				data: {
+					origin: {
+						parents: 0,
+						interior: {
+							X1: [
+								{
+									AccountId32: {
+										network: 'Westend',
+										id: '0x62fecf9c60d8d49d400bd86804558401ec7151fecd440041ca6bf5fd57825177',
+									},
+								},
+							],
+						},
+					},
+					destination: {
+						parents: 1,
+						interior: 'Here',
+					},
+					message: [
+						{
+							ReceiveTeleportedAsset: [
+								{
+									id: {
+										parents: 0,
+										interior: 'Here',
+									},
+									fun: {
+										Fungible: 1,
+									},
+								},
+							],
+						},
+						'ClearOrigin',
+						{
+							BuyExecution: {
+								fees: {
+									id: {
+										parents: 0,
+										interior: 'Here',
+									},
+									fun: {
+										Fungible: 1,
+									},
+								},
+								weightLimit: 'Unlimited',
+							},
+						},
+						{
+							DepositAsset: {
+								assets: {
+									Wild: {
+										AllCounted: 1,
+									},
+								},
+								beneficiary: {
+									parents: 0,
+									interior: {
+										X1: [
+											{
+												AccountId32: {
+													network: null,
+													id: '0x7369626c27080000000000000000000000000000000000000000000000000000',
+												},
+											},
+										],
+									},
+								},
+							},
+						},
+					],
+					messageId: '0x0a5e3678f8746990e65680ed6a463597f1e02e2c00802bf2eeef82368c4f6233',
+				},
+			},
+		],
+		localXcm: {
+			V4: [
+				{
+					WithdrawAsset: [
+						{
+							id: {
+								parents: 1,
+								interior: 'Here',
+							},
+							fun: {
+								Fungible: 1,
+							},
+						},
+					],
+				},
+				{
+					BurnAsset: [
+						{
+							id: {
+								parents: 1,
+								interior: 'Here',
+							},
+							fun: {
+								Fungible: 1,
+							},
+						},
+					],
+				},
+			],
+		},
+		forwardedXcms: [
+			[
+				{
+					V4: {
+						parents: 1,
+						interior: 'Here',
+					},
+				},
+				[
+					{
+						V4: [
+							{
+								ReceiveTeleportedAsset: [
+									{
+										id: {
+											parents: 0,
+											interior: 'Here',
+										},
+										fun: {
+											Fungible: 1,
+										},
+									},
+								],
+							},
+							'ClearOrigin',
+							{
+								BuyExecution: {
+									fees: {
+										id: {
+											parents: 0,
+											interior: 'Here',
+										},
+										fun: {
+											Fungible: 1,
+										},
+									},
+									weightLimit: 'Unlimited',
+								},
+							},
+							{
+								DepositAsset: {
+									assets: {
+										Wild: {
+											AllCounted: 1,
+										},
+									},
+									beneficiary: {
+										parents: 0,
+										interior: {
+											X1: [
+												{
+													AccountId32: {
+														network: null,
+														id: '0x7369626c27080000000000000000000000000000000000000000000000000000',
+													},
+												},
+											],
+										},
+									},
+								},
+							},
+							{
+								SetTopic: '0x0a5e3678f8746990e65680ed6a463597f1e02e2c00802bf2eeef82368c4f6233',
+							},
+						],
+					},
+				],
+			],
+		],
+	},
+};

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -16,31 +16,22 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { GenericExtrinsicPayload } from '@polkadot/types/extrinsic';
 import type { PostDispatchInfo } from '@polkadot/types/interfaces';
-import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { blockHash22887036, mockAssetHubWestendApi } from '../test-helpers/mock';
 import { mockDryRunCallResult } from '../test-helpers/mock/mockDryRunCall';
 import { TransactionDryRunService } from './TransactionDryRunService';
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const mockSubmittableExt = mockAssetHubWestendApi.registry.createType(
-	'Extrinsic',
-	'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
-) as SubmittableExtrinsic<'promise', ISubmittableResult>;
-
 describe('TransactionDryRunService', () => {
 	const sendersAddress = '5HBuLJz9LdkUNseUEL6DLeVkx2bqEi6pQr8Ea7fS4bzx7i7E';
 	it('Should correctly execute a dry run for a submittable executable', async () => {
-		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic<'submittable'>(
+		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			blockHash22887036,
 			sendersAddress,
-			mockSubmittableExt,
-			'submittable',
+			'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
 		);
+
 		expect(executionResult?.at.hash).toEqual(blockHash22887036);
 		const resData = executionResult?.result as PostDispatchInfo;
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
@@ -50,13 +41,11 @@ describe('TransactionDryRunService', () => {
 		const payloadTx: `0x${string}` =
 			'0xf81f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de16010400000204320504009101000000000045022800010000e0510f00040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503';
 
-		const tx = new GenericExtrinsicPayload(mockAssetHubWestendApi.registry, payloadTx);
-		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic<'payload'>(
+		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			blockHash22887036,
 			sendersAddress,
-			tx,
-			'payload',
+			payloadTx,
 		);
 
 		const resData = executionResult?.result as PostDispatchInfo;
@@ -71,12 +60,11 @@ describe('TransactionDryRunService', () => {
 
 		// expect(callTxResult.localXcmFees![1]).toEqual({ xcmFee: '3500000000000000' });
 
-		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic<'call'>(
+		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			blockHash22887036,
 			sendersAddress,
 			callTx,
-			'call',
 		);
 
 		expect(executionResult?.at.hash).toEqual(blockHash22887036);

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -18,6 +18,7 @@
 
 import type { PostDispatchInfo } from '@polkadot/types/interfaces';
 
+import { TransactionResultType } from '../../types/responses';
 import { blockHash22887036, mockAssetHubWestendApi } from '../test-helpers/mock';
 import { mockDryRunCallResult } from '../test-helpers/mock/mockDryRunCall';
 import { TransactionDryRunService } from './TransactionDryRunService';
@@ -32,7 +33,8 @@ describe('TransactionDryRunService', () => {
 		);
 
 		expect(executionResult?.at.hash).toEqual(blockHash22887036);
-		const resData = executionResult?.result as PostDispatchInfo;
+		const resData = executionResult?.result.result as PostDispatchInfo;
+		expect(executionResult?.result.resultType).toEqual(TransactionResultType.DispatchOutcome);
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
 	});
 
@@ -46,7 +48,7 @@ describe('TransactionDryRunService', () => {
 			blockHash22887036,
 		);
 
-		const resData = executionResult?.result as PostDispatchInfo;
+		const resData = executionResult?.result.result as PostDispatchInfo;
 
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
 	});
@@ -61,7 +63,7 @@ describe('TransactionDryRunService', () => {
 		);
 
 		expect(executionResult?.at.hash).toEqual('');
-		const resData = executionResult?.result as PostDispatchInfo;
+		const resData = executionResult?.result.result as PostDispatchInfo;
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
 	});
 });

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -1,0 +1,24 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { GenericExtrinsicPayload } from '@polkadot/types/extrinsic';
+import type { ISubmittableResult } from '@polkadot/types/types';
+
+import { mockAssetHubWestendApi } from '../test-helpers/mock';
+import { TransactionDryRunService } from './TransactionDryRunService';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const mockSubmittableExt = mockAssetHubWestendApi.registry.createType(
+	'Extrinsic',
+	'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
+) as SubmittableExtrinsic<'promise', ISubmittableResult>;
+
+describe("TransactionDryRunService", () => {
+    it("Should correctly execute a dry run for a submittable executable", async () => {
+        const executionResult = await new TransactionDryRunService().dryRuntExtrinsic(
+
+        )
+    });
+
+    it("should correctly execute a dry run for a payload extrinsic", async () => {});
+
+    it("should correctly execute a dry run for a call", async () => {});
+});

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -26,10 +26,9 @@ describe('TransactionDryRunService', () => {
 	const sendersAddress = '5HBuLJz9LdkUNseUEL6DLeVkx2bqEi6pQr8Ea7fS4bzx7i7E';
 	it('Should correctly execute a dry run for a submittable executable', async () => {
 		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			blockHash22887036,
 			sendersAddress,
 			'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
+			blockHash22887036,
 		);
 
 		expect(executionResult?.at.hash).toEqual(blockHash22887036);
@@ -42,15 +41,13 @@ describe('TransactionDryRunService', () => {
 			'0xf81f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de16010400000204320504009101000000000045022800010000e0510f00040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503';
 
 		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			blockHash22887036,
 			sendersAddress,
 			payloadTx,
+			blockHash22887036,
 		);
 
 		const resData = executionResult?.result as PostDispatchInfo;
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
 	});
 
@@ -58,16 +55,12 @@ describe('TransactionDryRunService', () => {
 		const callTx =
 			'0x1f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000' as `0x${string}`;
 
-		// expect(callTxResult.localXcmFees![1]).toEqual({ xcmFee: '3500000000000000' });
-
 		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			blockHash22887036,
 			sendersAddress,
 			callTx,
 		);
 
-		expect(executionResult?.at.hash).toEqual(blockHash22887036);
+		expect(executionResult?.at.hash).toEqual('');
 		const resData = executionResult?.result as PostDispatchInfo;
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
 	});

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -1,8 +1,28 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { GenericExtrinsicPayload } from '@polkadot/types/extrinsic';
+import type { PostDispatchInfo } from '@polkadot/types/interfaces';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
-import { mockAssetHubWestendApi } from '../test-helpers/mock';
+import { blockHash22887036, mockAssetHubWestendApi } from '../test-helpers/mock';
+import { mockDryRunCallResult } from '../test-helpers/mock/mockDryRunCall';
 import { TransactionDryRunService } from './TransactionDryRunService';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -11,14 +31,56 @@ const mockSubmittableExt = mockAssetHubWestendApi.registry.createType(
 	'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
 ) as SubmittableExtrinsic<'promise', ISubmittableResult>;
 
-describe("TransactionDryRunService", () => {
-    it("Should correctly execute a dry run for a submittable executable", async () => {
-        const executionResult = await new TransactionDryRunService().dryRuntExtrinsic(
+describe('TransactionDryRunService', () => {
+	const sendersAddress = '5HBuLJz9LdkUNseUEL6DLeVkx2bqEi6pQr8Ea7fS4bzx7i7E';
+	it('Should correctly execute a dry run for a submittable executable', async () => {
+		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic<'submittable'>(
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			blockHash22887036,
+			sendersAddress,
+			mockSubmittableExt,
+			'submittable',
+		);
+		expect(executionResult?.at.hash).toEqual(blockHash22887036);
+		const resData = executionResult?.result as PostDispatchInfo;
+		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
+	});
 
-        )
-    });
+	it('should correctly execute a dry run for a payload extrinsic', async () => {
+		const payloadTx: `0x${string}` =
+			'0xf81f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de16010400000204320504009101000000000045022800010000e0510f00040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503';
 
-    it("should correctly execute a dry run for a payload extrinsic", async () => {});
+		const tx = new GenericExtrinsicPayload(mockAssetHubWestendApi.registry, payloadTx);
+		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic<'payload'>(
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			blockHash22887036,
+			sendersAddress,
+			tx,
+			'payload',
+		);
 
-    it("should correctly execute a dry run for a call", async () => {});
+		const resData = executionResult?.result as PostDispatchInfo;
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
+	});
+
+	it('should correctly execute a dry run for a call', async () => {
+		const callTx =
+			'0x1f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000' as `0x${string}`;
+
+		// expect(callTxResult.localXcmFees![1]).toEqual({ xcmFee: '3500000000000000' });
+
+		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic<'call'>(
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			blockHash22887036,
+			sendersAddress,
+			callTx,
+			'call',
+		);
+
+		expect(executionResult?.at.hash).toEqual(blockHash22887036);
+		const resData = executionResult?.result as PostDispatchInfo;
+		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
+	});
 });

--- a/src/services/transaction/TransactionDryRunService.ts
+++ b/src/services/transaction/TransactionDryRunService.ts
@@ -29,9 +29,9 @@ export type SignedOriginCaller = {
 
 export class TransactionDryRunService extends AbstractService {
 	async dryRuntExtrinsic(
-		hash: BlockHash,
 		senderAddress: string,
 		transaction: `0x${string}`,
+		hash?: BlockHash,
 	): Promise<ITransactionDryRun> {
 		const { api } = this;
 
@@ -42,17 +42,17 @@ export class TransactionDryRunService extends AbstractService {
 				},
 			};
 
-			const [dryRunResponse, header] = await Promise.all([
+			const [dryRunResponse, { number }] = await Promise.all([
 				api.call.dryRunApi.dryRunCall(originCaller, transaction),
-				api.rpc.chain.getHeader(hash),
+				hash ? api.rpc.chain.getHeader(hash) : { number: null },
 			]);
 
 			const response = dryRunResponse as Result<CallDryRunEffects, XcmDryRunApiError>;
 
 			return {
 				at: {
-					hash,
-					height: header.number.unwrap().toString(10),
+					hash: hash ? hash : '',
+					height: number ? number.unwrap().toString(10) : '0',
 				},
 				result: response.isOk ? response.asOk.executionResult.asOk : response.asErr,
 			};

--- a/src/services/transaction/TransactionDryRunService.ts
+++ b/src/services/transaction/TransactionDryRunService.ts
@@ -17,7 +17,7 @@
 import type { BlockHash, CallDryRunEffects, XcmDryRunApiError } from '@polkadot/types/interfaces';
 import type { Result } from '@polkadot/types-codec';
 
-import { ITransactionDryRun } from '../../types/responses';
+import { ITransactionDryRun, TransactionResultType } from '../../types/responses';
 import { AbstractService } from '../AbstractService';
 import { extractCauseAndStack } from './extractCauseAndStack';
 
@@ -54,7 +54,12 @@ export class TransactionDryRunService extends AbstractService {
 					hash: hash ? hash : '',
 					height: number ? number.unwrap().toString(10) : '0',
 				},
-				result: response.isOk ? response.asOk.executionResult.asOk : response.asErr,
+				result: {
+					resultType: response.isOk
+						? TransactionResultType.DispatchOutcome
+						: TransactionResultType.TransactionValidityError,
+					result: response.isOk ? response.asOk.executionResult.asOk : response.asErr,
+				},
 			};
 		} catch (err) {
 			const { cause, stack } = extractCauseAndStack(err);

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -22,9 +22,9 @@ import type client from 'prom-client';
  * Body for RequestHandlerTx. In other words, the body of a POST route that sends an encoded transaction.
  */
 export interface ITx {
-	tx: string;
+	tx: `0x${string}`;
 	senderAddress: string;
-	format: 'payload' | 'call' | 'submittable';
+	at: string;
 }
 
 /**

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -23,6 +23,8 @@ import type client from 'prom-client';
  */
 export interface ITx {
 	tx: string;
+	senderAddress: string;
+	format: 'payload' | 'call' | 'submittable';
 }
 
 /**

--- a/src/types/responses/TransactionDryRun.ts
+++ b/src/types/responses/TransactionDryRun.ts
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import type { CallDryRunEffects } from '@polkadot/types/interfaces';
 import { DispatchOutcome, InvalidTransaction, UnknownTransaction } from '@polkadot/types/interfaces';
 
 import { IAt } from '.';
@@ -34,7 +35,7 @@ export interface ITransactionDryRun {
 	at: IAt;
 	dryRunResult: {
 		resultType: TransactionResultType;
-		result: TransactionResult;
+		result: CallDryRunEffects;
 		validityErrorType?: ValidityErrorType;
 	};
 }

--- a/src/types/responses/TransactionDryRun.ts
+++ b/src/types/responses/TransactionDryRun.ts
@@ -31,5 +31,8 @@ export enum ValidityErrorType {
 
 export interface ITransactionDryRun {
 	at: IAt;
-	result: PostDispatchInfo | XcmDryRunApiError | DispatchError;
+	result: {
+		resultType: TransactionResultType;
+		result: PostDispatchInfo | XcmDryRunApiError | DispatchError;
+	};
 }

--- a/src/types/responses/TransactionDryRun.ts
+++ b/src/types/responses/TransactionDryRun.ts
@@ -1,4 +1,5 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -14,10 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import type { CallDryRunEffects } from '@polkadot/types/interfaces';
-import { DispatchOutcome, InvalidTransaction, UnknownTransaction } from '@polkadot/types/interfaces';
+import type { DispatchError, PostDispatchInfo, XcmDryRunApiError } from '@polkadot/types/interfaces';
 
-import { IAt } from '.';
+import { IAt } from './At';
 
 export enum TransactionResultType {
 	TransactionValidityError = 'TransactionValidityError',
@@ -29,13 +29,7 @@ export enum ValidityErrorType {
 	Unknown = 'UnknownTransaction',
 }
 
-export type TransactionResult = DispatchOutcome | InvalidTransaction | UnknownTransaction;
-
 export interface ITransactionDryRun {
 	at: IAt;
-	dryRunResult: {
-		resultType: TransactionResultType;
-		result: CallDryRunEffects;
-		validityErrorType?: ValidityErrorType;
-	};
+	result: PostDispatchInfo | XcmDryRunApiError | DispatchError;
 }


### PR DESCRIPTION
It updates the transaction dry run endpoint to accept a body with the transaction string, the sender address and the block number. it returns if the dry run was successful or if it errored and for which block hash