### PR TITLE
feat: Add `rcAt` query parameter support for Asset Hub Migration

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2340,7 +2340,9 @@ paths:
         from Asset Hub for staking progress, this endpoint requires multi chain connections
         between the relay chain, and asset hub itself. Set the asset hub rpc to SAS_SUBSTRATE_URL,
         and add the relay chain to the SAS_SUBSTRATE_MULTI_CHAIN_URL env var. Refer to the README for the structure
-        of the env vars.
+        of the env vars. The `rcAt` parameter allows querying Asset Hub state using relay chain
+        block numbers, enabling post-migration infrastructure to continue using relay chain
+        block identifiers while accessing Asset Hub data.
       operationId: getStakingProgress
       parameters:
       - name: at
@@ -2351,6 +2353,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub staking progress report. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -2359,7 +2369,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StakingProgress'
         "400":
-          description: invalid blockId supplied for at query param
+          description: invalid blockId supplied for at/rcAt query param, or invalid parameter combination
           content:
             application/json:
               schema:
@@ -5053,6 +5063,14 @@ components:
           items:
             type: string
             format: ss58
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     StakingValidators:
       type: object
       properties:

--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -50,6 +50,8 @@ import { shidenControllers } from './shidenControllers';
 import { soraControllers } from './soraControllers';
 import { westendControllers } from './westendControllers';
 
