### PR TITLE
fix: foreign asset multilocation as hex

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -3051,6 +3051,24 @@ components:
           type: boolean
           description: Whether the asset metadata may be changed by a non Force origin. Note, that some runtimes may not have
             support for isFrozen and if so the following will be returned `isFrozen does not exist for this runtime`
+    AssetMultiLocation:
+      oneOf:
+        - $ref: '#/components/schemas/AssetMultiLocationObject'
+        - $ref: '#/components/schemas/AssetMultiLocationHex'
+    AssetMultiLocationObject:
+      type: object
+      properties:
+        parents:
+          type: string
+          format: unsignedInteger
+        interior:
+          type: object
+      description: The multiLocation of the foreign asset as an object.
+      example: "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}"
+    AssetMultiLocationHex:
+      type: string
+      pattern: '^0x[0-9a-fA-F]+$'
+      description: The multiLocation of the foreign asset given as a hexadecimal value.
     BalanceLock:
       type: object
       properties:
@@ -4342,6 +4360,8 @@ components:
     PalletsForeignAssetsInfo:
       type: object
       properties:
+        multiLocation:
+          $ref: '#/components/schemas/AssetMultiLocation'
         foreignAssetInfo:
           $ref: '#/components/schemas/AssetInfo'
         foreignAssetMetadata:

