### PR TITLE
fix: return DispatchError in dry-run endpoint

### DIFF
--- a/src/services/test-helpers/mock/mockAssetHubWestendApi.ts
+++ b/src/services/test-helpers/mock/mockAssetHubWestendApi.ts
@@ -39,6 +39,7 @@ import { getMetadata as mockMetaData } from './data/mockNonimationPoolResponseDa
 import traceBlockRPC from './data/traceBlock.json';
 import { defaultMockApi } from './mockApi';
 import { mockDryRunCallResult } from './mockDryRunCall';
+import { mockDryRunCallError } from './mockDryRunError';
 
 const chain = () =>
 	Promise.resolve().then(() => {
@@ -147,12 +148,19 @@ const runtimeDryRun = assetHubWestendRegistryV9435.createType(
 	mockDryRunCallResult,
 );
 
+const runtimeDryRunError = assetHubWestendRegistryV9435.createType(
+	'Result<CallDryRunEffects, XcmDryRunApiError>',
+	mockDryRunCallError,
+);
+
 export const assetHubWestendQueryInfoCall = (
 	_extrinsic: GenericExtrinsic,
 	_length: Uint8Array,
 ): Promise<RuntimeDispatchInfo> => Promise.resolve().then(() => runtimeDispatchInfo);
 
-const mockDryRunCall = () => Promise.resolve().then(() => runtimeDryRun);
+export const mockDryRunCall = () => Promise.resolve().then(() => runtimeDryRun);
+
+export const mockDryRunError = () => Promise.resolve().then(() => runtimeDryRunError);
 
 export const assetHubWestendQueryInfoAt = (_extrinsic: string, _hash: Hash): Promise<RuntimeDispatchInfo> =>
 	Promise.resolve().then(() => runtimeDispatchInfo);
@@ -219,9 +227,6 @@ export const mockAssetHubWestendApi = {
 		transactionPaymentApi: {
 			queryInfo: assetHubWestendQueryInfoCall,
 			queryFeeDetails,
-		},
-		dryRunApi: {
-			dryRunCall: mockDryRunCall,
 		},
 	},
 	consts: {

--- a/src/services/test-helpers/mock/mockDryRunError.ts
+++ b/src/services/test-helpers/mock/mockDryRunError.ts
@@ -1,0 +1,12 @@
+export const mockDryRunCallError = {
+	Ok: {
+		executionResult: {
+			Err: {
+				Token: 'NoFunds',
+			}
+		},
+		emittedEvents: [],
+		localXcm: null,
+		forwardedXcms: []
+	}
+};

--- a/src/services/test-helpers/mock/mockDryRunError.ts
+++ b/src/services/test-helpers/mock/mockDryRunError.ts
@@ -3,10 +3,10 @@ export const mockDryRunCallError = {
 		executionResult: {
 			Err: {
 				Token: 'NoFunds',
-			}
+			},
 		},
 		emittedEvents: [],
 		localXcm: null,
-		forwardedXcms: []
-	}
+		forwardedXcms: [],
+	},
 };

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -16,17 +16,28 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import type { PostDispatchInfo } from '@polkadot/types/interfaces';
+import type { PostDispatchInfo, DispatchError  } from '@polkadot/types/interfaces';
 
+import type { ApiPromise } from '@polkadot/api';
 import { TransactionResultType } from '../../types/responses';
-import { blockHash22887036, mockAssetHubWestendApi } from '../test-helpers/mock';
+import { blockHash22887036, mockAssetHubWestendApi, mockDryRunCall, mockDryRunError } from '../test-helpers/mock';
 import { mockDryRunCallResult } from '../test-helpers/mock/mockDryRunCall';
+import { mockDryRunCallError } from '../test-helpers/mock/mockDryRunError';
 import { TransactionDryRunService } from './TransactionDryRunService';
