### PR TITLE
feat: add accounts/compare endpoint

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -617,8 +617,9 @@ paths:
       parameters:
       - name: addresses
         in: query
-        description: An array of SS58 addresses. Provide up to 30 addresses using one of these formats
-          '?addresses=...&addresses=...' or '?addresses[]=...&addresses[]=...'.
+        description: An array or a comma separated string of SS58 addresses. Provide up to 30 addresses
+          using one of these formats `?addresses=...&addresses=...` or `?addresses[]=...&addresses[]=...`
+          or `?addresses=...,...`.
         required: true
         schema:
           type: array
@@ -632,7 +633,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccountCompare'
-              responses:
         "400":
           description: Invalid Address
           content:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -615,12 +615,16 @@ paths:
         Equality is determined by comparing the accountId/publicKey of each address.
       operationId: accountCompare
       parameters:
-      - name: address{n}
+      - name: addresses
         in: query
-        description: Compares SS58 addresses. Provide up to 30 addresses using the format `?address1=...&address2=...&address3=...`.
+        description: An array of SS58 addresses. Provide up to 30 addresses using one of these formats
+          '?addresses=...&addresses=...' or '?addresses[]=...&addresses[]=...'.
         required: true
         schema:
-          type: string
+          type: array
+          items:
+            type: string
+          description: An array of SS58 addresses.
       responses:
         "200":
           description: successfully compared at least two SS58 addresses.

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -606,6 +606,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccountValidation'
+  /accounts/compare:
+    get:
+      tags:
+      - accounts
+      summary: Compares up to 30 SS58 addresses.
+      description: Returns if the given addresses are equal or not, along with details of each address.
+        Equality is determined by comparing the accountId/publicKey of each address.
+      operationId: accountCompare
+      parameters:
+      - name: address{n}
+        in: query
+        description: Compares SS58 addresses. Provide up to 30 addresses using the format `?address1=...&address2=...&address3=...`.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: successfully compared at least two SS58 addresses.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountCompare'
+              responses:
+        "400":
+          description: Invalid Address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /blocks:
     get:
       tags:
@@ -2744,6 +2773,18 @@ components:
             locks
           items:
             $ref: '#/components/schemas/BalanceLock'
+    AccountCompare:
+      type: object
+      properties:
+        areEqual:
+          type: boolean
+          description: Whether the given SS58 addresses are equal or not. Equality is determined by comparing
+            the accountId/publicKey of each address.
+        addresses:
+          type: array
+          description: An array that contains detailed information for each of the queried SS58 addresses.
+          items:
+            $ref: '#/components/schemas/AddressDetails'
     AccountConvert:
       type: object
       properties:
@@ -2894,6 +2935,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VestingSchedule'
+    AddressDetails:
+      type: object
+      properties:
+        ss58Format:
+            type: string
+            description: The queried SS58 address.
+        ss58Prefix:
+          type: string
+          description: SS58 prefix of the given address.
+          format: unsignedInteger
+        network:
+          type: string
+          description: The network based on which the given address is encoded.
+        publicKey:
+          type: string
+          description: The account ID/Public Key (hex) of the queried SS58 address.
     AssetsBalance:
       type: object
       properties:

