### PR TITLE
fix: ignore extrinsicIndex in multiBlockMigrations event

### DIFF
--- a/src/services/blocks/BlocksService.spec.ts
+++ b/src/services/blocks/BlocksService.spec.ts
@@ -149,7 +149,7 @@ describe('BlocksService', () => {
 		});
 
 		it('throws when an extrinsic is undefined', async () => {
-			// Create a block with undefined as the first extrinisic and the last extrinsic removed
+			// Create a block with undefined as the first extrinsic and the last extrinsic removed
 			const mockBlock789629BadExt = polkadotRegistry.createType('Block', block789629);
 
 			mockBlock789629BadExt.extrinsics.pop();
@@ -377,7 +377,7 @@ describe('BlocksService', () => {
 			paraId: undefined,
 		};
 
-		it('Returns the correct extrinisics object for block 789629', async () => {
+		it('Returns the correct extrinsics object for block 789629', async () => {
 			const block = await blocksService.fetchBlock(blockHash789629, mockHistoricApi, options);
 
 			/**

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -438,7 +438,7 @@ export class BlocksService extends AbstractService {
 
 	/**
 	 * Retrieve the blockHash for the previous block to the one getting queried.
-	 * If the block is the geneisis hash it will return the same blockHash.
+	 * If the block is the genesis hash it will return the same blockHash.
 	 *
 	 * @param blockNumber The blockId being queried
 	 */
@@ -590,7 +590,7 @@ export class BlocksService extends AbstractService {
 					const extrinsicIdx = phase.asApplyExtrinsic.toNumber();
 					const extrinsic = extrinsics[extrinsicIdx];
 
-					if (!extrinsic) {
+					if (!extrinsic && event.section != 'multiBlockMigrations') {
 						throw new Error(`Missing extrinsic ${extrinsicIdx} in block ${hash.toString()}`);
 					}
 
@@ -610,7 +610,9 @@ export class BlocksService extends AbstractService {
 						}
 					}
 
-					extrinsic.events.push(sanitizedEvent);
+					if (extrinsic) {
+						extrinsic.events.push(sanitizedEvent);
+					}
 				} else if (phase.isFinalization) {
 					onFinalize.events.push(sanitizedEvent);
 				} else if (phase.isInitialization) {
@@ -789,7 +791,7 @@ export class BlocksService extends AbstractService {
 	}
 
 	/**
-	 * Fetch a block with raw extrinics values.
+	 * Fetch a block with raw extrinsics values.
 	 *
 	 * @param hash `BlockHash` of the block to fetch.
 	 */


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1538 

### Issue
In the `blocks` endpoint, we return a list of extrinsics included in the queried block and under each extrinsic their related event. However, during `multiBlockMigrations` we encounter cases where events reference extrinsic indexes that do not exist. 
In the code, this situation is represented by having an event with : 
- phase set as `ApplyExtrinsic` [here](https://github.com/paritytech/substrate-api-sidecar/blob/cef2d10ead615b81c11a493310c84411fd45738f/src/services/blocks/BlocksService.ts#L589) (which means we expect an extrinsic associated with this event)
- then we retrieve the extrinsic index [here](https://github.com/paritytech/substrate-api-sidecar/blob/cef2d10ead615b81c11a493310c84411fd45738f/src/services/blocks/BlocksService.ts#L590)
- the index retrieved in this case is `2` but there is no extrinsic in index `2` so we return an error msg

### Proposed Solution
During `multiBlockMigrations` : 
- we ignore the extrinsic index since it is a non existent one anyway
- we also ignore the `multiblockmigrations / MigrationAdvanced` event (shown in Subscan [here](https://shiden.subscan.io/block/7675808?tab=event)) since we cannot associate it with any valid/existing extrinsic.

In the code, we do that by : 
- **not** throwing an error if we find an event with a non existent extrinsic during `multiBlockMigrations`
- push the event only if the extrinsic is present.

This does not break any past logic since the error message will be thrown in all other cases.

### Testing
While connected to Shiden network (e.g. through `wss://rpc.shiden.astar.network`), query block 7675808 `http://127.0.0.1:8080/blocks/7675808`.

Before the fix we would get : 
```
Missing extrinsic 2 in block 0xc26eb7b19378e953c80ef9749df2b5ae67a7bdb17b3ad9b9a0ee9c1810438a9f
```

After the fix : 
```
...
...
"extrinsics": [
    {
      "method": {
        "pallet": "timestamp",
        "method": "set"
      },
     ...
     ...
      },
      "events": [
        {
          "method": {
            "pallet": "system",
            "method": "ExtrinsicSuccess"
          },
...
...
{
      "method": {
        "pallet": "parachainSystem",
        "method": "setValidationData"
      },
...
...
"events": [
        {
          "method": {
            "pallet": "system",
            "method": "ExtrinsicSuccess"
          },
```

The response now returns correctly the 2 extrinsics present in this block and their associated events. There is also the `multiblockmigrations / MigrationAdvanced` event (mentioned earlier) but we chose to ignore it since we cannot attach it to any valid/existing extrinsics.

### Downside
This solution has the downside that we are not showing an existing event.

### Long term Solution
As soon as this PR https://github.com/paritytech/polkadot-sdk/pull/3666 gets merged, I will expect that `multiBlockMigrations` events will have phase set as `ApplyInherent` so we will not have this issue for future blocks. However this fix needs to be kept for historic blocks.

### Todos
- [x] Added issue https://github.com/paritytech/substrate-api-sidecar/issues/1542 in Sidecar to track the progress of this polkadot-sdk [PR](https://github.com/paritytech/polkadot-sdk/pull/3666) and make the necessary changes as soon as it is applied.