+
+const mockAHWApi = {
+	...mockAssetHubWestendApi,
+	call: {
+		dryRunApi: {
+			dryRunCall: mockDryRunCall,
+		},
+	},
+} as unknown as ApiPromise;
 
 describe('TransactionDryRunService', () => {
 	const sendersAddress = '5HBuLJz9LdkUNseUEL6DLeVkx2bqEi6pQr8Ea7fS4bzx7i7E';
 	it('Should correctly execute a dry run for a submittable executable', async () => {
-		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
+		const executionResult = await new TransactionDryRunService(mockAHWApi).dryRuntExtrinsic(
 			sendersAddress,
 			'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
 			blockHash22887036,
@@ -42,7 +53,7 @@ describe('TransactionDryRunService', () => {
 		const payloadTx: `0x${string}` =
 			'0xf81f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de16010400000204320504009101000000000045022800010000e0510f00040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503';
 
-		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
+		const executionResult = await new TransactionDryRunService(mockAHWApi).dryRuntExtrinsic(
 			sendersAddress,
 			payloadTx,
 			blockHash22887036,
@@ -57,7 +68,7 @@ describe('TransactionDryRunService', () => {
 		const callTx =
 			'0x1f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000' as `0x${string}`;
 
-		const executionResult = await new TransactionDryRunService(mockAssetHubWestendApi).dryRuntExtrinsic(
+		const executionResult = await new TransactionDryRunService(mockAHWApi).dryRuntExtrinsic(
 			sendersAddress,
 			callTx,
 		);
@@ -65,5 +76,28 @@ describe('TransactionDryRunService', () => {
 		expect(executionResult?.at.hash).toEqual('');
 		const resData = executionResult?.result.result as PostDispatchInfo;
 		expect(resData.paysFee.toString()).toEqual(mockDryRunCallResult.Ok.executionResult.Ok.paysFee);
+	});
+
+	it('should correctly execute a dry run for a call and return an error', async () => {
+		const mockAHWApiErr = {
+			...mockAssetHubWestendApi,
+			call: {
+				dryRunApi: {
+					dryRunCall: mockDryRunError,
+				},
+			},
+		} as unknown as ApiPromise;
+
+		const callTx =
+			'0x0a0000fe06fc3db07fb1a4ce89a76eaed1e54519b5940d2652b8d6794ad4ddfcdcb16c0f00d0eca2b99401' as `0x${string}`;
+
+		const executionResult = await new TransactionDryRunService(mockAHWApiErr).dryRuntExtrinsic(
+			sendersAddress,
+			callTx,
+		);
+
+		expect(executionResult?.at.hash).toEqual('');
+		const resData = executionResult?.result.result as DispatchError;
+		expect(resData.asToken.toString()).toEqual(mockDryRunCallError.Ok.executionResult.Err.Token);
 	});
 });

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -16,9 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import type { PostDispatchInfo, DispatchError  } from '@polkadot/types/interfaces';
-
 import type { ApiPromise } from '@polkadot/api';
+import type { DispatchError, PostDispatchInfo } from '@polkadot/types/interfaces';
+
 import { TransactionResultType } from '../../types/responses';
 import { blockHash22887036, mockAssetHubWestendApi, mockDryRunCall, mockDryRunError } from '../test-helpers/mock';
 import { mockDryRunCallResult } from '../test-helpers/mock/mockDryRunCall';
@@ -68,10 +68,7 @@ describe('TransactionDryRunService', () => {
 		const callTx =
 			'0x1f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000' as `0x${string}`;
 
-		const executionResult = await new TransactionDryRunService(mockAHWApi).dryRuntExtrinsic(
-			sendersAddress,
-			callTx,
-		);
+		const executionResult = await new TransactionDryRunService(mockAHWApi).dryRuntExtrinsic(sendersAddress, callTx);
 
 		expect(executionResult?.at.hash).toEqual('');
 		const resData = executionResult?.result.result as PostDispatchInfo;
@@ -91,10 +88,7 @@ describe('TransactionDryRunService', () => {
 		const callTx =
 			'0x0a0000fe06fc3db07fb1a4ce89a76eaed1e54519b5940d2652b8d6794ad4ddfcdcb16c0f00d0eca2b99401' as `0x${string}`;
 
-		const executionResult = await new TransactionDryRunService(mockAHWApiErr).dryRuntExtrinsic(
-			sendersAddress,
-			callTx,
-		);
+		const executionResult = await new TransactionDryRunService(mockAHWApiErr).dryRuntExtrinsic(sendersAddress, callTx);
 
 		expect(executionResult?.at.hash).toEqual('');
 		const resData = executionResult?.result.result as DispatchError;

--- a/src/services/transaction/TransactionDryRunService.ts
+++ b/src/services/transaction/TransactionDryRunService.ts
@@ -17,7 +17,7 @@
 import type { BlockHash, CallDryRunEffects, XcmDryRunApiError } from '@polkadot/types/interfaces';
 import type { Result } from '@polkadot/types-codec';
 
-import { ITransactionDryRun, TransactionResultType } from '../../types/responses';
+import { ITransactionDryRun, TransactionResultType, ValidityErrorType } from '../../types/responses';
 import { AbstractService } from '../AbstractService';
 import { extractCauseAndStack } from './extractCauseAndStack';
 
@@ -56,9 +56,15 @@ export class TransactionDryRunService extends AbstractService {
 				},
 				result: {
 					resultType: response.isOk
-						? TransactionResultType.DispatchOutcome
-						: TransactionResultType.TransactionValidityError,
-					result: response.isOk ? response.asOk.executionResult.asOk : response.asErr,
+						? response.asOk.executionResult.isOk
+							? TransactionResultType.DispatchOutcome
+							: TransactionResultType.DispatchError
+						: ValidityErrorType.Invalid,
+					result: response.isOk
+						? response.asOk.executionResult.isOk
+							? response.asOk.executionResult.asOk
+							: response.asOk.executionResult.asErr
+						: response.asErr,
 				},
 			};
 		} catch (err) {

--- a/src/test-helpers/registries/assetHubWestendRegistry.ts
+++ b/src/test-helpers/registries/assetHubWestendRegistry.ts
@@ -1,4 +1,4 @@
-// Copyright 2017-2022 Parity Technologies (UK) Ltd.
+// Copyright 2017-2024 Parity Technologies (UK) Ltd.
 // This file is part of Substrate API Sidecar.
 //
 // Substrate API Sidecar is free software: you can redistribute it and/or modify
@@ -24,7 +24,7 @@ import { assetHubWestendMetadataRpcV9435 } from '../metadata/assetHubWestendMeta
  * Create a type registry for Asset Hub Westend.
  * Useful for creating types in order to facilitate testing.
  */
-function createAssetHubWestendRegistry(): TypeRegistry {
+function createAssetHubWestendRegistry(specVersion: number, metadata: `0x${string}`): TypeRegistry {
 	const registry = new TypeRegistry();
 	registry.setChainProperties(
 		registry.createType('ChainProperties', {
@@ -34,9 +34,9 @@ function createAssetHubWestendRegistry(): TypeRegistry {
 		}),
 	);
 
-	registry.register(getSpecTypes(registry, 'westmint', 'westmint', 9435));
+	registry.register(getSpecTypes(registry, 'Westend Asset Hub', 'westmint', specVersion));
 
-	registry.setMetadata(new Metadata(registry, assetHubWestendMetadataRpcV9435));
+	registry.setMetadata(new Metadata(registry, metadata));
 
 	return registry;
 }
@@ -44,4 +44,4 @@ function createAssetHubWestendRegistry(): TypeRegistry {
 /**
  * Asset Hub Westend v9435 TypeRegistry.
  */
-export const assetHubWestendRegistryV9435 = createAssetHubWestendRegistry();
+export const assetHubWestendRegistryV9435 = createAssetHubWestendRegistry(9435, assetHubWestendMetadataRpcV9435);

--- a/src/types/responses/TransactionDryRun.ts
+++ b/src/types/responses/TransactionDryRun.ts
@@ -20,8 +20,8 @@ import type { DispatchError, PostDispatchInfo, XcmDryRunApiError } from '@polkad
 import { IAt } from './At';
 
 export enum TransactionResultType {
-	TransactionValidityError = 'TransactionValidityError',
 	DispatchOutcome = 'DispatchOutcome',
+	DispatchError = 'DispatchError',
 }
 
 export enum ValidityErrorType {
@@ -32,7 +32,7 @@ export enum ValidityErrorType {
 export interface ITransactionDryRun {
 	at: IAt;
 	result: {
-		resultType: TransactionResultType;
+		resultType: TransactionResultType | ValidityErrorType;
 		result: PostDispatchInfo | XcmDryRunApiError | DispatchError;
 	};
 }


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1532

### Testing
Connected to Westend Asset Hub, when requesting: 
```
curl -X 'POST' \
  'http://127.0.0.1:8080/transaction/dry-run' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "senderAddress": "5F9aniqTwLsRn5ybqSeB2srKfaRXCLeNDSPPHQxPeuGw5Y8a",
  "tx": "0x0a0000fe06fc3db07fb1a4ce89a76eaed1e54519b5940d2652b8d6794ad4ddfcdcb16c0f00d0eca2b99401"
  }'
```

Before the change we would get the response : 
```
{"at":{"hash":"","height":"0"},"result":{"resultType":"DispatchError","result":{"postInfo":{"actualWeight":null,"paysFee":"Yes"},"error":{"token":"FundsUnavailable"}}}}
{"code":400,"error":"Unable to dry-run transaction","transaction":"0x0a0000fe06fc3db07fb1a4ce89a76eaed1e54519b5940d2652b8d6794ad4ddfcdcb16c0f00d0eca2b99401","cause":"Cannot extract Ok value from Err result, check isOk first","stack":"Error: Cannot extract Ok value from Err result, check isOk first\n    at get asOk [as asOk] (/Users/dominique/Documents/Parity/side-aaFresko/node_modules/@polkadot/types-codec/cjs/base/Result.js:37:19)\n    at TransactionDryRunService.dryRuntExtrinsic (/Users/dominique/Documents/Parity/side-aaFresko/build/src/services/transaction/TransactionDryRunService.js:45:75)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async TransactionDryRunController.dryRunTransaction (/Users/dominique/Documents/Parity/side-aaFresko/build/src/controllers/transaction/TransactionDryRunController.js:62:60)\n    at async /Users/dominique/Documents/Parity/side-aaFresko/build/src/controllers/AbstractController.js:222:9","at":{}}zsh: command not found: at:hash:,result:resultType:DispatchError
```

After the change we get : 
```
{"at":{"hash":"","height":"0"},"result":{"resultType":"DispatchError","result":{"postInfo":{"actualWeight":null,"paysFee":"Yes"},"error":{"token":"FundsUnavailable"}}}}
```
