### PR TITLE
fix: retreive safeXcmVersion when xcmVersion is not in the body

### DIFF
--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -28,7 +28,6 @@ import { TransactionResultType } from '../../types/responses';
 import { blockHash22887036 } from '../test-helpers/mock';
 import { mockDryRunCallResult } from '../test-helpers/mock/mockDryRunCall';
 import { mockDryRunCallError } from '../test-helpers/mock/mockDryRunError';
-import { mockKusamaApiBlock26187139 } from '../test-helpers/mock/mockKusamaApiBlock26187139';
 import { TransactionDryRunService } from './TransactionDryRunService';
 
 const mockMetadataAtVersion = () =>
@@ -138,7 +137,7 @@ describe('TransactionDryRunService', () => {
 
 	it('should correctly execute a dry run for a call and return an error', async () => {
 		const mockApiErr = {
-			...mockKusamaApiBlock26187139,
+			...mockHistoricApi,
 			call: {
 				dryRunApi: {
 					dryRunCall: mockDryRunError,

--- a/src/services/transaction/TransactionDryRunService.spec.ts
+++ b/src/services/transaction/TransactionDryRunService.spec.ts
@@ -41,6 +41,11 @@ const mockMetadataVersions = jest.fn().mockResolvedValue({
 	toHuman: jest.fn().mockReturnValue(['14', '15', '4,294,967,295']), // or whatever versions you want
 });
 
+const mockSafeXcmVersion = () =>
+	Promise.resolve().then(() => {
+		return polkadotRegistryV15.createType('Option<u32>', 5);
+	});
+
 const runtimeDryRun = polkadotRegistryV15.createType(
 	'Result<CallDryRunEffects, XcmDryRunApiError>',
 	mockDryRunCallResult,
@@ -63,6 +68,11 @@ const mockHistoricApi = {
 		metadata: {
 			metadataVersions: mockMetadataVersions,
 			metadataAtVersion: mockMetadataAtVersion,
+		},
+	},
+	query: {
+		xcmPallet: {
+			safeXcmVersion: mockSafeXcmVersion,
 		},
 	},
 	registry: polkadotRegistryV15,
@@ -132,6 +142,11 @@ describe('TransactionDryRunService', () => {
 			call: {
 				dryRunApi: {
 					dryRunCall: mockDryRunError,
+				},
+			},
+			query: {
+				xcmPallet: {
+					safeXcmVersion: mockSafeXcmVersion,
 				},
 			},
 		} as unknown as ApiPromise;

--- a/src/services/transaction/TransactionDryRunService.ts
+++ b/src/services/transaction/TransactionDryRunService.ts
@@ -67,7 +67,7 @@ export class TransactionDryRunService extends AbstractService {
 			};
 
 			const [dryRunResponse, { number }] = await Promise.all([
-				xcmVersion === undefined
+				foundXcmVersion === undefined
 					? api.call.dryRunApi.dryRunCall(originCaller, transaction)
 					: api.call.dryRunApi.dryRunCall(originCaller, transaction, foundXcmVersion),
 				hash ? api.rpc.chain.getHeader(hash) : { number: null },

--- a/src/services/transaction/TransactionDryRunService.ts
+++ b/src/services/transaction/TransactionDryRunService.ts
@@ -15,12 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { BlockHash, CallDryRunEffects, XcmDryRunApiError } from '@polkadot/types/interfaces';
-import type { Result } from '@polkadot/types-codec';
+import type { Option, Result, u32 } from '@polkadot/types-codec';
 import { BadRequest } from 'http-errors';
 
 import { ITransactionDryRun, TransactionResultType, ValidityErrorType } from '../../types/responses';
 import { AbstractService } from '../AbstractService';
-import { RuntimeMetadataService } from '../index';
 import { extractCauseAndStack } from './extractCauseAndStack';
 
 export type SignedOriginCaller = {
@@ -38,35 +37,26 @@ export class TransactionDryRunService extends AbstractService {
 	): Promise<ITransactionDryRun> {
 		const { api } = this;
 
-		const metadataService = new RuntimeMetadataService(this.specName);
+		if (!api.call.dryRunApi) {
+			throw new BadRequest('DryRunApi not found in metadata.');
+		} else if (!api.call.dryRunApi.dryRunCall) {
+			throw new BadRequest('dryRunCall not found in metadata.');
+		}
 
-		if (xcmVersion == undefined && hash) {
-			const metadataVersions = await metadataService.fetchMetadataVersions(hash);
-
-			const latestStableMetadataVersion = metadataVersions.reduce((max, current) => {
-				const metadata = Number(current);
-				if (isNaN(metadata)) {
-					return max;
-				}
-				return Math.max(max, metadata);
-			}, 0);
-
-			const metadata = await metadataService.fetchMetadataVersioned(api, latestStableMetadataVersion);
-
-			const dryRunApi = metadata.asLatest.apis.find((api) => api.name.toString() === 'DryRunApi');
-			if (!dryRunApi) {
-				throw new BadRequest('DryRunApi not found in metadata.');
+		let foundXcmVersion = xcmVersion;
+		if (!foundXcmVersion) {
+			if (!api.query.xcmPallet?.safeXcmVersion) {
+				throw BadRequest(
+					'If no xcmVersion is passed into the body the xcmPallet is required to query a safe xcm version. XcmPallet not found.',
+				);
 			}
 
-			const dryRunCall = dryRunApi.methods.find((method) => method.name.toString() === 'dry_run_call');
-			if (!dryRunCall) {
-				throw new BadRequest('dryRunCall not found in metadata.');
+			const version = await api.query.xcmPallet?.safeXcmVersion<Option<u32>>();
+			if (version.isNone) {
+				throw BadRequest('No safe xcm version found on chain.');
 			}
-			const xcmsVersion = dryRunCall.inputs.find((param) => param.name.toString() === 'result_xcms_version');
 
-			if (xcmsVersion) {
-				throw new BadRequest('Missing field `xcmVersion` on request body.');
-			}
+			foundXcmVersion = version.unwrap().toNumber();
 		}
 
 		try {
@@ -79,7 +69,7 @@ export class TransactionDryRunService extends AbstractService {
 			const [dryRunResponse, { number }] = await Promise.all([
 				xcmVersion === undefined
 					? api.call.dryRunApi.dryRunCall(originCaller, transaction)
-					: api.call.dryRunApi.dryRunCall(originCaller, transaction, xcmVersion),
+					: api.call.dryRunApi.dryRunCall(originCaller, transaction, foundXcmVersion),
 				hash ? api.rpc.chain.getHeader(hash) : { number: null },
 			]);
 


### PR DESCRIPTION
rel: https://github.com/paritytech/substrate-api-sidecar/pull/1649

## Fixes POST `/transaction/dry-run`

This ensures that when no xcmVersion is present in the body it will default to the safeXcmVersion provided by the xcmPallet.