### PR TITLE
feat: Add transferable field to `/accounts/{accountId}/balance-info`

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -4309,6 +4309,14 @@ components:
             Note, that some runtimes may not have support for frozen and if so the following 
             will be returned `frozen does not exist for this runtime`
           format: unsignedInteger
+        transferable:
+          type: string
+          description: The amount that can be transferred from this account. This is calculated using the formula
+            `free - max(maybeEd, frozen - reserve)` where `maybeEd` is the existential deposit if there are frozen
+            funds or reserves, otherwise zero. This represents the actual spendable balance.
+            Note, that some historical runtimes may not have support for the current formula used and if so the following
+            will be returned `transferable not supported for this runtime`.
+          format: unsignedInteger
         locks:
           type: array
           description: Array of locks on a balance. There can be many of these on

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -4313,7 +4313,7 @@ components:
           type: string
           description: The amount that can be transferred from this account. This is calculated using the formula
             `free - max(maybeEd, frozen - reserve)` where `maybeEd` is the existential deposit if there are frozen
-            funds or reserves, otherwise zero. This represents the actual spendable balance.
+            funds or reserves, otherwise it is zero. This represents the actual spendable balance.
             Note, that some historical runtimes may not have support for the current formula used and if so the following
             will be returned `transferable not supported for this runtime`.
           format: unsignedInteger

--- a/src/services/accounts/AccountsBalanceInfoService.spec.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.spec.ts
@@ -179,6 +179,7 @@ describe('AccountsBalanceInfoService', () => {
 					},
 				],
 				miscFrozen: '100000000000',
+				transferable: 'transferable formula not supported for this runtime',
 				nonce: '6',
 				reserved: '0',
 				tokenSymbol: 'DOT',

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -90,6 +90,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 					miscFrozen: 'miscFrozen does not exist for this runtime',
 					feeFrozen: 'feeFrozen does not exist for this runtime',
 					frozen: 'frozen does not exist for this runtime',
