### PR TITLE
feat: add `includeClaimedRewards` query param in staking-info

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -435,6 +435,15 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: includeClaimedRewards
+        in: query
+        description:  When set to `false`, the `claimedRewards` field is not included
+          in the response.
+        required: false
+        schema:
+          type: string
+          format: boolean
+          default: true
       responses:
         "200":
           description: successful operation

--- a/src/controllers/accounts/AccountsStakingInfoController.ts
+++ b/src/controllers/accounts/AccountsStakingInfoController.ts
@@ -18,7 +18,7 @@ import { ApiPromise } from '@polkadot/api';
 import { RequestHandler } from 'express';
 import { IAddressParam } from 'src/types/requests';
 
-import { validateAddress } from '../../middleware';
+import { validateAddress, validateBoolean } from '../../middleware';
 import { AccountsStakingInfoService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -31,6 +31,12 @@ import AbstractController from '../AbstractController';
  * Query:
  * - (Optional)`at`: Block at which to retrieve runtime version information at. Block
  * 		identifier, as the block height or block hash. Defaults to most recent block.
+ * - (Optional) `includeClaimedRewards`: Controls whether or not the `claimedRewards`
+ * 		field is included in the response. Defaults to `true`.
+ * 		If set to `false`:
+ * 		- the field `claimedRewards` will be omitted from the response and
+ * 		- all internal calculations for claimed rewards in `AccountsStakingInfoService`
+ * 		  will be skipped, potentially speeding up the response time.
  *
  * Returns:
  * - `at`: Block number and hash at which the call was made.
@@ -70,7 +76,7 @@ export default class AccountsStakingInfoController extends AbstractController<Ac
 	}
 
 	protected initRoutes(): void {
-		this.router.use(this.path, validateAddress);
+		this.router.use(this.path, validateAddress, validateBoolean(['includeClaimedRewards']));
 
 		this.safeMountAsyncGetHandlers([['', this.getAccountStakingInfo]]);
 	}
@@ -82,11 +88,14 @@ export default class AccountsStakingInfoController extends AbstractController<Ac
 	 * @param res Express Response
 	 */
 	private getAccountStakingInfo: RequestHandler<IAddressParam> = async (
-		{ params: { address }, query: { at } },
+		{ params: { address }, query: { at, includeClaimedRewards } },
 		res,
 	): Promise<void> => {
 		const hash = await this.getHashFromAt(at);
-
-		AccountsStakingInfoController.sanitizedSend(res, await this.service.fetchAccountStakingInfo(hash, address));
+		const includeClaimedRewardsArg = includeClaimedRewards !== 'false';
+		AccountsStakingInfoController.sanitizedSend(
+			res,
+			await this.service.fetchAccountStakingInfo(hash, includeClaimedRewardsArg, address),
+		);
 	};
 }

