### PR TITLE
feat: Support `rcAt` for `/pallets/*` endpoints

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1650,6 +1650,14 @@ paths:
             type: string
             description: Block identifier, as the block height or block hash.
             format: unsignedInteger or $hex
+        - name: rcAt
+          in: query
+          description: Relay chain block at which to retrieve Asset Hub liquidity pools info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+          required: false
+          schema:
+            type: string
+            description: Relay chain block identifier, as the block height or block hash.
+            format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -1679,6 +1687,14 @@ paths:
           schema:
             type: string
             description: Block identifier, as the block height or block hash.
+            format: unsignedInteger or $hex
+        - name: rcAt
+          in: query
+          description: Relay chain block at which to retrieve Asset Hub next available id. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+          required: false
+          schema:
+            type: string
+            description: Relay chain block identifier, as the block height or block hash.
             format: unsignedInteger or $hex
       responses:
         "200":
@@ -4267,6 +4283,14 @@ components:
             null}},{\"parents\":\"0\",\"interior\":{\"x2\":[{\"palletInstance\":
             \"50\"},{\"generalIndex\":\"2\"}]}}],\"lpToken\":{\"lpToken\":\"1\"}
             },{\"lpToken\":{\"lpToken\":\"0\"}}]"
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     LiquidityPool:
       type: object
       properties:
@@ -4293,6 +4317,14 @@ components:
           type: string
           description: Next availabe liquidity pool's id.
           example: "4"
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     NodeNetwork:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1758,6 +1758,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub nomination pools info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -1788,6 +1796,14 @@ paths:
         schema:
           type: string
           description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub nomination pool info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
       responses:
         "200":
@@ -4756,6 +4772,12 @@ components:
           $ref: '#/components/schemas/BondedPool'
         rewardPool:
           $ref: '#/components/schemas/RewardPool'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletsNominationPoolsInfo:
       type: object
       properties:
@@ -4786,6 +4808,12 @@ components:
             type: number
         minJoinBond:
             type: number
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletsOnGoingReferenda:
           type: object
           properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2670,6 +2670,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub staking validators. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -2678,7 +2686,7 @@ paths:
               schema:  
                 $ref: '#/components/schemas/StakingValidators'
         "400":
-          description: invalid blockId supplied for at query param
+          description: invalid blockId supplied for at/rcAt query param, or invalid parameter combination
           content:
             application/json:
               schema:
@@ -5575,6 +5583,14 @@ components:
               status:
                 type: string
                 description: Status of individual validator (active/waiting).
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     StorageEntryTypeV13:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1830,6 +1830,14 @@ paths:
             type: string
             description: Block identifier, as the block height or block hash.
             format: unsignedInteger or $hex
+        - name: rcAt
+          in: query
+          description: Relay chain block at which to retrieve Asset Hub on-going referenda info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+          required: false
+          schema:
+            type: string
+            description: Relay chain block identifier, as the block height or block hash.
+            format: unsignedInteger or $hex
         responses:
           "200":
             description: successful operation
@@ -4863,6 +4871,12 @@ components:
                         description: The block number at which the referendum's confirmation stage will end at as long as
                           it doesn't lose its approval in the meantime.
               description: A list of ongoing referenda and their details.
+            rcBlockNumber:
+              type: string
+              description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+            ahTimestamp:
+              type: string
+              description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletsPoolAssetsInfo:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2589,6 +2589,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pool asset info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -4987,6 +4995,12 @@ components:
           $ref: '#/components/schemas/AssetInfo'
         poolAssetMetadata:
           $ref: '#/components/schemas/AssetMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletStorage:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1726,6 +1726,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub foreign assets info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -4724,6 +4732,14 @@ components:
           items:
             $ref: '#/components/schemas/PalletsForeignAssetsInfo'
           description: Array containing the `AssetDetails` and `AssetMetadata` of every foreign asset.
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     PalletsForeignAssetsInfo:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1875,6 +1875,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet constants. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -1931,6 +1939,14 @@ paths:
         schema:
           default: false
           type: boolean
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet constant item. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -4538,6 +4554,12 @@ components:
           items:
             $ref: '#/components/schemas/PalletConstantsItemMetadata'
           description: Array containing metadata for each constant entry of the pallet.
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletConstantsItem:
       type: object
       properties:
@@ -4555,6 +4577,12 @@ components:
           example: "EnactmentPeriod"
         metadata:
           $ref: '#/components/schemas/PalletConstantsItemMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletConstantsItemMetadata:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1618,6 +1618,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub asset info. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -4440,6 +4448,14 @@ components:
           $ref: '#/components/schemas/AssetInfo'
         assetMetadata:
           $ref: '#/components/schemas/AssetMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     PalletConstants:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -1987,6 +1987,22 @@ paths:
         required: false
         schema:
           type: boolean
+      - name: at
+        in: query
+        description: Block at which to retrieve dispatchable metadata.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub dispatchable metadata. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -1996,7 +2012,7 @@ paths:
                 description: Pallet info and Array of dispatchableItemIds.
                 $ref: '#/components/schemas/PalletDispatchables'
         "400":
-          description: invalid blockId supplied for at query param
+          description: invalid blockId supplied for at/rcAt query param, or invalid parameter combination
           content:
             application/json:
               schema:
@@ -2035,6 +2051,22 @@ paths:
         schema:
           default: false
           type: boolean
+      - name: at
+        in: query
+        description: Block at which to retrieve dispatchable metadata.
+        required: false
+        schema:
+          type: string
+          description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub dispatchable metadata. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -2043,7 +2075,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PalletDispatchablesItem'
         "400":
-          description: invalid blockId supplied for at query param
+          description: invalid blockId supplied for at/rcAt query param, or invalid parameter combination
           content:
             application/json:
               schema:
@@ -4683,6 +4715,14 @@ components:
           items:
             $ref: '#/components/schemas/PalletDispatchablesItemMetadata'
           description: Array containing metadata for each dispatchable entry of the pallet.
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     PalletDispatchablesItem:
       type: object
       properties:
@@ -4700,6 +4740,14 @@ components:
           example: "vote"
         metadata:
           $ref: '#/components/schemas/PalletDispatchablesItemMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
+          format: unsignedInteger
     PalletDispatchablesItemMetadata:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2084,6 +2084,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet errors. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -2140,6 +2148,14 @@ paths:
         schema:
           default: false
           type: boolean
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet error item. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -2188,6 +2204,14 @@ paths:
         schema:
           type: string
           description: Block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet events. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
       responses:
         "200":
@@ -2245,6 +2269,14 @@ paths:
         schema:
           default: false
           type: boolean
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet event item. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -4677,6 +4709,12 @@ components:
           items:
             $ref: '#/components/schemas/PalletErrorsItemMetadata'
           description: Array containing metadata for each error entry of the pallet.
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletErrorsItem:
       type: object
       properties:
@@ -4694,6 +4732,12 @@ components:
           example: "ValueLow"
         metadata:
           $ref: '#/components/schemas/PalletErrorsItemMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletErrorsItemMetadata:
       type: object
       properties:
@@ -4734,6 +4778,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PalletEventsItemMetadata'
+          description: Array containing metadata for each event entry of the pallet.
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletEventsItem:
       type: object
       properties:
@@ -4751,6 +4802,12 @@ components:
           example: "Proposed"
         metadata:
           $ref: '#/components/schemas/PalletEventsItemMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletEventsItemMetadata:
       type: object
       properties:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -2461,6 +2461,14 @@ paths:
           type: string
           description: Block identifier, as the block height or block hash.
           format: unsignedInteger or $hex
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet storage. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -2530,6 +2538,14 @@ paths:
         schema:
           default: false
           type: boolean
+      - name: rcAt
+        in: query
+        description: Relay chain block at which to retrieve Asset Hub pallet storage item. Only supported for Asset Hub endpoints. Cannot be used with 'at' parameter.
+        required: false
+        schema:
+          type: string
+          description: Relay chain block identifier, as the block height or block hash.
+          format: unsignedInteger or $hex
       responses:
         "200":
           description: successful operation
@@ -4987,6 +5003,12 @@ components:
           items:
             $ref: '#/components/schemas/PalletStorageItemMetadata'
           description: Array containing metadata for each storage entry of the pallet.
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletStorageItem:
       type: object
       properties:
@@ -5025,6 +5047,12 @@ components:
                 turnout: "34485320658000000"
         metadata:
           $ref: '#/components/schemas/PalletStorageItemMetadata'
+        rcBlockNumber:
+          type: string
+          description: The relay chain block number used for the query. Only present when `rcAt` parameter is used.
+        ahTimestamp:
+          type: string
+          description: The Asset Hub block timestamp. Only present when `rcAt` parameter is used.
     PalletStorageItemMetadata:
       type: object
       properties:

--- a/src/controllers/pallets/PalletsAssetConversionController.ts
+++ b/src/controllers/pallets/PalletsAssetConversionController.ts
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { BlockHash } from '@polkadot/types/interfaces';
 import { RequestHandler } from 'express';
 
+import { validateRcAt } from '../../middleware';
 import { PalletsAssetConversionService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -28,20 +30,70 @@ export default class PalletsAssetConversionController extends AbstractController
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateRcAt);
 		this.safeMountAsyncGetHandlers([
 			['/next-available-id', this.getNextAvailableId],
 			['/liquidity-pools', this.getLiquidityPools],
 		]);
 	}
 