+export const ASSET_HUB_ID = 1000;
+
 export const specToControllerMap: { [x: string]: ControllerConfig } = {
 	westend: westendControllers,
 	polkadot: polkadotControllers,

--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -50,8 +50,6 @@ import { shidenControllers } from './shidenControllers';
 import { soraControllers } from './soraControllers';
 import { westendControllers } from './westendControllers';
 
-export const ASSET_HUB_ID = 1000;
-
 export const specToControllerMap: { [x: string]: ControllerConfig } = {
 	westend: westendControllers,
 	polkadot: polkadotControllers,

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -35,6 +35,7 @@ import {
 
 import { ApiPromiseRegistry } from '../../src/apiRegistry';
 import type { AssetHubInfo } from '../apiRegistry';
+import { ASSET_HUB_ID } from '../chains-config';
 import { sanitizeNumbers } from '../sanitize';
 import { isBasicLegacyError } from '../types/errors';
 import { ISanitizeOptions } from '../types/sanitize';
@@ -318,7 +319,7 @@ export default abstract class AbstractController<T extends AbstractService> {
 			const paraData = data[0] as PolkadotPrimitivesVstagingCommittedCandidateReceiptV2;
 			const { paraId } = paraData.descriptor;
 
-			return paraId.toNumber() === 1000;
+			return paraId.toNumber() === ASSET_HUB_ID;
 		});
 
 		if (ahInfo) {

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -334,10 +334,6 @@ export default abstract class AbstractController<T extends AbstractService> {
 	}
 
 	protected async getHashFromRcAt(rcAt: unknown): Promise<{ ahHash: BlockHash; rcBlockNumber: string }> {
-		if (!this.assetHubInfo.isAssetHub) {
-			throw new BadRequest('rcAt parameter is only supported for Asset Hub endpoints');
-		}
-
 		const ahHash = await this.getAhAtFromRcAt(rcAt);
 		const rcBlockNumber = typeof rcAt === 'string' ? rcAt : 'latest';
 

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -35,7 +35,6 @@ import {
 
 import { ApiPromiseRegistry } from '../../src/apiRegistry';
 import type { AssetHubInfo } from '../apiRegistry';
-import { ASSET_HUB_ID } from '../chains-config';
 import { sanitizeNumbers } from '../sanitize';
 import { isBasicLegacyError } from '../types/errors';
 import { ISanitizeOptions } from '../types/sanitize';
@@ -63,6 +62,7 @@ export type RequiredPallets = string[][];
  */
 export default abstract class AbstractController<T extends AbstractService> {
 	private _router: Router = express.Router();
+	public ASSET_HUB_ID = 1000;
 	static controllerName: string;
 	static requiredPallets: RequiredPallets;
 
@@ -319,7 +319,7 @@ export default abstract class AbstractController<T extends AbstractService> {
 			const paraData = data[0] as PolkadotPrimitivesVstagingCommittedCandidateReceiptV2;
 			const { paraId } = paraData.descriptor;
 
-			return paraId.toNumber() === ASSET_HUB_ID;
+			return paraId.toNumber() === this.ASSET_HUB_ID;
 		});
 
 		if (ahInfo) {

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -15,7 +15,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ApiPromise } from '@polkadot/api';
+import { Bytes } from '@polkadot/types';
 import { BlockHash } from '@polkadot/types/interfaces';
+import { PolkadotPrimitivesVstagingCommittedCandidateReceiptV2 } from '@polkadot/types/lookup';
 import { isHex } from '@polkadot/util';
 import { RequestHandler, Response, Router } from 'express';
 import * as express from 'express';
@@ -285,6 +287,50 @@ export default abstract class AbstractController<T extends AbstractService> {
 		return typeof at === 'string'
 			? await this.getHashForBlock(at, { api: chosenApi })
 			: await chosenApi.rpc.chain.getFinalizedHead();
+	}
+
+	protected async getAhAtFromRcAt(at: unknown, maxDepth: number = 2): Promise<BlockHash> {
+		const rcHash = await this.getHashFromAt(at);
+		const rcApi = ApiPromiseRegistry.getApiByType('relay')[0]?.api;
+
+		if (!rcApi) {
+			throw new Error('Relay chain api must be available');
+		}
+
+		return this.findAhBlockInRcBlock(rcHash, rcApi, maxDepth);
+	}
+
+	private async findAhBlockInRcBlock(rcHash: BlockHash, rcApi: ApiPromise, remainingDepth: number): Promise<BlockHash> {
+		if (remainingDepth <= 0) {
+			throw new Error('Maximum search depth reached while looking for Asset Hub inclusion');
+		}
+
+		const rcApiAt = await rcApi.at(rcHash);
+		const events = await rcApiAt.query.system.events();
+
+		const paraInclusion = events.filter((record) => {
+			return record.event.section === 'paraInclusion' && record.event.method === 'CandidateIncluded';
+		});
+
+		const ahInfo = paraInclusion.find(({ event }) => {
+			const { data } = event;
+			const paraData = data[0] as PolkadotPrimitivesVstagingCommittedCandidateReceiptV2;
+			const { paraId } = paraData.descriptor;
+
+			return paraId.toNumber() === 1000;
+		});
+
+		if (ahInfo) {
+			const headerData = ahInfo.event.data[1] as Bytes;
+			const header = rcApiAt.registry.createType('Header', headerData);
+			const ahBlockHash = header.hash;
+			return rcApi.createType('BlockHash', ahBlockHash);
+		}
+
+		const rcHeader = await rcApiAt.query.system.parentHash();
+		const previousRcHash = rcApi.createType('BlockHash', rcHeader);
+
+		return this.findAhBlockInRcBlock(previousRcHash, rcApi, remainingDepth - 1);
 	}
 
 	/**

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -291,11 +291,12 @@ export default abstract class AbstractController<T extends AbstractService> {
 
 	protected async getAhAtFromRcAt(at: unknown, maxDepth: number = 2): Promise<BlockHash> {
 		const rcApi = ApiPromiseRegistry.getApiByType('relay')[0]?.api;
-		const rcHash = await this.getHashFromAt(at, { api: rcApi });
 
 		if (!rcApi) {
 			throw new Error('Relay chain api must be available');
 		}
+
+		const rcHash = await this.getHashFromAt(at, { api: rcApi });
 
 		return this.findAhBlockInRcBlock(rcHash, rcApi, maxDepth);
 	}

--- a/src/controllers/AbstractController.ts
+++ b/src/controllers/AbstractController.ts
@@ -290,8 +290,8 @@ export default abstract class AbstractController<T extends AbstractService> {
 	}
 
 	protected async getAhAtFromRcAt(at: unknown, maxDepth: number = 2): Promise<BlockHash> {
-		const rcHash = await this.getHashFromAt(at);
 		const rcApi = ApiPromiseRegistry.getApiByType('relay')[0]?.api;
+		const rcHash = await this.getHashFromAt(at, { api: rcApi });
 
 		if (!rcApi) {
 			throw new Error('Relay chain api must be available');
@@ -331,6 +331,17 @@ export default abstract class AbstractController<T extends AbstractService> {
 		const previousRcHash = rcApi.createType('BlockHash', rcHeader);
 
 		return this.findAhBlockInRcBlock(previousRcHash, rcApi, remainingDepth - 1);
+	}
+
+	protected async getHashFromRcAt(rcAt: unknown): Promise<{ ahHash: BlockHash; rcBlockNumber: string }> {
+		if (!this.assetHubInfo.isAssetHub) {
+			throw new BadRequest('rcAt parameter is only supported for Asset Hub endpoints');
+		}
+
+		const ahHash = await this.getAhAtFromRcAt(rcAt);
+		const rcBlockNumber = typeof rcAt === 'string' ? rcAt : 'latest';
+
+		return { ahHash, rcBlockNumber };
 	}
 
 	/**

--- a/src/controllers/pallets/PalletsStakingProgressController.ts
+++ b/src/controllers/pallets/PalletsStakingProgressController.ts
@@ -17,6 +17,7 @@
 import { BlockHash } from '@polkadot/types/interfaces';
 import { RequestHandler } from 'express';
 
+import { validateRcAt } from '../../middleware';
 import { PalletsStakingProgressService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -92,6 +93,7 @@ export default class PalletsStakingProgressController extends AbstractController
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateRcAt);
 		this.safeMountAsyncGetHandlers([['', this.getPalletStakingProgress]]);
 	}
 
@@ -102,10 +104,6 @@ export default class PalletsStakingProgressController extends AbstractController
 	 * @param res Express Response
 	 */
 	private getPalletStakingProgress: RequestHandler = async ({ query: { at, rcAt } }, res): Promise<void> => {
-		if (rcAt && at) {
-			throw new Error('Cannot specify both "at" and "rcAt" parameters');
-		}
-
 		let hash: BlockHash;
 		let rcBlockNumber: string | undefined;
 

--- a/src/middleware/validate/index.ts
+++ b/src/middleware/validate/index.ts
@@ -19,3 +19,4 @@ export {
 	validateAddressQueryParamMiddleware as validateAddressQueryParam,
 } from './validateAddressMiddleware';
 export { validateBooleanMiddleware as validateBoolean } from './validateBooleanMiddleware';
+export { validateRcAtMiddleware as validateRcAt } from './validateRcAtMiddleware';

--- a/src/middleware/validate/validateRcAtMiddleware.ts
+++ b/src/middleware/validate/validateRcAtMiddleware.ts
@@ -1,0 +1,105 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { isHex } from '@polkadot/util';
+import { RequestHandler } from 'express';
+import { BadRequest } from 'http-errors';
+
+import { ApiPromiseRegistry } from '../../apiRegistry';
+import { verifyUInt } from '../../util/integers/verifyInt';
+
+/**
+ * Express Middleware to validate the `rcAt` query parameter.
+ *
+ * This middleware performs the following validations:
+ * 1. Block format validation - ensures rcAt is a valid block number or hash
+ * 2. Mutual exclusivity - checks that both `at` and `rcAt` aren't provided
+ * 3. Asset Hub requirement - validates that the current API is connected to Asset Hub
+ * 4. Relay chain availability - ensures relay chain API is available
+ */
+export const validateRcAtMiddleware: RequestHandler = (req, _res, next) => {
+	const { at, rcAt } = req.query;
+
+	// If rcAt is not provided, continue without validation
+	if (!rcAt) {
+		return next();
+	}
+
+	// 1. Mutual exclusivity check
+	if (at && rcAt) {
+		return next(new BadRequest('Cannot specify both "at" and "rcAt" parameters'));
+	}
+
+	// 2. Block format validation
+	if (typeof rcAt !== 'string') {
+		return next(new BadRequest('rcAt must be a string'));
+	}
+
+	const [isValidBlock, blockError] = validateBlockIdentifier(rcAt);
+	if (!isValidBlock) {
+		return next(new BadRequest(`Invalid rcAt parameter: ${blockError}`));
+	}
+
+	// 3. Asset Hub requirement check
+	const assetHubInfo = ApiPromiseRegistry.assetHubInfo;
+	if (!assetHubInfo.isAssetHub) {
+		return next(new BadRequest('rcAt parameter is only supported for Asset Hub endpoints'));
+	}
+
+	// 4. Relay chain availability check
+	const relayChainApis = ApiPromiseRegistry.getApiByType('relay');
+	if (!relayChainApis || relayChainApis.length === 0) {
+		return next(
+			new BadRequest(
+				'rcAt parameter requires relay chain API to be available. Please configure SAS_SUBSTRATE_MULTI_CHAIN_URL',
+			),
+		);
+	}
+
+	return next();
+};
+
+/**
+ * Validate that a block identifier is properly formatted.
+ * Similar to the validation in AbstractController.getHashForBlock but for middleware use.
+ *
+ * @param blockId Block identifier (number or hash)
+ * @returns [isValid, errorMessage]
+ */
+function validateBlockIdentifier(blockId: string): [boolean, string | undefined] {
+	// Check if it's a hex string
+	if (isHex(blockId)) {
+		if (blockId.length === 66) {
+			// Valid 32-byte block hash
+			return [true, undefined];
+		} else {
+			return [false, 'Hex string block IDs must be 32-bytes (66-characters) in length'];
+		}
+	}
+
+	// Check if it starts with 0x but isn't valid hex
+	if (blockId.slice(0, 2) === '0x') {
+		return [false, 'Hex string block IDs must be a valid hex string and must be 32-bytes (66-characters) in length'];
+	}
+
+	// Must be a block number - validate it's a non-negative integer
+	const blockNumber = Number(blockId);
+	if (!verifyUInt(blockNumber)) {
+		return [false, 'Block IDs must be either 32-byte hex strings or non-negative decimal integers'];
+	}
+
+	return [true, undefined];
+}

--- a/src/types/responses/PalletStakingProgress.ts
+++ b/src/types/responses/PalletStakingProgress.ts
@@ -33,4 +33,6 @@ export interface IPalletStakingProgress {
 		  }
 		| string;
 	validatorSet?: string[] | null;
+	rcBlockNumber?: string;
+	ahTimestamp?: string;
 }


### PR DESCRIPTION
  ## Summary
  Added comprehensive `rcAt` parameter support with the following components:

  ### 1. **Core Block Resolution Logic** (`AbstractController.ts`)
  - **`getAhAtFromRcAt(at, maxDepth)`**: Resolves relay chain block numbers to Asset Hub block hashes by searching for `paraInclusion.CandidateIncluded` events for paraId 1000
  - **`findAhBlockInRcBlock()`**: Recursively searches parent blocks when Asset Hub isn't included in the specified relay chain block
  - **`getHashFromRcAt(rcAt)`**: High-level method that wraps the resolution logic and returns both AH hash and RC block number

  ### 2. **Request Validation Middleware** (`validateRcAtMiddleware.ts`)
  - **Block format validation**: Ensures `rcAt` is a valid block number or 32-byte hex hash
  - **Mutual exclusivity**: Prevents using both `at` and `rcAt` parameters simultaneously
  - **Asset Hub requirement**: Validates that the current API is connected to Asset Hub
  - **Relay chain availability**: Ensures relay chain API is available in the registry

  ### 3. **Enhanced Response Format**
  - **Backward compatible**: Existing `?at=` parameter works unchanged
  - **Enhanced metadata**: When `rcAt` is used, responses include:
    - `rcBlockNumber`: The relay chain block number used
    - `ahTimestamp`: Asset Hub block timestamp
    - All existing response fields remain unchanged

  ### 4. **Example Implementation** (`PalletsStakingProgressController.ts`)
  - Updated `/pallets/staking/progress` endpoint to support `rcAt` parameter
  - Added proper error handling and response metadata
  - Integrated with the new middleware for validation

  ## Usage Examples

  ```bash
  # Traditional usage (still works)
  GET /pallets/staking/progress?at=1000

  # New rcAt usage
  GET /pallets/staking/progress?rcAt=1000000

  # Response includes additional metadata:
  {
    "at": { "hash": "0x...", "height": "25011" },
    "activeEra": "1000",
    "forceEra": { "forceNew": null },
    // ... existing fields ...
    "rcBlockNumber": "1000000",
    "ahTimestamp": "1642694400000"
  }

  Technical Implementation Details

  Relay Chain → Asset Hub Block Resolution

  1. Query relay chain block for system.events()
  2. Filter for paraInclusion.CandidateIncluded events
  3. Find event with paraId 1000 (Asset Hub)
  4. Extract Asset Hub block hash from event data
  5. If not found, recursively search parent blocks (with depth limit)

  Error Handling

  - "Cannot specify both 'at' and 'rcAt' parameters"
  - "rcAt parameter is only supported for Asset Hub endpoints"
  - "Invalid rcAt parameter: [specific validation error]"
  - "Maximum search depth reached while looking for Asset Hub inclusion"

  Future Expansion

  This implementation provides a foundation for expanding rcAt support to other Asset Hub endpoints. The middleware and core logic are designed to be reusable across the API.

  ---
  This PR establishes the infrastructure for post-migration Asset Hub queries while maintaining full backward compatibility and providing a clear path for expanding the feature across other endpoints.
  ```

rel: https://github.com/paritytech/substrate-api-sidecar/issues/1693