--- a/src/chains-config/assetHubNextWestendControllers.ts
+++ b/src/chains-config/assetHubNextWestendControllers.ts
@@ -42,6 +42,7 @@ export const assetHubNextWestendControllers: ControllerConfig = {
 		'PalletsDispatchables',
 		'PalletsErrors',
 		'PalletsEvents',
+		'PalletsForeignAssets',
 		'PalletsNominationPools',
 		'PalletsOnGoingReferenda',
 		'PalletsStakingProgress',

--- a/src/chains-config/assetHubWestendControllers.ts
+++ b/src/chains-config/assetHubWestendControllers.ts
@@ -40,6 +40,7 @@ export const assetHubWestendControllers: ControllerConfig = {
 		'PalletsDispatchables',
 		'PalletsErrors',
 		'PalletsEvents',
+		'PalletsForeignAssets',
 		'PalletsPoolAssets',
 		'RuntimeCode',
 		'RuntimeMetadata',

--- a/src/services/pallets/PalletsForeignAssetsService.spec.ts
+++ b/src/services/pallets/PalletsForeignAssetsService.spec.ts
@@ -18,9 +18,13 @@ import { ApiPromise } from '@polkadot/api';
 
 import { sanitizeNumbers } from '../../sanitize/sanitizeNumbers';
 import { foreignAssetsMetadata } from '../test-helpers/mock/assets/mockAssetHubKusamaData';
-import { foreignAssetsEntries } from '../test-helpers/mock/data/foreignAssetsEntries';
+import { foreignAssetsMetadataWestendAH } from '../test-helpers/mock/assets/mockAssetHubWestendData';
+import { foreignAssetsEntries, foreignAssetsEntriesWestendAH } from '../test-helpers/mock/data/foreignAssetsEntries';
 import { mockAssetHubKusamaApi } from '../test-helpers/mock/mockAssetHubKusamaApi';
+import { mockAssetHubWestendApi } from '../test-helpers/mock/mockAssetHubWestendApi';
 import { blockHash523510 } from '../test-helpers/mock/mockBlock523510';
+import { blockHash5236177 } from '../test-helpers/mock/mockBlock5236177';
+import foreignAssetsResponse from '../test-helpers/responses/pallets/foreignAssetsResponse.json';
 import { PalletsForeignAssetsService } from './PalletsForeignAssetsService';
 
 const foreignAssetsEntriesAt = () => Promise.resolve().then(() => foreignAssetsEntries());
@@ -49,6 +53,14 @@ describe('PalletsForeignAssetsService', () => {
 				},
 				items: [
 					{
+						multiLocation: {
+							parents: '2',
+							interior: {
+								X1: {
+									GlobalConsensus: 'Polkadot',
+								},
+							},
+						},
 						foreignAssetInfo: {
 							owner: 'FxqimVubBRPqJ8kTwb3wL7G4q645hEkBEnXPyttLsTrFc5Q',
 							issuer: 'FxqimVubBRPqJ8kTwb3wL7G4q645hEkBEnXPyttLsTrFc5Q',
@@ -72,6 +84,19 @@ describe('PalletsForeignAssetsService', () => {
 						},
 					},
 					{
+						multiLocation: {
+							parents: '1',
+							interior: {
+								X2: [
+									{
+										Parachain: '2,125',
+									},
+									{
+										GeneralIndex: '0',
+									},
+								],
+							},
+						},
 						foreignAssetInfo: {
 							owner: 'FBeL7DiQ6JkoypYATheXhH3GQr5de2L3hL444TP6qQr3yA9',
 							issuer: 'FBeL7DiQ6JkoypYATheXhH3GQr5de2L3hL444TP6qQr3yA9',
@@ -100,6 +125,32 @@ describe('PalletsForeignAssetsService', () => {
 			const response = await palletsForeignAssetsService.fetchForeignAssets(blockHash523510);
 
 			expect(sanitizeNumbers(response)).toStrictEqual(expectedResponse);
+		});
+	});
+});
+
+const foreignAssetsEntriesAtWAH = () => Promise.resolve().then(() => foreignAssetsEntriesWestendAH());
+
+const mockApiWAH = {
+	...mockAssetHubWestendApi,
+	query: {
+		foreignAssets: {
+			asset: {
+				entries: foreignAssetsEntriesAtWAH,
+			},
+			metadata: foreignAssetsMetadataWestendAH,
+		},
+	},
+} as unknown as ApiPromise;
+
+const palletsForeignAssetsServiceWAH = new PalletsForeignAssetsService(mockApiWAH);
+
+describe('PalletsForeignAssetsService', () => {
+	describe('PalletsForeignAssetsService.fetchForeignAssets', () => {
+		it('Should return the correct response for Foreign Assets', async () => {
+			const response = await palletsForeignAssetsServiceWAH.fetchForeignAssets(blockHash5236177);
+
+			expect(sanitizeNumbers(response)).toStrictEqual(foreignAssetsResponse);
 		});
 	});
 });

--- a/src/services/test-helpers/mock/assets/mockAssetHubWestendData.ts
+++ b/src/services/test-helpers/mock/assets/mockAssetHubWestendData.ts
@@ -155,3 +155,227 @@ export const poolAssetApprovals = (): Promise<Option<AssetApproval>> =>
 		};
 		return assetHubWestendRegistryV9435.createType('Option<AssetApproval>', assetObj);
 	});
+
+/**
+ * This mock data uses Asset Hub Westend specVersion V9435
+ */
+
+const accountIdWAH1 = assetHubWestendRegistryV9435.createType(
+	'AccountId',
+	'5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy',
+);
+const balanceOfTknr = assetHubWestendRegistryV9435.createType('BalanceOf', 6693666633);
+
+const accountIdWAH2 = assetHubWestendRegistryV9435.createType(
+	'AccountId',
+	'5ENpP27BrVdJTdUfY6djmcw3d3xEJ6NzSUU52CCPmGpMrdEY',
+);
+
+const accountIdWAH3 = assetHubWestendRegistryV9435.createType(
+	'AccountId',
+	'5GxRGwT8bU1JeBPTUXc7LEjZMxNrK8MyL2NJnkWFQJTQ4sii',
+);
+
+const accountIdWAH4 = assetHubWestendRegistryV9435.createType(
+	'AccountId',
+	'5Eg2fnsiMxRhMVoAcrXoSYgi9LfB786LKf8yWLA8FPWNYyYD',
+);
+
+const foreignAssetInfoWAH0 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH1,
+		issuer: accountIdWAH1,
+		admin: accountIdWAH1,
+		freezer: accountIdWAH1,
+		supply: assetHubWestendRegistryV9435.createType('u64', 0),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 0),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 15000),
+		isSufficient: trueBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 0),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 0),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+const foreignAssetInfoWAH1 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH1,
+		issuer: accountIdWAH1,
+		admin: accountIdWAH1,
+		freezer: accountIdWAH1,
+		supply: assetHubWestendRegistryV9435.createType('u64', 106000000000000),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 100000000000),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 1),
+		isSufficient: falseBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 2),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 0),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+const foreignAssetInfoWAH2 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH2,
+		issuer: accountIdWAH2,
+		admin: accountIdWAH2,
+		freezer: accountIdWAH2,
+		supply: assetHubWestendRegistryV9435.createType('u64', 0),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 0),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 100000000),
+		isSufficient: trueBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 1),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 0),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+const foreignAssetInfoWAH3 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH3,
+		issuer: accountIdWAH3,
+		admin: accountIdWAH3,
+		freezer: accountIdWAH3,
+		supply: assetHubWestendRegistryV9435.createType('u64', 202835530084563),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 0),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 10000000000),
+		isSufficient: trueBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 14),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 11),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+const foreignAssetInfoWAH4 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH1,
+		issuer: accountIdWAH1,
+		admin: accountIdWAH1,
+		freezer: accountIdWAH1,
+		supply: assetHubWestendRegistryV9435.createType('u64', 998000000000),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 0),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 15000),
+		isSufficient: trueBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 1),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 1),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+const foreignAssetInfoWAH5 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH1,
+		issuer: accountIdWAH1,
+		admin: accountIdWAH1,
+		freezer: accountIdWAH1,
+		supply: assetHubWestendRegistryV9435.createType('u64', 0),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 100000000000),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 15000000000000),
+		isSufficient: trueBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 3),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 1),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+const foreignAssetInfoWAH6 = (): Option<PalletAssetsAssetDetails> => {
+	const responseObj = {
+		owner: accountIdWAH4,
+		issuer: accountIdWAH4,
+		admin: accountIdWAH4,
+		freezer: accountIdWAH4,
+		supply: assetHubWestendRegistryV9435.createType('u64', 0),
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 100000000000),
+		minBalance: assetHubWestendRegistryV9435.createType('u64', 100000000000000),
+		isSufficient: falseBool,
+		accounts: assetHubWestendRegistryV9435.createType('u8', 0),
+		sufficients: assetHubWestendRegistryV9435.createType('u8', 0),
+		approvals: assetHubWestendRegistryV9435.createType('u8', 0),
+		status: 'Live',
+	};
+
+	return assetHubWestendRegistryV9435.createType('Option<PalletAssetsAssetDetails>', responseObj);
+};
+
+export const foreignAssetsInfoWestendAH = [
+	foreignAssetInfoWAH0,
+	foreignAssetInfoWAH1,
+	foreignAssetInfoWAH2,
+	foreignAssetInfoWAH3,
+	foreignAssetInfoWAH4,
+	foreignAssetInfoWAH5,
+	foreignAssetInfoWAH6,
+];
+
+// TODO: The values in foreignAssetMetadataDot need to be updated
+// as soon as the Metadata of Polkadot are correctly updated in Kusama Asset Hub.
+// Right now Polkadot does not have metadata due to an error.
+const foreignAssetMetadataDot = (): AssetMetadata => {
+	const responseObj = {
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 0),
+		name: assetHubWestendRegistryV9435.createType('Bytes', '0x'),
+		symbol: assetHubWestendRegistryV9435.createType('Bytes', '0x'),
+		decimals: assetHubWestendRegistryV9435.createType('u8', 0),
+		isFrozen: falseBool,
+	};
+
+	return assetHubWestendRegistryV9435.createType('AssetMetadata', responseObj);
+};
+
+const foreignAssetMetadataEth = (): AssetMetadata => {
+	const responseObj = {
+		deposit: assetHubWestendRegistryV9435.createType('BalanceOf', 0),
+		name: assetHubWestendRegistryV9435.createType('Bytes', '0x'),
+		symbol: assetHubWestendRegistryV9435.createType('Bytes', '0x'),
+		decimals: assetHubWestendRegistryV9435.createType('u8', 0),
+		isFrozen: falseBool,
+	};
+
+	return assetHubWestendRegistryV9435.createType('AssetMetadata', responseObj);
+};
+
+const foreignAssetMetadataRococo = (): AssetMetadata => {
+	const responseObj = {
+		deposit: balanceOfTknr,
+		name: assetHubWestendRegistryV9435.createType('Bytes', 'Rococo'),
+		symbol: assetHubWestendRegistryV9435.createType('Bytes', 'ROC'),
+		decimals: assetHubWestendRegistryV9435.createType('u8', 12),
+		isFrozen: falseBool,
+	};
+
+	return assetHubWestendRegistryV9435.createType('AssetMetadata', responseObj);
+};
+
+export const foreignAssetsMetadataWestendAH = (location: string): AssetMetadata | string => {
+	const foreignAssetMultiLocationStr = JSON.stringify(location).replace(/(\d),/g, '$1');
+
+	if (foreignAssetMultiLocationStr == '0') {
+		return location;
+	} else if (foreignAssetMultiLocationStr == '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}') {
+		return foreignAssetMetadataDot();
+	} else if (
+		foreignAssetMultiLocationStr ==
+		'{"parents":"2","interior":{"X1":{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}}}}'
+	) {
+		return foreignAssetMetadataEth();
+	} else if (foreignAssetMultiLocationStr == '{"parents":"2","interior":{"X1":{"GlobalConsensus":"__Unused5"}}}') {
+		return foreignAssetMetadataRococo();
+	} else return foreignAssetMetadataDot();
+};

