### PR TITLE
fix: asset-hub-next specName

### DIFF
--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -66,7 +66,7 @@ const specToControllerMap: { [x: string]: ControllerConfig } = {
 	statemint: assetHubPolkadotControllers,
 	westmine: assetHubKusamaControllers,
 	'asset-hub-westend': assetHubWestendControllers,
-	'asset-hub-next-westend': assetHubNextWestendControllers,
+	'asset-hub-next': assetHubNextWestendControllers,
 	westmint: assetHubWestendControllers,
 	shiden: shidenControllers,
 	astar: astarControllers,


### PR DESCRIPTION
### Description
Updating the specName for `Asset-Hub-Next` so that it loads the controllers defined in [assetHubNextWestendControllers.ts](https://github.com/paritytech/substrate-api-sidecar/blob/2c926c786536bfee73b1875909c13d0750284090/src/chains-config/assetHubNextWestendControllers.ts#L23) when connected to `Westend Asset Hub Next` rather than the default ones. 

### Note
This is no blocker since Sidecar is still working with the `defaultControllers` which include the essential Staking and Balance endpoints.

### Testing
Tested with Westend Asset Hub Next endpoint and it is working as expected.