-	private getNextAvailableId: RequestHandler = async ({ query: { at } }, res): Promise<void> => {
-		const hash = await this.getHashFromAt(at);
+	private getNextAvailableId: RequestHandler = async ({ query: { at, rcAt } }, res): Promise<void> => {
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
 
-		PalletsAssetConversionController.sanitizedSend(res, await this.service.fetchNextAvailableId(hash));
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
+		const result = await this.service.fetchNextAvailableId(hash);
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsAssetConversionController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsAssetConversionController.sanitizedSend(res, result);
+		}
 	};
 
-	private getLiquidityPools: RequestHandler = async ({ query: { at } }, res): Promise<void> => {
-		const hash = await this.getHashFromAt(at);
-		PalletsAssetConversionController.sanitizedSend(res, await this.service.fetchLiquidityPools(hash));
+	private getLiquidityPools: RequestHandler = async ({ query: { at, rcAt } }, res): Promise<void> => {
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
+
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
+		const result = await this.service.fetchLiquidityPools(hash);
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsAssetConversionController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsAssetConversionController.sanitizedSend(res, result);
+		}
 	};
 }

--- a/src/controllers/pallets/PalletsDispatchablesController.ts
+++ b/src/controllers/pallets/PalletsDispatchablesController.ts
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { BlockHash } from '@polkadot/types/interfaces';
 import { stringCamelCase } from '@polkadot/util';
 import { RequestHandler } from 'express-serve-static-core';
 
