### PR TITLE
fix: Ensure `rcBlockNumber` is always a number

### DIFF
--- a/src/controllers/controllerInjection.spec.ts
+++ b/src/controllers/controllerInjection.spec.ts
@@ -63,7 +63,7 @@ const chainsToNode: Record<string, string> = {
 	'coretime-polkadot': 'wss://sys.ibp.network/coretime-polkadot',
 	crust: 'wss://crust-parachain.crustapps.net',
 	karura: 'wss://karura-rpc.dwellir.com',
-	manta: 'wss://ws.manta.systems',
+	// manta: 'wss://ws.manta.systems',
 	kilt: 'wss://kilt.ibp.network',
 	'asset-hub-polkadot': 'wss://asset-hub-polkadot-rpc.dwellir.com',
 };


### PR DESCRIPTION
This just patches `rcBlockNumber`. Technically if the user passes in no `at` it will get the `latest`, and if the user passes in a hash, it will return the hash. This PR fixes that.