### PR TITLE
fix: dependabot yaml & explicit pjs deps declaration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,14 @@ updates:
       # EST timezone
       timezone: "America/New_York"
     rebase-strategy: "auto"
-    # Disable versioned updates, and only allow security updates
-    open-pull-requests-limit: 0
+    groups:
+      pjs:
+        patterns:
+          - "@polkadot/*"
     commit-message:
       # Prefix all commit messages with "chore"
       # include a list of updated dependencies
-      prefix: "chore(deps):"
+      prefix: "chore"
+      include: "scope"
     labels:
       - "D0 - Dependencies"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,11 @@
   },
   "dependencies": {
     "@polkadot/api": "^14.1.1",
+    "@polkadot/api-augment": "^14.1.1",
     "@polkadot/api-contract": "^14.1.1",
+    "@polkadot/types": "^14.1.1",
+    "@polkadot/types-codec": "^14.1.1",
+    "@polkadot/util": "^13.2.1",
     "@polkadot/util-crypto": "^13.2.1",
     "@substrate/calc": "^0.3.1",
     "argparse": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,7 +1044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:14.1.1":
+"@polkadot/api-augment@npm:14.1.1, @polkadot/api-augment@npm:^14.1.1":
   version: 14.1.1
   resolution: "@polkadot/api-augment@npm:14.1.1"
   dependencies:
@@ -1220,7 +1220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:14.1.1":
+"@polkadot/types-codec@npm:14.1.1, @polkadot/types-codec@npm:^14.1.1":
   version: 14.1.1
   resolution: "@polkadot/types-codec@npm:14.1.1"
   dependencies:
@@ -1266,7 +1266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:14.1.1":
+"@polkadot/types@npm:14.1.1, @polkadot/types@npm:^14.1.1":
   version: 14.1.1
   resolution: "@polkadot/types@npm:14.1.1"
   dependencies:
@@ -1581,7 +1581,11 @@ __metadata:
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
     "@polkadot/api": "npm:^14.1.1"
+    "@polkadot/api-augment": "npm:^14.1.1"
     "@polkadot/api-contract": "npm:^14.1.1"
+    "@polkadot/types": "npm:^14.1.1"
+    "@polkadot/types-codec": "npm:^14.1.1"
+    "@polkadot/util": "npm:^13.2.1"
     "@polkadot/util-crypto": "npm:^13.2.1"
     "@substrate/calc": "npm:^0.3.1"
     "@substrate/dev": "npm:^0.8.0"


### PR DESCRIPTION
### Description
- Enables the Dependabot to update the packages that match the `@polkadot/*` pattern (same as in [ata](https://github.com/paritytech/asset-transfer-api/pull/457/files))
- Update again the pattern for the Dependabot PR title (same as in [ata](https://github.com/paritytech/asset-transfer-api/pull/464/files))
- Declare explicit pjs dependencies (same as in [ata](https://github.com/paritytech/asset-transfer-api/pull/458/files))

### Notes
- We could declare explicitly more pjs deps in Sidecar. Not sure if it is needed.