+import { validateRcAt } from '../../middleware';
 import { PalletsDispatchablesService } from '../../services';
 import { IPalletsDispatchablesParam } from '../../types/requests';
 import AbstractController from '../AbstractController';
@@ -42,57 +44,92 @@ export default class PalletsDispatchablesController extends AbstractController<P
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateRcAt);
 		this.safeMountAsyncGetHandlers([
 			['/:dispatchableItemId', this.getDispatchableById as RequestHandler],
 			['/', this.getDispatchables],
 		]);
 	}
 
-	/**
-	 * Note: the `at` parameter is not provided because the call for dispatchables does not exist on the historicApi currently.
-	 * Support may be added for this in a future update.
-	 */
 	private getDispatchableById: RequestHandler<IPalletsDispatchablesParam, unknown, unknown> = async (
-		{ query: { metadata }, params: { palletId, dispatchableItemId } },
+		{ query: { metadata, at, rcAt }, params: { palletId, dispatchableItemId } },
 		res,
 	): Promise<void> => {
-		const at = undefined;
-		const hash = await this.getHashFromAt(at);
 		const metadataArg = metadata === 'true';
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
+
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
 		const historicApi = await this.api.at(hash);
 
-		PalletsDispatchablesController.sanitizedSend(
-			res,
-			await this.service.fetchDispatchableItem(historicApi, {
-				hash,
-				// stringCamelCase ensures we don't have snake case or kebab case
-				palletId: stringCamelCase(palletId),
-				dispatchableItemId: stringCamelCase(dispatchableItemId),
-				metadata: metadataArg,
-			}),
-		);
+		const result = await this.service.fetchDispatchableItem(historicApi, {
+			hash,
+			// stringCamelCase ensures we don't have snake case or kebab case
+			palletId: stringCamelCase(palletId),
+			dispatchableItemId: stringCamelCase(dispatchableItemId),
+			metadata: metadataArg,
+		});
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsDispatchablesController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsDispatchablesController.sanitizedSend(res, result);
+		}
 	};
 
-	/**
-	 * Note: the `at` parameter is not provided because the call for dispatchables does not exist on the historicApi currently.
-	 * Support may be added for this in a future update.
-	 */
 	private getDispatchables: RequestHandler = async (
-		{ params: { palletId }, query: { onlyIds } },
+		{ params: { palletId }, query: { onlyIds, at, rcAt } },
 		res,
 	): Promise<void> => {
-		const at = undefined;
-		const hash = await this.getHashFromAt(at);
 		const onlyIdsArg = onlyIds === 'true';
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
+
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
 		const historicApi = await this.api.at(hash);
 
-		PalletsDispatchablesController.sanitizedSend(
-			res,
-			await this.service.fetchDispatchables(historicApi, {
-				hash,
-				palletId: stringCamelCase(palletId),
-				onlyIds: onlyIdsArg,
-			}),
-		);
+		const result = await this.service.fetchDispatchables(historicApi, {
+			hash,
+			palletId: stringCamelCase(palletId),
+			onlyIds: onlyIdsArg,
+		});
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsDispatchablesController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsDispatchablesController.sanitizedSend(res, result);
+		}
 	};
 }