--- a/src/services/accounts/AccountsStakingInfoService.spec.ts
+++ b/src/services/accounts/AccountsStakingInfoService.spec.ts
@@ -227,7 +227,7 @@ describe('AccountsStakingInfoService', () => {
 	describe('fetchAccountStakingInfo', () => {
 		it('works with a valid stash address (block 789629)', async () => {
 			expect(
-				sanitizeNumbers(await accountStakingInfoService.fetchAccountStakingInfo(blockHash789629, testAddress)),
+				sanitizeNumbers(await accountStakingInfoService.fetchAccountStakingInfo(blockHash789629, true, testAddress)),
 			).toStrictEqual(response789629);
 		});
 
@@ -236,7 +236,7 @@ describe('AccountsStakingInfoService', () => {
 				Promise.resolve().then(() => polkadotRegistry.createType('Option<AccountId>', null));
 
 			await expect(
-				accountStakingInfoService.fetchAccountStakingInfo(blockHash789629, 'NotStash'),
+				accountStakingInfoService.fetchAccountStakingInfo(blockHash789629, true, 'NotStash'),
 			).rejects.toStrictEqual(new BadRequest('The address NotStash is not a stash address.'));
 
 			(historicApi.query.staking.bonded as any) = bondedAt;
@@ -247,7 +247,7 @@ describe('AccountsStakingInfoService', () => {
 				Promise.resolve().then(() => polkadotRegistry.createType('Option<StakingLedger>', null));
 
 			await expect(
-				accountStakingInfoService.fetchAccountStakingInfo(blockHash789629, testAddress),
+				accountStakingInfoService.fetchAccountStakingInfo(blockHash789629, true, testAddress),
 			).rejects.toStrictEqual(
 				new InternalServerError(
 					`Staking ledger could not be found for controller address "${testAddressController.toString()}"`,
@@ -260,7 +260,7 @@ describe('AccountsStakingInfoService', () => {
 		it('works with a valid stash account (block 22939322) and returns eras claimed that include era 6514 (when the migration occurred in Kusama)', async () => {
 			expect(
 				sanitizeNumbers(
-					await accountStakingInfoService22939322.fetchAccountStakingInfo(blockHash22939322, testAddressKusama),
+					await accountStakingInfoService22939322.fetchAccountStakingInfo(blockHash22939322, true, testAddressKusama),
 				),
 			).toStrictEqual(response22939322);
 		});
@@ -268,7 +268,11 @@ describe('AccountsStakingInfoService', () => {
 		it('works with a validator account (block 21157800) & returns an array of claimed (including case erasStakersOverview=null & erasStakers>0, era 1419), partially claimed & unclaimed eras (Polkadot)', async () => {
 			expect(
 				sanitizeNumbers(
-					await accountStakingInfoService21157800val.fetchAccountStakingInfo(blockHash21157800, testAddressPolkadot),
+					await accountStakingInfoService21157800val.fetchAccountStakingInfo(
+						blockHash21157800,
+						true,
+						testAddressPolkadot,
+					),
 				),
 			).toStrictEqual(response21157800);
 		});
@@ -277,6 +281,7 @@ describe('AccountsStakingInfoService', () => {
 				sanitizeNumbers(
 					await accountStakingInfoService21157800nom.fetchAccountStakingInfo(
 						blockHash21157800,
+						true,
 						testNominatorAddressPolkadot,
 					),
 				),

--- a/src/services/accounts/AccountsStakingInfoService.spec.ts
+++ b/src/services/accounts/AccountsStakingInfoService.spec.ts
@@ -67,6 +67,7 @@ import response789629 from '../test-helpers/responses/accounts/stakingInfo789629
 import response21157800 from '../test-helpers/responses/accounts/stakingInfo21157800.json';
 import response21157800nominator from '../test-helpers/responses/accounts/stakingInfo21157800nominator.json';
 import response22939322 from '../test-helpers/responses/accounts/stakingInfo22939322.json';
+import stakingInfo22939322ClaimedFalse from '../test-helpers/responses/accounts/stakingInfo22939322ClaimedFalse.json';
 import { AccountsStakingInfoService } from './AccountsStakingInfoService';
 
 export const bondedAt = (_hash: Hash, _address: string): Promise<Option<AccountId>> =>
@@ -255,6 +256,14 @@ describe('AccountsStakingInfoService', () => {
 			);
 
 			(historicApi.query.staking.ledger as any) = ledgerAt;
+		});
+
+		it('works when `includeClaimedRewards` is set to `false` hence claimedRewards field is not returned in the response', async () => {
+			expect(
+				sanitizeNumbers(
+					await accountStakingInfoService22939322.fetchAccountStakingInfo(blockHash22939322, false, testAddressKusama),
+				),
+			).toStrictEqual(stakingInfo22939322ClaimedFalse);
 		});
 
 		it('works with a valid stash account (block 22939322) and returns eras claimed that include era 6514 (when the migration occurred in Kusama)', async () => {

--- a/src/services/test-helpers/responses/accounts/stakingInfo22939322ClaimedFalse.json
+++ b/src/services/test-helpers/responses/accounts/stakingInfo22939322ClaimedFalse.json
@@ -1,0 +1,18 @@
+{
+  "at": {
+    "hash": "0x1ef674fffb042c9016987e0e3995a36401a7e2b66e0b6c0bb111a0b049857098",
+    "height": "22939322"
+  },
+  "controller": "F2VckTExmProzJnwNaN3YVqDoBPS1LyNVmyG8HUAygtDV3T",
+  "rewardDestination": {
+    "account": "GLEJRAEdGxLhNEH2AWAtjhUYVrcRWxbYSemvVv2JwxBG2fg"
+  },
+  "numSlashingSpans": "3",
+  "nominations": null,
+  "staking": {
+    "stash": "F2VckTExmProzJnwNaN3YVqDoBPS1LyNVmyG8HUAygtDV3T",
+    "total": "5340420989561",
+    "active": "5340420989561",
+    "unlocking": []
+  }
+}


### PR DESCRIPTION
### Description
This PR adds the `includeClaimedRewards` query param in the endpoint `/accounts/{accountId}/staking-info`. When set to `false`:
 - the field `claimedRewards` will be omitted from the response and
 - all internal calculations for claimed rewards in `AccountsStakingInfoService` will be skipped, potentially speeding up the response time. 

Defaults to `true` so it does not break the current functionality of the endpoint.

### Motivation
An exchange reported significantly long response times for the endpoint `/accounts/{accountId}/staking-info` after the release of [v20.0.0](https://github.com/paritytech/substrate-api-sidecar/releases/tag/v20.0.0). This is most likely due to the breaking changes introduced to this endpoint (calculation of `claimedRewards` changed). To address this, a new flag/query parameter has been added to improve performance when the `claimedRewards` data is not required, speeding up the response time.