### PR TITLE
add evmFormat option to blocks queries for revive pallet

### DIFF
--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -180,7 +180,11 @@ export default class BlocksController extends AbstractController<BlocksService> 
 	 * @param res Express Response
 	 */
 	private getLatestBlock: IRequestHandlerWithMetrics<unknown, IBlockQueryParams> = async (
-		{ query: { eventDocs, extrinsicDocs, finalized, noFees, decodedXcmMsgs, paraId, useRcBlock }, method, route },
+		{
+			query: { eventDocs, extrinsicDocs, finalized, noFees, decodedXcmMsgs, paraId, useRcBlock, useEvmFormat },
+			method,
+			route,
+		},
 		res,
 	) => {
 		const eventDocsArg = eventDocs === 'true';
@@ -261,6 +265,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			noFees: noFeesArg,
 			checkDecodedXcm: decodedXcmMsgsArg,
 			paraId: paraIdArg,
+			useEvmAddressFormat: useEvmFormat === 'true',
 		};
 		// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
 		const cacheKey =
@@ -270,7 +275,8 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			Number(options.checkFinalized) +
 			Number(options.noFees) +
 			Number(options.checkDecodedXcm) +
-			Number(options.paraId);
+			Number(options.paraId) +
+			Number(options.useEvmAddressFormat);
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -329,7 +335,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 	private getBlockById: IRequestHandlerWithMetrics<INumberParam, IBlockQueryParams> = async (
 		{
 			params: { number },
-			query: { eventDocs, extrinsicDocs, noFees, finalizedKey, decodedXcmMsgs, paraId, useRcBlock },
+			query: { eventDocs, extrinsicDocs, noFees, finalizedKey, decodedXcmMsgs, paraId, useRcBlock, useEvmFormat },
 			method,
 			route,
 		},
@@ -379,6 +385,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			noFees: noFeesArg,
 			checkDecodedXcm: decodedXcmMsgsArg,
 			paraId: paraIdArg,
+			useEvmAddressFormat: useEvmFormat === 'true',
 		};
 
 		// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
@@ -390,7 +397,8 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			Number(options.checkFinalized) +
 			Number(options.noFees) +
 			Number(options.checkDecodedXcm) +
-			Number(options.paraId);
+			Number(options.paraId) +
+			Number(options.useEvmAddressFormat);
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -553,7 +561,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 	 * @param res Express Response
 	 */
 	private getBlocks: IRequestHandlerWithMetrics<unknown, IRangeQueryParam & IBlockQueryParams> = async (
-		{ query: { range, eventDocs, extrinsicDocs, noFees, useRcBlock }, method, route },
+		{ query: { range, eventDocs, extrinsicDocs, noFees, useRcBlock, useEvmFormat }, method, route },
 		res,
 	): Promise<void> => {
 		if (!range) throw new BadRequest('range query parameter must be inputted.');
@@ -576,6 +584,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			noFees: noFeesArg,
 			checkDecodedXcm: false,
 			paraId: undefined,
+			useEvmAddressFormat: useEvmFormat === 'true',
 		};
 
 		const pQueue = new PromiseQueue(4);

--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -38,7 +38,7 @@ import type {
 } from '@polkadot/types/interfaces';
 import type { AnyJson, Codec, Registry } from '@polkadot/types/types';
 import { u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
+import { blake2AsU8a, decodeAddress, isAddress } from '@polkadot/util-crypto';
 import { calc_partial_fee } from '@substrate/calc';
 import BN from 'bn.js';
 import { BadRequest, InternalServerError } from 'http-errors';
@@ -76,6 +76,7 @@ interface FetchBlockOptions {
 	noFees: boolean;
 	checkDecodedXcm: boolean;
 	paraId?: number;
+	useEvmAddressFormat?: boolean;
 }
 
 interface ExtrinsicSuccessOrFailedOverride {
@@ -119,6 +120,7 @@ export class BlocksService extends AbstractService {
 			noFees,
 			checkDecodedXcm,
 			paraId,
+			useEvmAddressFormat = false,
 		}: FetchBlockOptions,
 	): Promise<IBlock> {
 		const { api } = this;
@@ -238,6 +240,38 @@ export class BlocksService extends AbstractService {
 			finalized,
 			decodedXcmMsgs,
 		};
+
+		const convertToEvm =
+			useEvmAddressFormat &&
+			(this.api.registry.metadata.toJSON().pallets as unknown as Record<string, unknown>[])
+				.map((p) => (p.name as string).toLowerCase())
+				.includes('revive');
+
+		if (convertToEvm) {
+			// Convert SS58 addresses to EVM addresses if the revive pallet is present
+			const updatedExtrinsics = extrinsics.map((ext) => {
+				if (isFrameMethod(ext.method) && ext.method.pallet === 'revive') {
+					return {
+						...ext,
+						events: ext.events.map((event) => {
+							return {
+								...event,
+								data: event.data.map((d) => {
+									if (isAddress(d.toString())) {
+										return u8aToHex(decodeAddress(d.toString()).subarray(0, 20));
+									}
+									return d;
+								}),
+							};
+						}),
+					};
+				}
+				return ext;
+			});
+
+			response.extrinsics = updatedExtrinsics as IBlock['extrinsics'];
+		}
+
 		return response;
 	}
 


### PR DESCRIPTION
This PR aims to implement an option to convert the data included in the emitted events from pallet-revive into evm format (for addresses). The default method returns the standard SS58 format, while using the query param `useEvmFormat=true` will return the data with evm formatted addresses.

closes #1660 