--- a/src/controllers/pallets/PalletsErrorsController.ts
+++ b/src/controllers/pallets/PalletsErrorsController.ts
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { BlockHash } from '@polkadot/types/interfaces';
 import { stringCamelCase } from '@polkadot/util';
 import { RequestHandler } from 'express-serve-static-core';
 
+import { validateRcAt } from '../../middleware';
 import { PalletsErrorsService } from '../../services';
 import { IPalletsErrorsParam } from '../../types/requests';
 import AbstractController from '../AbstractController';
@@ -42,6 +44,7 @@ export default class PalletsErrorsController extends AbstractController<PalletsE
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateRcAt);
 		this.safeMountAsyncGetHandlers([
 			['/:errorItemId', this.getErrorById as RequestHandler],
 			['/', this.getErrors],
@@ -49,37 +52,84 @@ export default class PalletsErrorsController extends AbstractController<PalletsE
 	}
 
 	private getErrorById: RequestHandler<IPalletsErrorsParam, unknown, unknown> = async (
-		{ query: { at, metadata }, params: { palletId, errorItemId } },
+		{ query: { at, metadata, rcAt }, params: { palletId, errorItemId } },
 		res,
 	): Promise<void> => {
 		const metadataArg = metadata === 'true';
-		const hash = await this.getHashFromAt(at);
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
+
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
 		const historicApi = await this.api.at(hash);
 
-		PalletsErrorsController.sanitizedSend(
-			res,
-			await this.service.fetchErrorItem(historicApi, {
-				hash,
-				// stringCamelCase ensures we don't have snake case or kebab case
-				palletId: stringCamelCase(palletId),
-				errorItemId: stringCamelCase(errorItemId),
-				metadata: metadataArg,
-			}),
-		);
+		const result = await this.service.fetchErrorItem(historicApi, {
+			hash,
+			// stringCamelCase ensures we don't have snake case or kebab case
+			palletId: stringCamelCase(palletId),
+			errorItemId: stringCamelCase(errorItemId),
+			metadata: metadataArg,
+		});
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsErrorsController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsErrorsController.sanitizedSend(res, result);
+		}
 	};
 
-	private getErrors: RequestHandler = async ({ params: { palletId }, query: { at, onlyIds } }, res): Promise<void> => {
+	private getErrors: RequestHandler = async (
+		{ params: { palletId }, query: { at, onlyIds, rcAt } },
+		res,
+	): Promise<void> => {
 		const onlyIdsArg = onlyIds === 'true';
-		const hash = await this.getHashFromAt(at);
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
+
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
 		const historicApi = await this.api.at(hash);
 
-		PalletsErrorsController.sanitizedSend(
-			res,
-			await this.service.fetchErrors(historicApi, {
-				hash,
-				palletId: stringCamelCase(palletId),
-				onlyIds: onlyIdsArg,
-			}),
-		);
+		const result = await this.service.fetchErrors(historicApi, {
+			hash,
+			palletId: stringCamelCase(palletId),
+			onlyIds: onlyIdsArg,
+		});
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsErrorsController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsErrorsController.sanitizedSend(res, result);
+		}
 	};
 }

--- a/src/controllers/pallets/PalletsNominationPoolsController.ts
+++ b/src/controllers/pallets/PalletsNominationPoolsController.ts
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { BlockHash } from '@polkadot/types/interfaces';
 import { RequestHandler } from 'express';
 
