### PR TITLE
chore: update Dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,4 @@ updates:
       include: "scope"
     labels:
       - "D0 - Dependencies"
+    versioning-strategy: increase


### PR DESCRIPTION
### Current Setup
After reviewing this Dependabot PR https://github.com/paritytech/substrate-api-sidecar/pull/1534, I noticed that Dependabot does not update the `package.json` file. This is the expected behaviour since polkadot deps are using the caret `^` in [package.json](https://github.com/paritytech/substrate-api-sidecar/blob/master/package.json#L53L59) and Dependabot does not need to update it (default Dependabot versioning is [auto](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy)).

#### Example
- `package.json` has a dependency in some version `"example-dep": "^14.1.1"`
- Dependabot will bump the version to the latest one (either patch or minor), e.g. `14.x.x` version so `14.2.2` or `14.1.3` 
- It will not update the `package.json` since it is a compatible version with the range that it is shown in `package.json`.

### Proposed Change
Explicitly set Dependabot's `versioning-strategy` to `increase` which will update also the version in package.json even if it is in the compatible range.

#### Example
- Same updates as above with the only difference that the Dependabot will now also update the `package.json` even if it is a compatible version / within the range specified in package.json.

### Reason for this Change
In Sidecar, it is quite important to know the exact versions of polkadot-js dependencies we are using. In the case of issues, the first thing that we do when debugging is to check in `package.json` which version of polkadot deps we are using and then research the changes in the corresponding repos. Even minor or patch releases of polkadot-js packages can affect Sidecar. Therefore, I think its important that `package.json` reflects the exact pjs dep versions, so we do not have to check the `yarn.lock` every time to verify this. 

### Alternative Solution
I think we would have the same result if we remove the carets from the polkadot js deps. Example from asset-transfer-api : 
- [package.json](https://github.com/paritytech/asset-transfer-api/blob/main/package.json#L53L58) : pjs deps without carets
- [dependabot.yml](https://github.com/paritytech/asset-transfer-api/blob/main/.github/dependabot.yml) : without explicitly setting the versioning-strategy
- [example of Dependabot PR](https://github.com/paritytech/asset-transfer-api/pull/469/files) : it updates both `package.json` and `yarn.lock` even for minor release.


