### PR TITLE
fix: small updates in injection tests

### DIFF
--- a/src/controllers/controllerInjection.spec.ts
+++ b/src/controllers/controllerInjection.spec.ts
@@ -56,7 +56,6 @@ const chainsToNode: Record<string, string> = {
 	'asset-hub-westend': 'wss://asset-hub-westend-rpc.dwellir.com',
 	astar: 'wss://astar-rpc.dwellir.com',
 	bifrost_polkadot: 'wss://bifrost-polkadot.ibp.network',
-	calamari: 'wss://calamari.systems',
 	polkadot: 'wss://polkadot-rpc.dwellir.com',
 	'coretime-westend': 'wss://coretime-westend-rpc.dwellir.com',
 	'coretime-polkadot': 'wss://sys.ibp.network/coretime-polkadot',
@@ -68,7 +67,7 @@ const chainsToNode: Record<string, string> = {
 };
 
 describe('controllerInjection', () => {
-	jest.setTimeout(10000); // Increase timeout for async operations
+	jest.setTimeout(60000); // Increase timeout for async operations
 
 	for (const [chain, nodeUrl] of Object.entries(chainsToNode)) {
 		it(`should return the correct response for ${chain}`, async () => {


### PR DESCRIPTION
### Description
This PR aims to minimize the frequency in which the tests fail (with `yarn test`) in PRs, especially the ones opened from the Dependabot.

### Issue
In the last PRs, the tests in [controllerInjection.spec.ts](https://github.com/paritytech/substrate-api-sidecar/compare/domi-injection-timeout?expand=1#diff-1378505656c30b1e4f18b5b171c61cfa1937fe1f2025c8cc38ccde9ca943f6d6) were failing either with error:

```
controllerInjection › should return the correct response for bifrost_polkadot
thrown: "Exceeded timeout of 10000 ms for a test.
```
Example [here](https://github.com/paritytech/substrate-api-sidecar/actions/runs/14360119412/job/40260173475)

or with error

```
2025-04-09 13:51:01          API-WS: disconnected from wss://calamari.systems: 1006:: Abnormal Closure
```
Example [here](https://github.com/paritytech/substrate-api-sidecar/actions/runs/14358841402/job/40254741680)

### Changes
To eliminate the errors described above, two changes are proposed:
- Increase `jest.timeout` from `10000` to `60000` (same as we have in historical test [here](https://github.com/paritytech/substrate-api-sidecar/blob/bd0b57ab69d3372cae5e8cffb2189f7bdc6c4efd/e2e-tests/historical-e2e-tests.spec.ts#L25))
- Remove the `calamari` endpoint because it is significantly unstable and testing against this chain is not essential.