+import { validateRcAt } from '../../middleware';
 import { PalletsNominationPoolService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -28,6 +30,7 @@ export default class PalletsNominationPoolController extends AbstractController<
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateRcAt);
 		this.safeMountAsyncGetHandlers([
 			['/info', this.getNominationPoolInfo],
 			['/:poolId', this.getNominationPoolById],
@@ -35,7 +38,7 @@ export default class PalletsNominationPoolController extends AbstractController<
 	}
 
 	private getNominationPoolById: RequestHandler = async (
-		{ params: { poolId }, query: { at, metadata } },
+		{ params: { poolId }, query: { at, rcAt, metadata } },
 		res,
 	): Promise<void> => {
 		/**
@@ -46,17 +49,62 @@ export default class PalletsNominationPoolController extends AbstractController<
 
 		const metadataArg = metadata === 'true';
 
-		const hash = await this.getHashFromAt(at);
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
 
-		PalletsNominationPoolController.sanitizedSend(
-			res,
-			await this.service.fetchNominationPoolById(index, hash, metadataArg),
-		);
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
+		const result = await this.service.fetchNominationPoolById(index, hash, metadataArg);
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsNominationPoolController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsNominationPoolController.sanitizedSend(res, result);
+		}
 	};
 
-	private getNominationPoolInfo: RequestHandler = async ({ query: { at } }, res): Promise<void> => {
-		const hash = await this.getHashFromAt(at);
+	private getNominationPoolInfo: RequestHandler = async ({ query: { at, rcAt } }, res): Promise<void> => {
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
 
-		PalletsNominationPoolController.sanitizedSend(res, await this.service.fetchNominationPoolInfo(hash));
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
+		const result = await this.service.fetchNominationPoolInfo(hash);
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsNominationPoolController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsNominationPoolController.sanitizedSend(res, result);
+		}
 	};
 }

--- a/src/controllers/pallets/PalletsStakingValidatorsController.ts
+++ b/src/controllers/pallets/PalletsStakingValidatorsController.ts
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import { BlockHash } from '@polkadot/types/interfaces';
 import { RequestHandler } from 'express';
 
+import { validateRcAt } from '../../middleware';
 import { PalletsStakingValidatorsService } from '../../services';
 import AbstractController from '../AbstractController';
 
@@ -28,6 +30,7 @@ export default class PalletsStakingValidatorsController extends AbstractControll
 	}
 
 	protected initRoutes(): void {
+		this.router.use(this.path, validateRcAt);
 		this.safeMountAsyncGetHandlers([['', this.getPalletStakingValidators]]);
 	}
 
@@ -37,8 +40,33 @@ export default class PalletsStakingValidatorsController extends AbstractControll
 	 * @param _req Express Request
 	 * @param res Express Response
 	 */
-	private getPalletStakingValidators: RequestHandler = async ({ query: { at } }, res): Promise<void> => {
-		const hash = await this.getHashFromAt(at);
-		PalletsStakingValidatorsController.sanitizedSend(res, await this.service.derivePalletStakingValidators(hash));
+	private getPalletStakingValidators: RequestHandler = async ({ query: { at, rcAt } }, res): Promise<void> => {
+		let hash: BlockHash;
+		let rcBlockNumber: string | undefined;
+
+		if (rcAt) {
+			const rcAtResult = await this.getHashFromRcAt(rcAt);
+			hash = rcAtResult.ahHash;
+			rcBlockNumber = rcAtResult.rcBlockNumber;
+		} else {
+			hash = await this.getHashFromAt(at);
+		}
+
+		const result = await this.service.derivePalletStakingValidators(hash);
+
+		if (rcBlockNumber) {
+			const apiAt = await this.api.at(hash);
+			const ahTimestamp = await apiAt.query.timestamp.now();
+
+			const enhancedResult = {
+				...result,
+				rcBlockNumber,
+				ahTimestamp: ahTimestamp.toString(),
+			};
+
+			PalletsStakingValidatorsController.sanitizedSend(res, enhancedResult);
+		} else {
+			PalletsStakingValidatorsController.sanitizedSend(res, result);
+		}
 	};
 }


### PR DESCRIPTION
  Summary

  - Adds rcAt parameter support to multiple pallets endpoints for Asset Hub relay chain integration
  - Enhances responses with relay chain context when rcAt parameter is used

  Endpoints with rcAt support added:

  - /pallets/nomination-pools/info
  - /pallets/nomination-pools/{poolId}
  - /pallets/on-going-referenda
  - /pallets/{palletId}/consts
  - /pallets/{palletId}/consts/{constItemId}
  - /pallets/{palletId}/dispatchables
  - /pallets/{palletId}/dispatchables/{dispatchableItemId}
  - /pallets/{palletId}/errors
  - /pallets/{palletId}/errors/{errorItemId}
  - /pallets/{palletId}/events
  - /pallets/{palletId}/events/{eventItemId}
  - /pallets/{palletId}/storage
  - /pallets/{palletId}/storage/{storageItemId}
  - /pallets/pool-assets/{assetId}/asset-info
  - /pallets/staking/validators