### PR TITLE
perf: optimization of mapStakers function

### DIFF
--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -577,20 +577,21 @@ export class AccountsStakingPayoutsService extends AbstractService {
 			const validators: DeriveEraValidatorExposure = {};
 			const validatorsOverview: Record<string, Option<SpStakingPagedExposureMetadata>> = {};
 
+			const validatorLookupMap: { [key: string]: Option<SpStakingPagedExposureMetadata> } = {};
+			if (validatorsOverviewEntries) {
+				for (const validator of validatorsOverviewEntries) {
+					const validatorKey: StorageKey = validator[0];
+					const valKey: [string, string] = validatorKey.toHuman() as unknown as [string, string];
+					if (valKey) {
+						validatorLookupMap[valKey[1].toString()] = validator[1];
+					}
+				}
+			}
+
 			stakers.forEach(([key, exposure]): void => {
 				const validatorId = key.args[1].toString();
-
-				if (validatorsOverviewEntries) {
-					for (const validator of validatorsOverviewEntries) {
-						const validatorKey: StorageKey = validator[0];
-						const valKey: [string, string] = validatorKey.toHuman() as unknown as [string, string];
-						if (valKey) {
-							if (valKey[1].toString() === validatorId) {
-								validatorsOverview[validatorId] = validator[1];
-								break;
-							}
-						}
-					}
+				if (validatorLookupMap[validatorId]) {
+					validatorsOverview[validatorId] = validatorLookupMap[validatorId];
 				}
 
 				validators[validatorId] = exposure;


### PR DESCRIPTION
### Description
Closes https://github.com/paritytech/substrate-api-sidecar/issues/1610

Relates to : https://github.com/paritytech/substrate-api-sidecar/issues/1361

### How to Test
#### Measuring Execution Time
I measured the execution time of the nested loops (old code) by doing the following:

1. I added : 
    ```
    const start = performance.now();
    ```
    right before the `stakers.forEach...` statement so in line [579](https://github.com/paritytech/substrate-api-sidecar/blob/master/src/services/accounts/AccountsStakingPayoutsService.ts#L579).

2. and this code:
    ```
    const end = performance.now();
    console.log(`Execution time in mapStakers: ${end - start} ms`);
    ```
    right after the loop ended so right after line [609](https://github.com/paritytech/substrate-api-sidecar/blob/eae70c15b5a48db3a3ecb7fc1c2b24ff85145534/src/services/accounts/AccountsStakingPayoutsService.ts#L609).

I then implemented the new code and kept the measurement statements as they were to compare the execution times between the old and new implementations.

### Test1
For request (Kusama chain) that does not return any payouts:
```
accounts/GTzRQPzkcuynHgkEHhsPBFpKdh4sAacVRsnd8vYfPpTMeEY/staking-payouts?depth=1&era=7798&unclaimedOnly=false
```

#### Execution Time of Old Code
```
Execution time in mapStakers: 14394.41800000146 ms
```

#### Execution Time of New Code
```
Execution time in mapStakers: 148.08579199761152 ms
```

### Test2
For request (in Kusama chain) that returns payouts for 3 eras:
```
accounts/DPc3YPyWts9LjqBUy7hhLDwN4iHPXU6vicURDMYAMqnW5gi/staking-payouts?at=22798724&depth=3&era=6514&unclaimedOnly=false
```

#### Execution Time of Old Code
```
Execution time in mapStakers: 123.73270799964666 ms
Execution time in mapStakers: 108.02466700226068 ms
Execution time in mapStakers: 14742.94466599822 ms
```

#### Execution Time of New Code
```
Execution time in mapStakers: 100.085250005126 ms
Execution time in mapStakers: 101.02266599982977 ms
Execution time in mapStakers: 135.65316700190306 ms
```

### Conclusion from Tests
In the second test, notice that with the old code we also get fast replies for the first 2 eras and only the 3rd one is very slow. The reason is that for the first 2 eras, `validatorsOverviewEntries.length` is 0 so the code never goes into the inner loop. However, for the 3rd era that was requested (depth = 3), `validatorsOverviewEntries.length` is 1000 so then the code checks the inner loop also and the performance impact is huge.
In contrast, the new optimized code shows almost consistent execution times in all 3 eras, regardless of whether `validatorsOverviewEntries.length` is 0 or 1000.