### PR TITLE
fix(dev): fix tsconfig extends pathing for ts-node-dev

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@substrate/dev/config/tsconfig.json",
+  "extends": "./node_modules/@substrate/dev/config/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "build",


### PR DESCRIPTION
This fixes the broken - `yarn dev`.

rel: https://github.com/microsoft/TypeScript/issues/56492
rel: https://github.com/TypeStrong/ts-node/issues/2076