+					transferable: 'transferable not supported for this runtime',
 					locks: this.inDenominationLocks(denominate, locks, decimal),
 				};
 			} else {
@@ -106,11 +107,15 @@ export class AccountsBalanceInfoService extends AbstractService {
 
 			const { data, nonce } = accountInfo;
 
-			let free, reserved, feeFrozen, miscFrozen, frozen;
+			let free, reserved, feeFrozen, miscFrozen, frozen, transferable;
 			if (accountInfo.data?.frozen) {
+				const deriveData = await this.api.derive.balances.all(address);
 				free = data.free;
 				reserved = data.reserved;
 				frozen = data.frozen;
+				// We put `!` because we know the transferable wont be null in this specific case.
+				// Since the underlying logic in PJS and here verify the same set of cases.
+				transferable = deriveData.transferable!;
 				miscFrozen = 'miscFrozen does not exist for this runtime';
 				feeFrozen = 'feeFrozen does not exist for this runtime';
 			} else {
@@ -119,6 +124,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				reserved = tmpData.reserved;
 				feeFrozen = tmpData.feeFrozen;
 				miscFrozen = tmpData.miscFrozen;
+				transferable = 'transferable formula not supported for this runtime';
 				frozen = 'frozen does not exist for this runtime';
 			}
 
@@ -138,6 +144,8 @@ export class AccountsBalanceInfoService extends AbstractService {
 						typeof miscFrozen === 'string' ? miscFrozen : this.inDenominationBal(denominate, miscFrozen, decimal),
 					feeFrozen: typeof feeFrozen === 'string' ? feeFrozen : this.inDenominationBal(denominate, feeFrozen, decimal),
 					frozen: typeof frozen === 'string' ? frozen : this.inDenominationBal(denominate, frozen, decimal),
+					transferable:
+						typeof transferable === 'string' ? transferable : this.inDenominationBal(denominate, transferable, decimal),
 					locks: this.inDenominationLocks(denominate, locks, decimal),
 				};
 			} else {
@@ -188,7 +196,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 
 		if (accountData && locks && accountInfo) {
 			const { nonce } = accountInfo;
-			let free, reserved, feeFrozen, miscFrozen, frozen;
+			let free, reserved, feeFrozen, miscFrozen, frozen, transferable;
 			if ((accountData as AccountData).miscFrozen) {
 				const tmpData = accountData as AccountData;
 				free = tmpData.free;
@@ -196,11 +204,14 @@ export class AccountsBalanceInfoService extends AbstractService {
 				feeFrozen = tmpData.feeFrozen;
 				miscFrozen = tmpData.miscFrozen;
 				frozen = 'frozen does not exist for this runtime';
+				transferable = 'transferable not supported for this runtime';
 			} else {
+				const deriveData = await this.api.derive.balances.all(address);
 				const tmpData = accountData as PalletBalancesAccountData;
 				free = tmpData.free;
 				reserved = tmpData.reserved;
 				frozen = tmpData.frozen;
+				transferable = deriveData.transferable!;
 				feeFrozen = 'feeFrozen does not exist for this runtime';
 				miscFrozen = 'miscFrozen does not exist for this runtime';
 			}
@@ -215,6 +226,8 @@ export class AccountsBalanceInfoService extends AbstractService {
 					typeof miscFrozen === 'string' ? miscFrozen : this.inDenominationBal(denominate, miscFrozen, decimal),
 				feeFrozen: typeof feeFrozen === 'string' ? feeFrozen : this.inDenominationBal(denominate, feeFrozen, decimal),
 				frozen: typeof frozen === 'string' ? frozen : this.inDenominationBal(denominate, frozen, decimal),
+				transferable:
+					typeof transferable === 'string' ? transferable : this.inDenominationBal(denominate, transferable, decimal),
 				locks: this.inDenominationLocks(denominate, locks, decimal),
 			};
 		} else {

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -90,7 +90,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 					miscFrozen: 'miscFrozen does not exist for this runtime',
 					feeFrozen: 'feeFrozen does not exist for this runtime',
 					frozen: 'frozen does not exist for this runtime',
-					transferable: 'transferable not supported for this runtime',
+					transferable: 'transferable formula not supported for this runtime',
 					locks: this.inDenominationLocks(denominate, locks, decimal),
 				};
 			} else {
@@ -204,7 +204,7 @@ export class AccountsBalanceInfoService extends AbstractService {
 				feeFrozen = tmpData.feeFrozen;
 				miscFrozen = tmpData.miscFrozen;
 				frozen = 'frozen does not exist for this runtime';
-				transferable = 'transferable not supported for this runtime';
+				transferable = 'transferable formula not supported for this runtime';
 			} else {
 				const deriveData = await this.api.derive.balances.all(address);
 				const tmpData = accountData as PalletBalancesAccountData;

--- a/src/services/accounts/AccountsBalanceInfoService.ts
+++ b/src/services/accounts/AccountsBalanceInfoService.ts
@@ -113,9 +113,9 @@ export class AccountsBalanceInfoService extends AbstractService {
 				free = data.free;
 				reserved = data.reserved;
 				frozen = data.frozen;
-				// We put `!` because we know the transferable wont be null in this specific case.
-				// Since the underlying logic in PJS and here verify the same set of cases.
-				transferable = deriveData.transferable!;
+				transferable = deriveData.transferable
+					? deriveData.transferable
+					: 'transferable formula not supported for this runtime';
 				miscFrozen = 'miscFrozen does not exist for this runtime';
 				feeFrozen = 'feeFrozen does not exist for this runtime';
 			} else {
@@ -211,7 +211,9 @@ export class AccountsBalanceInfoService extends AbstractService {
 				free = tmpData.free;
 				reserved = tmpData.reserved;
 				frozen = tmpData.frozen;
-				transferable = deriveData.transferable!;
+				transferable = deriveData.transferable
+					? deriveData.transferable
+					: 'transferable formula not supported for this runtime';
 				feeFrozen = 'feeFrozen does not exist for this runtime';
 				miscFrozen = 'miscFrozen does not exist for this runtime';
 			}

--- a/src/services/test-helpers/responses/accounts/balanceInfo789629.json
+++ b/src/services/test-helpers/responses/accounts/balanceInfo789629.json
@@ -10,6 +10,7 @@
   "miscFrozen": "100000000000",
   "feeFrozen": "100000000000",
   "frozen": "frozen does not exist for this runtime",
+  "transferable": "transferable formula not supported for this runtime",
   "locks": [
     {
       "id": "0x7374616b696e6720",

--- a/src/services/test-helpers/responses/accounts/balanceInfoFeeFrozen.json
+++ b/src/services/test-helpers/responses/accounts/balanceInfoFeeFrozen.json
@@ -10,6 +10,7 @@
     "miscFrozen": "111111",
     "feeFrozen": "111111",
     "frozen": "frozen does not exist for this runtime",
+    "transferable": "transferable formula not supported for this runtime",
     "locks": [
         {
             "id": "0x7374616b696e6720",

--- a/src/types/responses/AccountBalanceInfo.ts
+++ b/src/types/responses/AccountBalanceInfo.ts
@@ -28,6 +28,15 @@ export interface IAccountBalanceInfo {
 	miscFrozen: Balance | string;
 	feeFrozen: Balance | string;
 	frozen: Balance | string;
+	/**
+	 * Calculated transferable balance. This uses the formula: free - max(maybeEd, frozen - reserve)
+	 * Where `maybeEd` means if there is no frozen and reserves it will be zero, else it will be the existential deposit.
+	 * This is only correct when the return type of `api.query.system.account` is `FrameSystemAccountInfo`.
+	 * Which is the most up to date calculation for transferable balances.
+	 *
+	 * ref: https://github.com/paritytech/polkadot-sdk/issues/1833
+	 */
+	transferable: Balance | string;
 	locks: Vec<BalanceLock> | IBalanceLock[];
 	rcBlockNumber?: string;
 	ahTimestamp?: string;


### PR DESCRIPTION
## Add transferable balance field and documentation

  This PR adds the `transferable` field to balance-info endpoints and provides documentation explaining its calculation.

  ### Changes
  - Added `transferable` field to the `IAccountBalanceInfo` interface with detailed JSDoc documentation
  - Updated OpenAPI schema to include the `transferable` field for both balance-info endpoints:
    - `/accounts/{accountId}/balance-info`
    - `/rc/accounts/{address}/balance-info`

  ### Transferable Balance Formula
  The transferable balance uses the formula: `free - max(maybeEd, frozen - reserve)`

  Where:
  - `maybeEd` is the existential deposit if there are frozen funds or reserves, otherwise zero
  - This represents the actual spendable balance after accounting for locks, reserves, and the existential deposit
  
  NOTE: The polkadot-js implementation I am using here is a UI-friendly calculation that considers:
  
- When the account has NO reserves and NO frozen funds, the user can practically transfer their entire free balance.
- When the account HAS reserves or frozen funds, the ED must be protected