--- a/src/services/test-helpers/mock/data/foreignAssets.ts
+++ b/src/services/test-helpers/mock/data/foreignAssets.ts
@@ -29,3 +29,29 @@ const foreignAssetsLocation2 = {
 };
 
 export const foreignAssetsLocations = [foreignAssetsLocation1, foreignAssetsLocation2];
+
+const foreignAssetsLocation3 = {
+	parents: '2',
+	interior: {
+		X1: {
+			GlobalConsensus: {
+				Ethereum: {
+					chainId: '11,155,111',
+				},
+			},
+		},
+	},
+};
+
+const foreignAssetsLocation4 =
+	'0x30e64a56026f4b5e3c2d196283a9a17dd34371a193a751eea5883e9553457b2e6bfbb13fd9927e49c4a09ac55ab47d05020209049edaa8020300fff9976782d46cc05630d1f6ebab18b2324d6b14';
+
+export const foreignAssetsLocationsWestend = [
+	foreignAssetsLocation3,
+	foreignAssetsLocation4,
+	foreignAssetsLocation1,
+	foreignAssetsLocation1,
+	foreignAssetsLocation3,
+	foreignAssetsLocation3,
+	foreignAssetsLocation3,
+];

--- a/src/services/test-helpers/mock/data/foreignAssetsEntries.ts
+++ b/src/services/test-helpers/mock/data/foreignAssetsEntries.ts
@@ -15,9 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { assetHubKusamaV14 } from '../../../../test-helpers/metadata/assetHubKusamaMetadata';
+import { assetHubWestendMetadataRpcV9435 } from '../../../../test-helpers/metadata/assetHubWestendMetadata';
 import { createApiWithAugmentations, TypeFactory } from '../../../../test-helpers/typeFactory';
 import { foreignAssetsInfo } from '../assets/mockAssetHubKusamaData';
