### PR TITLE
chore(deps): update polkadot-js deps to v14.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "test:test-release": "yarn build:scripts && node scripts/build/runYarnPack.js"
   },
   "dependencies": {
-    "@polkadot/api": "^14.2.3",
-    "@polkadot/api-augment": "^14.2.3",
-    "@polkadot/api-contract": "^14.2.3",
-    "@polkadot/types": "^14.2.3",
-    "@polkadot/types-codec": "^14.2.3",
+    "@polkadot/api": "^14.3.1",
+    "@polkadot/api-augment": "^14.3.1",
+    "@polkadot/api-contract": "^14.3.1",
+    "@polkadot/types": "^14.3.1",
+    "@polkadot/types-codec": "^14.3.1",
     "@polkadot/util": "^13.2.3",
     "@polkadot/util-crypto": "^13.2.3",
     "@substrate/calc": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,95 +1044,95 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:14.2.3, @polkadot/api-augment@npm:^14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/api-augment@npm:14.2.3"
+"@polkadot/api-augment@npm:14.3.1, @polkadot/api-augment@npm:^14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/api-augment@npm:14.3.1"
   dependencies:
-    "@polkadot/api-base": "npm:14.2.3"
-    "@polkadot/rpc-augment": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-augment": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/api-base": "npm:14.3.1"
+    "@polkadot/rpc-augment": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-augment": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/7c7bebf13311217e7a8ae8dc4bb1684a58e16790edaa3e8ced5f70a2a3bd4f3050dd364886a0eea768bb49ab446a64b73e1d35a0f7b643e31e616da8706532fb
+  checksum: 10/3f5c00c4ef44f24c02f5c7ef5a19fa28d7539a9e5eef1f9f9b4ca7b815bd7927d6d194ad657d82325110ae886293b64ccfa681938681cf034cf2132ae411ce7b
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/api-base@npm:14.2.3"
+"@polkadot/api-base@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/api-base@npm:14.3.1"
   dependencies:
-    "@polkadot/rpc-core": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/rpc-core": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/bda2df6b2208feffa1e007dd02cc85f70d21f2b9b5e338fe5623d68e1f1749af9583d0653c33e7bf28d997a0c629450627033a0b6edea4bd6e17964672c22eb5
+  checksum: 10/ce626a7e624e1906cc7c922f5261e9bf52dd8b2a1b0964b83c176354cda1aebae1898d8b5a7e4306cdccf734e9a5eee6a13ca1c9d940d77513bce270f423effa
   languageName: node
   linkType: hard
 
-"@polkadot/api-contract@npm:^14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/api-contract@npm:14.2.3"
+"@polkadot/api-contract@npm:^14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/api-contract@npm:14.3.1"
   dependencies:
-    "@polkadot/api": "npm:14.2.3"
-    "@polkadot/api-augment": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/types-create": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
-    "@polkadot/util-crypto": "npm:^13.2.2"
+    "@polkadot/api": "npm:14.3.1"
+    "@polkadot/api-augment": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/types-create": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
+    "@polkadot/util-crypto": "npm:^13.2.3"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/033b6580981b44d39a87dc14c32621c7a41d6b8916b19ee90a23187f6d4ca46d85befbbbc3706229b41f44ce8153045455873f4f4c309beced1d7c4da9000d87
+  checksum: 10/511ab325b3834dca2b2f56330a91d0bdc2df55c8947b8d44ba4ace394a110f260df280e4beeb76b682e669629694523251b3f658a50aa1649e73938584566d04
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/api-derive@npm:14.2.3"
+"@polkadot/api-derive@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/api-derive@npm:14.3.1"
   dependencies:
-    "@polkadot/api": "npm:14.2.3"
-    "@polkadot/api-augment": "npm:14.2.3"
-    "@polkadot/api-base": "npm:14.2.3"
-    "@polkadot/rpc-core": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
-    "@polkadot/util-crypto": "npm:^13.2.2"
+    "@polkadot/api": "npm:14.3.1"
+    "@polkadot/api-augment": "npm:14.3.1"
+    "@polkadot/api-base": "npm:14.3.1"
+    "@polkadot/rpc-core": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
+    "@polkadot/util-crypto": "npm:^13.2.3"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/a788cd64d24015ad6beba1e024230a21460ecd4fdb2946b0dc128b7c17aa1c43c9523ca9e080aef8cfd16e86ef88dc4c6c70a722ae1107ac0bcd89a60cd1cbc8
+  checksum: 10/18201342ff4f7b42994a2d2d796ae8d7b0cdf4d6f022ed9359d3c95f299ff7f2175eaf31c358ce411eb51d0ad090977d131974f6094ec49e8e145fc5771f1f76
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:14.2.3, @polkadot/api@npm:^14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/api@npm:14.2.3"
+"@polkadot/api@npm:14.3.1, @polkadot/api@npm:^14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/api@npm:14.3.1"
   dependencies:
-    "@polkadot/api-augment": "npm:14.2.3"
-    "@polkadot/api-base": "npm:14.2.3"
-    "@polkadot/api-derive": "npm:14.2.3"
-    "@polkadot/keyring": "npm:^13.2.2"
-    "@polkadot/rpc-augment": "npm:14.2.3"
-    "@polkadot/rpc-core": "npm:14.2.3"
-    "@polkadot/rpc-provider": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-augment": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/types-create": "npm:14.2.3"
-    "@polkadot/types-known": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
-    "@polkadot/util-crypto": "npm:^13.2.2"
+    "@polkadot/api-augment": "npm:14.3.1"
+    "@polkadot/api-base": "npm:14.3.1"
+    "@polkadot/api-derive": "npm:14.3.1"
+    "@polkadot/keyring": "npm:^13.2.3"
+    "@polkadot/rpc-augment": "npm:14.3.1"
+    "@polkadot/rpc-core": "npm:14.3.1"
+    "@polkadot/rpc-provider": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-augment": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/types-create": "npm:14.3.1"
+    "@polkadot/types-known": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
+    "@polkadot/util-crypto": "npm:^13.2.3"
     eventemitter3: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/99738ac9af51465f1fbc017c187eb29a5a8bdea88ba335dfd9e98927dfa20503383a9abe5e073165c2d443d4e153e0f9d0b09642a19ed71fe723b1ea247ea473
+  checksum: 10/560a9a5735820474542010c0102e3f43910d797918e37101dbb601c4363efba715d90cb29d609a9703b69559e8b0542d7103493b07c8090d67cc036da6ce6f40
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^13.2.2":
+"@polkadot/keyring@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/keyring@npm:13.2.3"
   dependencies:
@@ -1146,7 +1146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:13.2.3, @polkadot/networks@npm:^13.2.2":
+"@polkadot/networks@npm:13.2.3, @polkadot/networks@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/networks@npm:13.2.3"
   dependencies:
@@ -1157,45 +1157,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/rpc-augment@npm:14.2.3"
+"@polkadot/rpc-augment@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/rpc-augment@npm:14.3.1"
   dependencies:
-    "@polkadot/rpc-core": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/rpc-core": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/c2f37cd28578147a27424f7ef81c11afca8ab2b81aaddad5047c1445d1ca389047edf5c1d41e9b7b8d5ebc32062eff7f5b6863f10abb5355d38031d841c4d293
+  checksum: 10/71743f3aa3f7ed57d17149e7bc2d4892bd0df7b2e9b8f4922d0edb8e5944774c142b478158b16c2a1dad2d3f34db5eff0c042a53a3ce16498d25d892456b59e2
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/rpc-core@npm:14.2.3"
+"@polkadot/rpc-core@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/rpc-core@npm:14.3.1"
   dependencies:
-    "@polkadot/rpc-augment": "npm:14.2.3"
-    "@polkadot/rpc-provider": "npm:14.2.3"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/rpc-augment": "npm:14.3.1"
+    "@polkadot/rpc-provider": "npm:14.3.1"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/56e96c2ad714c70361b2d5fd2e7f38e5653ba545966cfa23d82750b26c3585a790175cd18e60178408c1810ee1a9534d38e667d1a4d598f76377d3b9dd7b67eb
+  checksum: 10/1f3d2ac384d26a7c5f24bc276082b852b301889e41acddc8f6c1ad3a7c5b553e06df66603e336d1e8b94fe5b322245d49ad9282eab19b1f7af024edb2f0d4ba1
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/rpc-provider@npm:14.2.3"
+"@polkadot/rpc-provider@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/rpc-provider@npm:14.3.1"
   dependencies:
-    "@polkadot/keyring": "npm:^13.2.2"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-support": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
-    "@polkadot/util-crypto": "npm:^13.2.2"
-    "@polkadot/x-fetch": "npm:^13.2.2"
-    "@polkadot/x-global": "npm:^13.2.2"
-    "@polkadot/x-ws": "npm:^13.2.2"
+    "@polkadot/keyring": "npm:^13.2.3"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-support": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
+    "@polkadot/util-crypto": "npm:^13.2.3"
+    "@polkadot/x-fetch": "npm:^13.2.3"
+    "@polkadot/x-global": "npm:^13.2.3"
+    "@polkadot/x-ws": "npm:^13.2.3"
     "@substrate/connect": "npm:0.8.11"
     eventemitter3: "npm:^5.0.1"
     mock-socket: "npm:^9.3.1"
@@ -1204,85 +1204,85 @@ __metadata:
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: 10/3f1be813a62ef271eddff4d5d7aa680f40d90c43b6ba60cb7296ccae0ad1ca3c9508fa90c933f5859676903efd4d3f1c366b72dde7c7033afec561972a5958d8
+  checksum: 10/3a9b3040cd15f58efeb65bd0789199e0b169e1babf9625ef0516b8fd9fbf37d3dc8cc61619be83019e27986278ecc3b8fc4084fbb8249e6643d5eadf42705dd7
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/types-augment@npm:14.2.3"
+"@polkadot/types-augment@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/types-augment@npm:14.3.1"
   dependencies:
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/7a3bb4945356e1a49f1b69042fcdb9b81b02cb60b521f5b89c79e484cf2808492bbc46d7e6b1f5703a9763d9c5fa0460819dcbe8a5e78056e07e9cb20b8e7dd9
+  checksum: 10/a8636b993732da426f992f6383d803ce31a2a92244dce3fdc033d1fb2e2d29259f0690a5a5e3d5b92ffe21aaae39343280b5c9d7153659f3b92672669140d644
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:14.2.3, @polkadot/types-codec@npm:^14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/types-codec@npm:14.2.3"
+"@polkadot/types-codec@npm:14.3.1, @polkadot/types-codec@npm:^14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/types-codec@npm:14.3.1"
   dependencies:
-    "@polkadot/util": "npm:^13.2.2"
-    "@polkadot/x-bigint": "npm:^13.2.2"
+    "@polkadot/util": "npm:^13.2.3"
+    "@polkadot/x-bigint": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/6bc9ae7f221e918f9f1d69feb4339f2995e485a89ab6748d1902c257dcef6a12a615050af841b9e5201bd497c90b86774fdc97990c61635efcd04135a22c8109
+  checksum: 10/2b3131fa5e4c5ecc8d06dc2cd7bf061aed20e093ac2426629b7f7872fbb9579fb0277260c12192b856d59dae3e1733efde7e9cbbd4fc89548d9fdcc35bca9e85
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/types-create@npm:14.2.3"
+"@polkadot/types-create@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/types-create@npm:14.3.1"
   dependencies:
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/6e5cdc55680ebb69c3f9e879f5d62d1beccd42a8d5455872870b03e9091909835110f9499cebeb332cb46519ca8435732f8faededf360d79794c3c80b1d2d0ca
+  checksum: 10/bdf89b24382f90722f853c636023c9963f8c22ddf2e4c0dcc98ec4876a6c0094d666d283a900aeed67ec5ea1006e81168ef28d8e5c630171f4c4b60b6e1f2faf
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/types-known@npm:14.2.3"
+"@polkadot/types-known@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/types-known@npm:14.3.1"
   dependencies:
-    "@polkadot/networks": "npm:^13.2.2"
-    "@polkadot/types": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/types-create": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/networks": "npm:^13.2.3"
+    "@polkadot/types": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/types-create": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/c54dc15315c6ccc7cdfea4b859fd98338e0021f7be17a6788712e533ada2349be138b0f8861d8408655d8ef9fe4cb70fa0c4103fad46580370b579ec985314d6
+  checksum: 10/7923bcc5e9d2c412edfe68360e19b7d83b50015d87b7db19664cee24afe998ffb968573ba1698b975b9f1e5e46f7cfac0c83b09f8b77c2b3cf88637f1858f0ba
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/types-support@npm:14.2.3"
+"@polkadot/types-support@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/types-support@npm:14.3.1"
   dependencies:
-    "@polkadot/util": "npm:^13.2.2"
+    "@polkadot/util": "npm:^13.2.3"
     tslib: "npm:^2.8.0"
-  checksum: 10/f3c50a768b8fefa0d93034852f77fdb5d6180318958943dcc1d0be7b8d9a29a90e968fdeb15cdc855a7cfef7bd6523c4bd89bf79569b572fc730280310b8fbab
+  checksum: 10/a8dbb853f275b5ff2df08faba7f5bb858f0e9d2ebbe90daa0ca8e8e161b0a23c26e36c32ce0efbe62b26ce0627dd117d612da8c259f1c3ee089c499d1acef054
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:14.2.3, @polkadot/types@npm:^14.2.3":
-  version: 14.2.3
-  resolution: "@polkadot/types@npm:14.2.3"
+"@polkadot/types@npm:14.3.1, @polkadot/types@npm:^14.3.1":
+  version: 14.3.1
+  resolution: "@polkadot/types@npm:14.3.1"
   dependencies:
-    "@polkadot/keyring": "npm:^13.2.2"
-    "@polkadot/types-augment": "npm:14.2.3"
-    "@polkadot/types-codec": "npm:14.2.3"
-    "@polkadot/types-create": "npm:14.2.3"
-    "@polkadot/util": "npm:^13.2.2"
-    "@polkadot/util-crypto": "npm:^13.2.2"
+    "@polkadot/keyring": "npm:^13.2.3"
+    "@polkadot/types-augment": "npm:14.3.1"
+    "@polkadot/types-codec": "npm:14.3.1"
+    "@polkadot/types-create": "npm:14.3.1"
+    "@polkadot/util": "npm:^13.2.3"
+    "@polkadot/util-crypto": "npm:^13.2.3"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.8.0"
-  checksum: 10/96ee678bbea707c2bce674c7489b1598ea22ce3315994c7807482c3d032bf747f96f5a4cd229196398b80a901cdd0039dd62dcd171012f5751ab9f1a9c186b45
+  checksum: 10/6c3822a7d07576f2bd215eade91d8470fd2ce61b17902ac7d18d1c6ae4a8874a184b897af4788f3ee8ef7e224ddd1c51d08b6c4bf604a224d9ca556b44130f06
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:13.2.3, @polkadot/util-crypto@npm:^13.2.2, @polkadot/util-crypto@npm:^13.2.3":
+"@polkadot/util-crypto@npm:13.2.3, @polkadot/util-crypto@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/util-crypto@npm:13.2.3"
   dependencies:
@@ -1302,7 +1302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:13.2.3, @polkadot/util@npm:^13.2.2, @polkadot/util@npm:^13.2.3":
+"@polkadot/util@npm:13.2.3, @polkadot/util@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/util@npm:13.2.3"
   dependencies:
@@ -1397,7 +1397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:13.2.3, @polkadot/x-bigint@npm:^13.2.2":
+"@polkadot/x-bigint@npm:13.2.3, @polkadot/x-bigint@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/x-bigint@npm:13.2.3"
   dependencies:
@@ -1407,7 +1407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^13.2.2":
+"@polkadot/x-fetch@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/x-fetch@npm:13.2.3"
   dependencies:
@@ -1418,7 +1418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:13.2.3, @polkadot/x-global@npm:^13.2.2":
+"@polkadot/x-global@npm:13.2.3, @polkadot/x-global@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/x-global@npm:13.2.3"
   dependencies:
@@ -1460,7 +1460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^13.2.2":
+"@polkadot/x-ws@npm:^13.2.3":
   version: 13.2.3
   resolution: "@polkadot/x-ws@npm:13.2.3"
   dependencies:
@@ -1580,11 +1580,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/api-sidecar@workspace:."
   dependencies:
-    "@polkadot/api": "npm:^14.2.3"
-    "@polkadot/api-augment": "npm:^14.2.3"
-    "@polkadot/api-contract": "npm:^14.2.3"
-    "@polkadot/types": "npm:^14.2.3"
-    "@polkadot/types-codec": "npm:^14.2.3"
+    "@polkadot/api": "npm:^14.3.1"
+    "@polkadot/api-augment": "npm:^14.3.1"
+    "@polkadot/api-contract": "npm:^14.3.1"
+    "@polkadot/types": "npm:^14.3.1"
+    "@polkadot/types-codec": "npm:^14.3.1"
     "@polkadot/util": "npm:^13.2.3"
     "@polkadot/util-crypto": "npm:^13.2.3"
     "@substrate/calc": "npm:^0.3.1"
@@ -4889,20 +4889,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"logform@npm:^2.6.1":
-  version: 2.6.1
-  resolution: "logform@npm:2.6.1"
-  dependencies:
-    "@colors/colors": "npm:1.6.0"
-    "@types/triple-beam": "npm:^1.3.2"
-    fecha: "npm:^4.2.0"
-    ms: "npm:^2.1.1"
-    safe-stable-stringify: "npm:^2.3.1"
-    triple-beam: "npm:^1.3.0"
-  checksum: 10/e67f414787fbfe1e6a997f4c84300c7e06bee3d0bd579778af667e24b36db3ea200ed195d41b61311ff738dab7faabc615a07b174b22fe69e0b2f39e985be64b
-  languageName: node
-  linkType: hard
-
 "logform@npm:^2.7.0":
   version: 2.7.0
   resolution: "logform@npm:2.7.0"
@@ -6818,18 +6804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston-transport@npm:^4.3.0":
-  version: 4.7.1
-  resolution: "winston-transport@npm:4.7.1"
-  dependencies:
-    logform: "npm:^2.6.1"
-    readable-stream: "npm:^3.6.2"
-    triple-beam: "npm:^1.3.0"
-  checksum: 10/bc48c921ec9b4a71c1445bf274aa6b00c01089a6c26fc0b19534f8a32fa2710c6766c9e6db53a23492c20772934025d312dd9fb08df157ccb6579ad6b9dae9a7
-  languageName: node
-  linkType: hard
-
-"winston-transport@npm:^4.9.0":
+"winston-transport@npm:^4.3.0, winston-transport@npm:^4.9.0":
   version: 4.9.0
   resolution: "winston-transport@npm:4.9.0"
   dependencies:


### PR DESCRIPTION
### Description
Updated pjs deps from [v14.2.3](https://github.com/polkadot-js/api/releases/tag/v14.2.3) to [v14.3.1](https://github.com/polkadot-js/api/releases/tag/v14.3.1) : 
- `@polkadot/api`
- `@polkadot/api-augment`
- `@polkadot/api-contract`
- `@polkadot/types`
- `@polkadot/types-codec`