### PR TITLE
fix: claimed in staking payout endpoint

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.spec.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.spec.ts
@@ -93,7 +93,7 @@ describe('AccountsStakingPayoutsService', () => {
 						era: '1039',
 						payouts: [
 							{
-								claimed: true,
+								claimed: 'claimed',
 								nominatorExposure: '0',
 								nominatorStakingPayout: '1043968334900993560134832959396203124',
 								totalValidatorExposure: '17302617747768368',
@@ -129,7 +129,7 @@ describe('AccountsStakingPayoutsService', () => {
 						era: '1039',
 						payouts: [
 							{
-								claimed: true,
+								claimed: 'claimed',
 								nominatorExposure: '21133134966048676',
 								nominatorStakingPayout: '0',
 								totalValidatorExposure: '21133134966048676',

--- a/src/types/responses/AccountStakingPayouts.ts
+++ b/src/types/responses/AccountStakingPayouts.ts
@@ -16,6 +16,17 @@
 
 import { IAt, IEraPayouts } from '.';
 
+export enum IStatus {
+	claimed = 'claimed',
+	partiallyClaimed = 'partially claimed',
+	unclaimed = 'unclaimed',
+	undefined = 'undefined',
+}
+
+export interface IStatusPerEra {
+	[era: number]: IStatus;
+}
+
 export interface IAccountStakingPayouts {
 	at: IAt;
 	erasPayouts: (IEraPayouts | { message: string })[];

--- a/src/types/responses/Payout.ts
+++ b/src/types/responses/Payout.ts
@@ -16,10 +16,12 @@
 
 import { Balance, Perbill, RewardPoint } from '@polkadot/types/interfaces';
 
+import { IStatus } from './AccountStakingPayouts';
+
 export interface IPayout {
 	validatorId: string;
 	nominatorStakingPayout: string;
-	claimed: boolean;
+	claimed: IStatus;
 	validatorCommission: Perbill;
 	totalValidatorRewardPoints: RewardPoint;
 	totalValidatorExposure: Balance;


### PR DESCRIPTION
### Description
New PR that is replacing the following quite old & outdated PRs : 
- https://github.com/paritytech/substrate-api-sidecar/pull/1436
- https://github.com/paritytech/substrate-api-sidecar/pull/1457

All changes in the current PR should be aligned with the changes merged & final logic implemented in the https://github.com/paritytech/substrate-api-sidecar/pull/1445 PR of the `staking-info` endpoint. In the 1445 PR, two very useful guides were added to explain the finalized logic for the field `claimed`: 
1. the [hackMD](https://hackmd.io/@LwMsxe3-SFmNXxugAXOKgg/ryPwFoezyl): "_Staking PR - claimed field - Guide_".
1. the [README](https://github.com/paritytech/substrate-api-sidecar/pull/1445/files): "_STAKING_IMPLEMENTATION_DETAILS.md_". 

which can be helpful here too.

### Changes
- Renamed `fetchCommissionAndLedger` to `fetchCommissionLedgerAndClaimed` because it now also returns `claimedRewards`.
- The logic for `claimedRewards` is based on this [PR](https://github.com/paritytech/substrate-api-sidecar/pull/1445) for the `staking-info` endpoint.
- The `claimed` field returned from `staking-payouts` is no longer a boolean value; It now has different statuses.
- A status called `undefined` was added which means that with the current information, we cannot determine if the rewards of the era were claimed, unclaimed or partially claimed.
	- an example is the case when the only available info is `lastReward` and it is null, then `claimed` is set to `undefined`
- With the old code, if none of the checks/properties/calls could define the `claimed`field, we would `continue`/skip that era and do not return any info about that era. Now we don't, we just set the claimed field as `undefined`.
- Some of the logic was moved from function `deriveEraPayouts` to `fetchCommissionAndLedger`.
- The case `era < 518` && chain is Kusama is still working as expected. The era in this case is "automatically" considered as `claimed`.

### Testing
- Tested cases claimed and unclaimed
- Tested for era < 518 in Kusama chain 
- Tested a case where lastReward is available and it is null
- Updated the existing tests
- I did **not** test a case with a `partially claimed` era

### Todos
- [x] Minor adjustment for query param `unclaimedOnly` to work with the new statuses.
- [ ] Review all the latest changes from https://github.com/paritytech/substrate-api-sidecar/pull/1445 and make sure that is all implemented in this endpoint
- [ ] Test with validator and nominator accounts.
- [ ] Update docs.

