### PR TITLE
fix: benchmark-publish job (github action)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,7 +55,10 @@ jobs:
           name: benchmarks
           path: artifacts
 
-      - name: Modify benches result for benhcmark action
+      - name: Make script executable
+        run: chmod +x ./scripts/ci/benchmarks/generate_benchmark_result.sh
+
+      - name: Modify benches result for benchmark action
         run: ./scripts/ci/benchmarks/generate_benchmark_result.sh artifacts/benchmarks.txt > artifacts/benchmarks.json
 
       - name: Store benchmark result


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1584

This PR adds a step in the `Benchmark` workflow that makes `generate_benchmark_result` script executable. This change aims to resolve the `Permission denied` error described in the linked issue.