-import { foreignAssetsLocations } from './foreignAssets';
+import { foreignAssetsInfoWestendAH } from '../assets/mockAssetHubWestendData';
+import { foreignAssetsLocations, foreignAssetsLocationsWestend } from './foreignAssets';
 
 const typeFactoryApiV9430 = createApiWithAugmentations(assetHubKusamaV14);
 const factory = new TypeFactory(typeFactoryApiV9430);
@@ -32,5 +34,25 @@ export const foreignAssetsEntries = () => {
 
 		const assetInfo = foreignAssetsInfo[idx]();
 		return [storage, assetInfo];
+	});
+};
+
+const typeFactoryApiV9435 = createApiWithAugmentations(assetHubWestendMetadataRpcV9435);
+const factoryWAH = new TypeFactory(typeFactoryApiV9435);
+
+export const foreignAssetsEntriesWestendAH = () => {
+	return foreignAssetsLocationsWestend.map((location, idx) => {
+		if (typeof location === 'string') {
+			return [location, foreignAssetsInfoWestendAH[idx]()];
+		} else {
+			const storage = factoryWAH.storageKeyMultilocation(
+				location,
+				'XcmV3MultiLocation',
+				typeFactoryApiV9435.query.foreignAssets.asset,
+			);
+
+			const assetInfo = foreignAssetsInfoWestendAH[idx]();
+			return [storage, assetInfo];
+		}
 	});
 };