--- a/src/chains-config/assetHubKusamaControllers.ts
+++ b/src/chains-config/assetHubKusamaControllers.ts
@@ -24,6 +24,7 @@ export const assetHubKusamaControllers: ControllerConfig = {
 	controllers: [
 		'AccountsAssets',
 		'AccountsBalanceInfo',
+		'AccountsCompare',
 		'AccountsValidate',
 		'Blocks',
 		'BlocksExtrinsics',

--- a/src/chains-config/assetHubPolkadotControllers.ts
+++ b/src/chains-config/assetHubPolkadotControllers.ts
@@ -24,6 +24,7 @@ export const assetHubPolkadotControllers: ControllerConfig = {
 	controllers: [
 		'AccountsAssets',
 		'AccountsBalanceInfo',
+		'AccountsCompare',
 		'AccountsProxyInfo',
 		'AccountsValidate',
 		'Blocks',

--- a/src/chains-config/assetHubWestendControllers.ts
+++ b/src/chains-config/assetHubWestendControllers.ts
@@ -24,6 +24,7 @@ export const assetHubWestendControllers: ControllerConfig = {
 	controllers: [
 		'AccountsAssets',
 		'AccountsBalanceInfo',
+		'AccountsCompare',
 		'AccountsProxyInfo',
 		'AccountsPoolAssets',
 		'AccountsValidate',

--- a/src/chains-config/kusamaControllers.ts
+++ b/src/chains-config/kusamaControllers.ts
@@ -23,6 +23,7 @@ import { initLRUCache, QueryFeeDetailsCache } from './cache';
 export const kusamaControllers: ControllerConfig = {
 	controllers: [
 		'AccountsBalanceInfo',
+		'AccountsCompare',
 		'AccountsConvert',
 		'AccountsProxyInfo',
 		'AccountsStakingInfo',

--- a/src/chains-config/polkadotControllers.ts
+++ b/src/chains-config/polkadotControllers.ts
@@ -23,6 +23,7 @@ import { initLRUCache, QueryFeeDetailsCache } from './cache';
 export const polkadotControllers: ControllerConfig = {
 	controllers: [
 		'AccountsBalanceInfo',
+		'AccountsCompare',
 		'AccountsConvert',
 		'AccountsProxyInfo',
 		'AccountsStakingInfo',

--- a/src/chains-config/westendControllers.ts
+++ b/src/chains-config/westendControllers.ts
@@ -23,6 +23,7 @@ import { initLRUCache, QueryFeeDetailsCache } from './cache';
 export const westendControllers: ControllerConfig = {
 	controllers: [
 		'AccountsBalanceInfo',
+		'AccountsCompare',
 		'AccountsConvert',
 		'AccountsProxyInfo',
 		'AccountsStakingInfo',

--- a/src/controllers/accounts/AccountsCompareController.ts
+++ b/src/controllers/accounts/AccountsCompareController.ts
@@ -1,0 +1,75 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { ApiPromise } from '@polkadot/api';
+import { RequestHandler } from 'express';
+import { BadRequest } from 'http-errors';
+
+import { validateAddressQueryParam } from '../../middleware';
+import { AccountsCompareService } from '../../services/accounts';
+import { ICompareQueryParams } from '../../types/requests';
+import AbstractController from '../AbstractController';
+
+export default class AccountsCompareController extends AbstractController<AccountsCompareService> {
+	constructor(api: ApiPromise) {
+		super(api, '/accounts/compare', new AccountsCompareService(api));
+		this.initRoutes();
+	}
+
+	protected initRoutes(): void {
+		this.router.use(this.path, validateAddressQueryParam);
+		this.safeMountAsyncGetHandlers([['', this.accountCompare]]);
+	}
+
+	private accountCompare: RequestHandler<unknown, unknown, ICompareQueryParams> = ({ query }, res) => {
+		const addressQueryParams = Object.keys(query);
+
+		// Check that the query parameters are named correctly.
+		const invalidParams = addressQueryParams.filter((key) => !/^address\d+$/.test(key));
+		if (invalidParams.length > 0) {
+			throw new BadRequest(
+				`Invalid query parameter found: ${invalidParams.join(', ')}. Address parameters should be provided as query parameters with names such as address1, address2, address3, and so on.`,
+			);
+		}
+
+		// Check that at least two addresses are provided.
+		if (addressQueryParams.length === 0 || addressQueryParams.length === 1) {
+			throw new BadRequest(
+				`At least two addresses are required for comparison. Address parameters should be provided as query parameters with names such as address1, address2, address3, and so on.`,
+			);
+		}
+
+		// Check that the number of addresses is less than 30.
+		if (addressQueryParams.length > 30) {
+			throw new BadRequest(
+				`Please limit the amount of address parameters to 30. Address parameters should be provided as query parameters with names such as address1, address2, address3, and so on.`,
+			);
+		}
+
+		// Check for duplicate names of query params. If there is an array in the query params, it means that the user has provided multiple values for the same key (duplicate name of a query parameter).
+		const hasArrays = Object.values(query).some((value) => Array.isArray(value));
+		if (hasArrays) {
+			const duplicateQueryParam = Object.keys(query).filter((key) => Array.isArray(query[key]));
+			throw new BadRequest(
+				`Duplicate query parameters found: ${duplicateQueryParam.join(', ')}. Address parameters should be provided as query parameters with names such as address1, address2, address3, and so on.`,
+			);
+		}
+
+		const addresses = Object.keys(query).map((key) => query[key]);
+
+		AccountsCompareController.sanitizedSend(res, this.service.accountCompare(addresses as string[]));
+	};
+}

--- a/src/controllers/accounts/AccountsCompareController.ts
+++ b/src/controllers/accounts/AccountsCompareController.ts
@@ -35,24 +35,15 @@ export default class AccountsCompareController extends AbstractController<Accoun
 	}
 
 	private accountCompare: RequestHandler<unknown, unknown, ICompareQueryParams> = ({ query: { addresses } }, res) => {
-		if (!Array.isArray(addresses)) {
-			throw new BadRequest(
-				`Please provide the addresses as an array query parameter. You can use one of these formats: '?addresses=...&addresses=...' or '?addresses[]=...&addresses[]=...'`,
-			);
-		}
-
-		const addressesArray = Array.isArray(addresses) ? (addresses as string[]) : [];
-
-		// Check that at least two addresses are provided.
-		if (addressesArray.length <= 1) {
-			throw new BadRequest(`At least two addresses are required for comparison.`);
-		}
+		const addressesArray = Array.isArray(addresses)
+			? (addresses as string[] | string)
+			: (addresses as string).split(',');
 
 		// Check that the number of addresses is less than 30.
 		if (addressesArray.length > 30) {
 			throw new BadRequest(`Please limit the amount of address parameters to 30.`);
 		}
 
-		AccountsCompareController.sanitizedSend(res, this.service.accountCompare(addresses as string[]));
+		AccountsCompareController.sanitizedSend(res, this.service.accountCompare(addressesArray as string[]));
 	};
 }

--- a/src/controllers/accounts/index.ts
+++ b/src/controllers/accounts/index.ts
@@ -16,6 +16,7 @@
 
 export { default as AccountsAssets } from './AccountsAssetsController';
 export { default as AccountsBalanceInfo } from './AccountsBalanceInfoController';
+export { default as AccountsCompare } from './AccountsCompareController';
 export { default as AccountsConvert } from './AccountsConvertController';
 export { default as AccountsPoolAssets } from './AccountsPoolAssetsController';
 export { default as AccountsProxyInfo } from './AccountsProxyInfoController';

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -17,6 +17,7 @@
 import {
 	AccountsAssets,
 	AccountsBalanceInfo,
+	AccountsCompare,
 	AccountsConvert,
 	AccountsPoolAssets,
 	AccountsProxyInfo,
@@ -58,6 +59,7 @@ export const controllers = {
 	BlocksRawExtrinsics,
 	AccountsAssets,
 	AccountsBalanceInfo,
+	AccountsCompare,
 	AccountsConvert,
 	AccountsPoolAssets,
 	AccountsProxyInfo,

--- a/src/middleware/validate/validateAddressMiddleware.ts
+++ b/src/middleware/validate/validateAddressMiddleware.ts
@@ -39,17 +39,47 @@ export const validateAddressMiddleware: RequestHandler = (req, _res, next) => {
 
 /**
  * Express Middleware to validate that an `:address` given as a query parameter is properly formatted.
+ * It also does the following checks:
+ * 	- that the query parameter name is `addresses`.
+ * 	- that the query parameter is given as an array of addresses or a string of comma separated addresses.
+ * 	- validates all addresses found in the query parameter.
  */
 export const validateAddressQueryParamMiddleware: RequestHandler = (req, _res, next) => {
+	// Check that the query parameter name is `addresses`.
+	const queryParamKey = Object.keys(req.query);
+	const validParamKey = queryParamKey.filter((key) => /^addresses$/.test(key));
+
+	if (validParamKey.length != queryParamKey.length || validParamKey.length === 0) {
+		return next(new BadRequest(`Please use the query parameter key 'addresses' to provide the addresses values.`));
+	}
+
 	// Check that the addresses are valid. Same check as in the `validateAddressMiddleware` but for query parameters.
-	const addressQueryParams = Object.keys(req.query);
-	const validAddressParams = addressQueryParams.filter((key) => /^address\d+$/.test(key));
-	for (const param of validAddressParams) {
-		const address = req.query[param];
-		if (typeof address === 'string') {
-			const [isValid, error] = checkAddress(address);
-			if (!isValid && error) {
-				return next(new BadRequest(`Invalid ${param}: ${error}`));
+	for (const param of validParamKey) {
+		const addresses = req.query[param];
+		// Check if the address is a string of comma separated addresses or an array of addresses.
+		if (typeof addresses === 'string') {
+			const addressesArray = addresses.split(',');
+
+			if (addressesArray.length <= 1) {
+				return next(new BadRequest(`At least two addresses are required for comparison.`));
+			}
+
+			for (const address of addressesArray) {
+				const [isValid, error] = checkAddress(address);
+				if (!isValid && error) {
+					return next(new BadRequest(`Invalid ${param}: ${error}`));
+				}
+			}
+		} else if (Array.isArray(addresses)) {
+			if (addresses.length <= 1) {
+				return next(new BadRequest(`At least two addresses are required for comparison.`));
+			}
+
+			for (const address of addresses) {
+				const [isValid, error] = checkAddress(address as string);
+				if (!isValid && error) {
+					return next(new BadRequest(`Invalid ${param}: ${error}`));
+				}
 			}
 		}
 	}

--- a/src/middleware/validate/validateAddressMiddleware.ts
+++ b/src/middleware/validate/validateAddressMiddleware.ts
@@ -38,6 +38,26 @@ export const validateAddressMiddleware: RequestHandler = (req, _res, next) => {
 };
 
 /**
+ * Express Middleware to validate that an `:address` given as a query parameter is properly formatted.
+ */
+export const validateAddressQueryParamMiddleware: RequestHandler = (req, _res, next) => {
+	// Check that the addresses are valid. Same check as in the `validateAddressMiddleware` but for query parameters.
+	const addressQueryParams = Object.keys(req.query);
+	const validAddressParams = addressQueryParams.filter((key) => /^address\d+$/.test(key));
+	for (const param of validAddressParams) {
+		const address = req.query[param];
+		if (typeof address === 'string') {
+			const [isValid, error] = checkAddress(address);
+			if (!isValid && error) {
+				return next(new BadRequest(`Invalid ${param}: ${error}`));
+			}
+		}
+	}
+
+	return next();
+};
+
+/**
  * Verify that an address is a valid substrate address.
  *
  * Note: this is very similar '@polkadot/util-crypto/address/checkAddress,

--- a/src/services/accounts/AccountsCompareService.spec.ts
+++ b/src/services/accounts/AccountsCompareService.spec.ts
@@ -1,0 +1,92 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { ApiPromise } from '@polkadot/api';
+
+import { sanitizeNumbers } from '../../sanitize';
+import { defaultMockApi } from '../test-helpers/mock';
+import { AccountsCompareService } from './AccountsCompareService';
+
+const mockApi = {
+	...defaultMockApi,
+} as unknown as ApiPromise;
+const validateService = new AccountsCompareService(mockApi);
+
+describe('Compare two addresses', () => {
+	it('Should compare the two addresses and return that they are not equal, along with the details of each address.', () => {
+		const expectedResponse = {
+			areEqual: false,
+			addresses: [
+				{
+					ss58Format: '7P9y4pUmp5SJ4gKK3rFw6TvR24eqW7jVoyDs8LPunRYcHuzi',
+					ss58Prefix: '63',
+					network: 'hydradx',
+					publicKey: '0xf5e51345031c9ba63ae27605d028ad959ba7f4eba289fb16368ddfab2788936f',
+				},
+				{
+					ss58Format: '1kFahMfeRf4XJbApbczHczTTioF9NzKBe9D8g5xFw9JAVdE',
+					ss58Prefix: '0',
+					network: 'polkadot',
+					publicKey: '0x20fca2e352c4906760cb18af6a36e42169e489246ed739307e01b4922a5d119f',
+				},
+			],
+		};
+		const address1 = '7P9y4pUmp5SJ4gKK3rFw6TvR24eqW7jVoyDs8LPunRYcHuzi';
+		const address2 = '1kFahMfeRf4XJbApbczHczTTioF9NzKBe9D8g5xFw9JAVdE';
+
+		expect(sanitizeNumbers(validateService.accountCompare([address1, address2]))).toStrictEqual(expectedResponse);
+	});
+
+	it('Should compare the four addresses and return that they are equal, along with the details of each address.', () => {
+		const expectedResponse = {
+			areEqual: true,
+			addresses: [
+				{
+					ss58Format: '1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw',
+					ss58Prefix: '0',
+					network: 'polkadot',
+					publicKey: '0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c',
+				},
+				{
+					ss58Format: 'DJxh51wJYvcY1VhJqhnngRN7SGFZrmH4DuPKFXicFgwMQCT',
+					ss58Prefix: '2',
+					network: 'kusama',
+					publicKey: '0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c',
+				},
+				{
+					ss58Format: 'WfwU3e9TRYo1Bi62SLrvPDe3th8jQeqd3ZnAJTczpUQCNZ8',
+					ss58Prefix: '5',
+					network: 'astar',
+					publicKey: '0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c',
+				},
+				{
+					ss58Format: 'cTbj3BYqiRXAF7YvyDtJHV4hNqRnbHMoz7umz6vTg4tUjCY',
+					ss58Prefix: '6',
+					network: 'bifrost',
+					publicKey: '0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c',
+				},
+			],
+		};
+		const address1 = '1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw';
+		const address2 = 'DJxh51wJYvcY1VhJqhnngRN7SGFZrmH4DuPKFXicFgwMQCT';
+		const address3 = 'WfwU3e9TRYo1Bi62SLrvPDe3th8jQeqd3ZnAJTczpUQCNZ8';
+		const address4 = 'cTbj3BYqiRXAF7YvyDtJHV4hNqRnbHMoz7umz6vTg4tUjCY';
+
+		expect(sanitizeNumbers(validateService.accountCompare([address1, address2, address3, address4]))).toStrictEqual(
+			expectedResponse,
+		);
+	});
+});

--- a/src/services/accounts/AccountsCompareService.ts
+++ b/src/services/accounts/AccountsCompareService.ts
@@ -1,0 +1,54 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { IAccountCompare, IAddressDetails } from '../../types/responses/AccountCompare';
+import { IValidateAddrResponse } from '../../types/responses/ValidateAddress';
+import { AbstractService } from '../AbstractService';
+import { AccountsValidateService } from './AccountsValidateService';
+
+export class AccountsCompareService extends AbstractService {
+	private accountsValidateService = new AccountsValidateService(this.api);
+	/**
+	 * Compares up to 30 SS58 addresses and returns if they are equal or not,
+	 * along with details of each address. Equality is determined by comparing
+	 * the accountId/publicKey of each address.
+	 *
+	 * @param addresses up to 30 SS58 addresses
+	 */
+	public accountCompare(addresses: string[]): IAccountCompare {
+		const addressDetailsArray: IValidateAddrResponse[] = [];
+		for (let i = 0; i < addresses.length; i++) {
+			addressDetailsArray.push(this.accountsValidateService.validateAddress(addresses[i]));
+		}
+
+		const areEqual = addressDetailsArray.every(
+			(address) => address.accountId === (addressDetailsArray[0] as unknown as IValidateAddrResponse).accountId,
+		);
+
+		return {
+			areEqual,
+			addresses: addresses.map((address, index) => {
+				const addressDetails = addressDetailsArray[index];
+				return {
+					ss58Format: address,
+					ss58Prefix: addressDetails.ss58Prefix,
+					network: addressDetails.network,
+					publicKey: addressDetails.accountId,
+				};
+			}) as IAddressDetails[],
+		};
+	}
+}

--- a/src/services/accounts/index.ts
+++ b/src/services/accounts/index.ts
@@ -16,6 +16,7 @@
 
 export * from './AccountsAssetsService';
 export * from './AccountsBalanceInfoService';
+export * from './AccountsCompareService';
 export * from './AccountsConvertService';
 export * from './AccountsPoolAssetsService';
 export * from './AccountsProxyInfoService';

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -94,6 +94,12 @@ export interface IPalletsStorageQueryParam extends Query {
 	metadata: string;
 }
 
+// Only query parameters that start with the keyword "address"
+// followed by a number are allowed.
+export interface ICompareQueryParams extends Query {
+	[key: `address${number}`]: string;
+}
+
 export interface IConvertQueryParams extends Query {
 	scheme: string;
 	prefix: string;

--- a/src/types/responses/AccountCompare.ts
+++ b/src/types/responses/AccountCompare.ts
@@ -14,8 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-export {
-	validateAddressMiddleware as validateAddress,
-	validateAddressQueryParamMiddleware as validateAddressQueryParam,
-} from './validateAddressMiddleware';
-export { validateBooleanMiddleware as validateBoolean } from './validateBooleanMiddleware';
+export interface IAddressDetails {
+	ss58Format: string;
+	ss58Prefix: number | null;
+	network: string | null;
+	publicKey: string | null;
+}
+
+export interface IAccountCompare {
+	areEqual: boolean;
+	addresses: IAddressDetails[];
+}


### PR DESCRIPTION
### Description 
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1591

Adds a new endpoint, `accounts/compare`, that compares up to 30 `SS58` addresses and determines if they are equal which means that they share the same public key. Returns a boolean result along with detailed information for each address queried.

### Implementation Notes
- The request should be follow one of these formats : 
  - by repeating the `addresses` key: `?addresses=...&addresses=...` or
  - by using the array style key: `?addresses[]=...&addresses[]=...` or
  - by using comma-separated values: `?addresses=...,...`.

- The limit of 30 addresses was set to keep the character count of the request at a reasonable size/not too big.
- The additional function `validateAddressQueryParamMiddleware` was added to check that the addresses as query parameters were valid.

### Sample Request/Response
Example request to check 4 SS58 addresses
```
http://127.0.0.1:8080/accounts/compare?addresses[]=1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw&addresses[]=DJxh51wJYvcY1VhJqhnngRN7SGFZrmH4DuPKFXicFgwMQCT&addresses[]=WfwU3e9TRYo1Bi62SLrvPDe3th8jQeqd3ZnAJTczpUQCNZ8&addresses[]=cTbj3BYqiRXAF7YvyDtJHV4hNqRnbHMoz7umz6vTg4tUjCY
```

Example response
```
{
  "areEqual": true,
  "addresses": [
    {
      "ss58Format": "1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw",
      "ss58Prefix": "0",
      "network": "polkadot",
      "publicKey": "0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c"
    },
    {
      "ss58Format": "DJxh51wJYvcY1VhJqhnngRN7SGFZrmH4DuPKFXicFgwMQCT",
      "ss58Prefix": "2",
      "network": "kusama",
      "publicKey": "0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c"
    },
    {
      "ss58Format": "WfwU3e9TRYo1Bi62SLrvPDe3th8jQeqd3ZnAJTczpUQCNZ8",
      "ss58Prefix": "5",
      "network": "astar",
      "publicKey": "0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c"
    },
    {
      "ss58Format": "cTbj3BYqiRXAF7YvyDtJHV4hNqRnbHMoz7umz6vTg4tUjCY",
      "ss58Prefix": "6",
      "network": "bifrost",
      "publicKey": "0x20857206fde63ea508a317a77bc1ca2a795c978533b71fc7bc21d352d832637c"
    }
  ]
}
```

### Additional Tests
Tested for:
- Invalid query param names (address, addressA)
  ```
  http://127.0.0.1:8080/accounts/compare?address=1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw&addressA=DJxh51wJYvcY1VhJqhnngRN7SGFZrmH4DuPKFXicFgwMQCT
  ```
- No query params
  ```
  http://127.0.0.1:8080/accounts/compare
  ```
- 1 query param
   ```
   http://127.0.0.1:8080/accounts/compare?addresses[]=1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw
   ```
- 30 addresses
- `> 30 addresses`
- Use a valid query param key and an invalid one
   ```
    http://127.0.0.1:8080/accounts/compare?addresses[]=1jeB5w8XyBADtgmVmwk2stWpTyfTVWEgLo85tF7gYVxnmSw&addressA=DJxh51wJYvcY1VhJqhnngRN7SGFZrmH4DuPKFXicFgwMQCT
   ```
- Correct query param name but no address value
   ```
   http://127.0.0.1:8080/accounts/compare?addresses[]=
   ```