--- a/src/services/test-helpers/responses/pallets/foreignAssetsResponse.json
+++ b/src/services/test-helpers/responses/pallets/foreignAssetsResponse.json
@@ -1,0 +1,234 @@
+{
+  "at": {
+    "hash": "0x270c4262eacfd16f05a63ef36eeabf165abbc3a4c53d0480f5460e6d5b2dc8b5",
+    "height": "5236177"
+  },
+  "items": [
+    {
+      "multiLocation": {
+        "parents": "2",
+        "interior": {
+          "X1": 
+            {
+              "GlobalConsensus": {
+                "Ethereum": {
+                  "chainId": "11,155,111"
+                }
+              }
+            }
+        }
+      },
+      "foreignAssetInfo": {
+        "owner": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "issuer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "admin": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "freezer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "supply": "0",
+        "deposit": "0",
+        "minBalance": "15000",
+        "isSufficient": true,
+        "accounts": "0",
+        "sufficients": "0",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {
+        "deposit": "0",
+        "name": "0x",
+        "symbol": "0x",
+        "decimals": "0",
+        "isFrozen": false
+      }
+    },
+    {
+      "multiLocation": "0x30e64a56026f4b5e3c2d196283a9a17dd34371a193a751eea5883e9553457b2e6bfbb13fd9927e49c4a09ac55ab47d05020209049edaa8020300fff9976782d46cc05630d1f6ebab18b2324d6b14",
+      "foreignAssetInfo": {
+        "owner": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "issuer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "admin": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "freezer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "supply": "106000000000000",
+        "deposit": "100000000000",
+        "minBalance": "1",
+        "isSufficient": false,
+        "accounts": "2",
+        "sufficients": "0",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {}
+    },
+    {
+      "multiLocation": {
+        "parents": "2",
+        "interior": {
+          "X1":
+            {
+              "GlobalConsensus": "Polkadot"
+            }
+        }
+      },
+      "foreignAssetInfo": {
+        "owner": "5ENpP27BrVdJTdUfY6djmcw3d3xEJ6NzSUU52CCPmGpMrdEY",
+        "issuer": "5ENpP27BrVdJTdUfY6djmcw3d3xEJ6NzSUU52CCPmGpMrdEY",
+        "admin": "5ENpP27BrVdJTdUfY6djmcw3d3xEJ6NzSUU52CCPmGpMrdEY",
+        "freezer": "5ENpP27BrVdJTdUfY6djmcw3d3xEJ6NzSUU52CCPmGpMrdEY",
+        "supply": "0",
+        "deposit": "0",
+        "minBalance": "100000000",
+        "isSufficient": true,
+        "accounts": "1",
+        "sufficients": "0",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {
+        "deposit": "0",
+        "name": "0x",
+        "symbol": "0x",
+        "decimals": "0",
+        "isFrozen": false
+      }
+    },
+    {
+      "multiLocation": {
+        "parents": "2",
+        "interior": {
+          "X1":
+            {
+              "GlobalConsensus": "Polkadot"
+            }
+        }
+      },
+      "foreignAssetInfo": {
+        "owner": "5GxRGwT8bU1JeBPTUXc7LEjZMxNrK8MyL2NJnkWFQJTQ4sii",
+        "issuer": "5GxRGwT8bU1JeBPTUXc7LEjZMxNrK8MyL2NJnkWFQJTQ4sii",
+        "admin": "5GxRGwT8bU1JeBPTUXc7LEjZMxNrK8MyL2NJnkWFQJTQ4sii",
+        "freezer": "5GxRGwT8bU1JeBPTUXc7LEjZMxNrK8MyL2NJnkWFQJTQ4sii",
+        "supply": "202835530084563",
+        "deposit": "0",
+        "minBalance": "10000000000",
+        "isSufficient": true,
+        "accounts": "14",
+        "sufficients": "11",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {
+        "deposit": "0",
+        "name": "0x",
+        "symbol": "0x",
+        "decimals": "0",
+        "isFrozen": false
+      }
+    },
+    {
+      "multiLocation": {
+        "parents": "2",
+        "interior": {
+          "X1":
+            {
+              "GlobalConsensus": {
+                "Ethereum": {
+                  "chainId": "11,155,111"
+                }
+              }
+            }
+        }
+      },
+      "foreignAssetInfo": {
+        "owner": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "issuer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "admin": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "freezer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "supply": "998000000000",
+        "deposit": "0",
+        "minBalance": "15000",
+        "isSufficient": true,
+        "accounts": "1",
+        "sufficients": "1",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {
+        "deposit": "0",
+        "name": "0x",
+        "symbol": "0x",
+        "decimals": "0",
+        "isFrozen": false
+      }
+    },
+    {
+      "multiLocation": {
+        "parents": "2",
+        "interior": {
+          "X1":
+            {
+              "GlobalConsensus": {
+                "Ethereum": {
+                  "chainId": "11,155,111"
+                }
+              }
+            }
+        }
+      },
+      "foreignAssetInfo": {
+        "owner": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "issuer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "admin": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "freezer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
+        "supply": "0",
+        "deposit": "100000000000",
+        "minBalance": "15000000000000",
+        "isSufficient": true,
+        "accounts": "3",
+        "sufficients": "1",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {
+        "deposit": "0",
+        "name": "0x",
+        "symbol": "0x",
+        "decimals": "0",
+        "isFrozen": false
+      }
+    },
+    {
+      "multiLocation": {
+        "parents": "2",
+        "interior": {
+          "X1": 
+            {
+              "GlobalConsensus": {
+                "Ethereum": {
+                  "chainId": "11,155,111"
+                }
+              }
+            }
+        }
+      },
+      "foreignAssetInfo": {
+        "owner": "5Eg2fnsiMxRhMVoAcrXoSYgi9LfB786LKf8yWLA8FPWNYyYD",
+        "issuer": "5Eg2fnsiMxRhMVoAcrXoSYgi9LfB786LKf8yWLA8FPWNYyYD",
+        "admin": "5Eg2fnsiMxRhMVoAcrXoSYgi9LfB786LKf8yWLA8FPWNYyYD",
+        "freezer": "5Eg2fnsiMxRhMVoAcrXoSYgi9LfB786LKf8yWLA8FPWNYyYD",
+        "supply": "0",
+        "deposit": "100000000000",
+        "minBalance": "100000000000000",
+        "isSufficient": false,
+        "accounts": "0",
+        "sufficients": "0",
+        "approvals": "0",
+        "status": "Live"
+      },
+      "foreignAssetMetadata": {
+        "deposit": "0",
+        "name": "0x",
+        "symbol": "0x",
+        "decimals": "0",
+        "isFrozen": false
+      }
+    }
+  ]
+}

--- a/src/types/responses/ForeignAssets.ts
+++ b/src/types/responses/ForeignAssets.ts
@@ -16,12 +16,14 @@
 
 import { AssetMetadata } from '@polkadot/types/interfaces';
 import { PalletAssetsAssetDetails } from '@polkadot/types/lookup';
+import type { AnyJson } from '@polkadot/types/types';
 
 import { IAt } from '.';
 
 export interface IForeignAssetInfo {
+	multiLocation: AnyJson | string;
 	foreignAssetInfo: PalletAssetsAssetDetails | {};
-	foreignAssetMetadata: AssetMetadata;
+	foreignAssetMetadata: AssetMetadata | {};
 }
 
 export interface IForeignAssets {


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1599

### Changes 
- Added Foreign Assets controller to `Westend Asset Hub` and `Westend Asset Hub Next` chain config.
- Implemented a fallback when multilocation is given as a hexadecimal value to still return the AssetInfo and Metadata (as empty).
- Added the `multiLocation` of the foreign asset in the response.
- Updated existing test to include the `multiLocation`.
- Created a new test that has a hexadecimal value as `multiLocation`.
- Updated docs.

### Testing
When connecting Sidecar to `Westend Asset Hub`  (wss://westend-asset-hub-rpc.polkadot.io) and querying the endpoint `http://127.0.0.1:8080/pallets/foreign-assets`, the response is now returned with no errors:

```
{
  "at": {
    "hash": "0x2e75bb2ed5541d6fc754aa75f604bdd9cbe1de1511710e47405a54e9eb38c2e0",
    "height": "11052065"
  },
  "items": [
    {
      "multiLocation": {
        "parents": "2",
        "interior": {
          "X1": [
            {
              "GlobalConsensus": {
                "Ethereum": {
                  "chainId": "11,155,111"
                }
              }
            }
          ]
        }
      },
      "foreignAssetInfo": {
        "owner": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "issuer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "admin": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "freezer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "supply": "0",
        "deposit": "0",
        "minBalance": "15000",
        "isSufficient": true,
        "accounts": "0",
        "sufficients": "0",
        "approvals": "0",
        "status": "Live"
      },
      "foreignAssetMetadata": {
        "deposit": "0",
        "name": "0x",
        "symbol": "0x",
        "decimals": "0",
        "isFrozen": false
      }
    },
    {
      "multiLocation": "0x30e64a56026f4b5e3c2d196283a9a17dd34371a193a751eea5883e9553457b2e6bfbb13fd9927e49c4a09ac55ab47d05020209049edaa8020300fff9976782d46cc05630d1f6ebab18b2324d6b14",
      "foreignAssetInfo": {
        "owner": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "issuer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "admin": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "freezer": "5GjRnmh5o3usSYzVmsxBWzHEpvJyHK4tKNPhjpUR3ASrruBy",
        "supply": "106000000000000",
        "deposit": "100000000000",
        "minBalance": "1",
        "isSufficient": false,
        "accounts": "2",
        "sufficients": "0",
        "approvals": "0",
        "status": "Live"
      },
      "foreignAssetMetadata": {}
    },
  ...
```

Note: The second item in this example is the one with multiLocation as a hexadecimal value. 