### PR TITLE
fix: Add support for migrationStartBlock and migrationEndBlock storage in staking

### DIFF
--- a/src/chains-config/index.ts
+++ b/src/chains-config/index.ts
@@ -88,7 +88,7 @@ export const specToControllerMap: { [x: string]: ControllerConfig } = {
 	'coretime-kusama': coretimeControllers,
 };
 
-export const assetHubSpecNames = new Set(['statemine', 'statemint', 'westmint']);
+export const assetHubSpecNames = new Set(['statemine', 'statemint', 'westmint', 'asset-hub-paseo']);
 
 export const assetHubToBabe: Record<
 	string,

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -346,8 +346,9 @@ export class AccountsStakingPayoutsService extends AbstractService {
 					rcApiAt.query.staking.currentEra(),
 				]);
 
+				// We should never hit this, but its here for safety and clarity
 				if (ahCurrentEra.isNone || rcCurrentEra.isNone) {
-					throw new Error('No era found');
+					throw new Error('No era found in staking payouts');
 				}
 
 				migrationBoundaries = {

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -315,10 +315,18 @@ export class AccountsStakingPayoutsService extends AbstractService {
 		const specName = this.getSpecName().toLowerCase();
 
 		// Get migration boundaries for this chain
-		const migrationBoundaries = MIGRATION_BOUNDARIES[specName];
+		let migrationBoundaries = MIGRATION_BOUNDARIES[specName];
+
 		if (!migrationBoundaries) {
-			// Fallback to regular method if no migration boundaries defined
-			return this.fetchAccountStakingPayout(hash, address, depth, era, unclaimedOnly, currentEra, historicApi);
+			// Check storage first then fallback to fetchStakingAccount;
+			if (api.query.ahMigrator?.migrationStartBlock && api.query.ahMigrator?.migrationEndBlock) {
+				// Query the migration start block and end block for both assethub and relay chain
+				// Also query the eras for the given start blocks.
+				// Then set `migrationBoundaries`
+			} else {
+				// Fallback to regular method if no migration boundaries defined
+				return this.fetchAccountStakingPayout(hash, address, depth, era, unclaimedOnly, currentEra, historicApi);
+			}
 		}
 
 		const sanitizedEra = era < 0 ? 0 : era;

--- a/src/services/accounts/AccountsStakingPayoutsService.ts
+++ b/src/services/accounts/AccountsStakingPayoutsService.ts
@@ -320,9 +320,44 @@ export class AccountsStakingPayoutsService extends AbstractService {
 		if (!migrationBoundaries) {
 			// Check storage first then fallback to fetchStakingAccount;
 			if (api.query.ahMigrator?.migrationStartBlock && api.query.ahMigrator?.migrationEndBlock) {
-				// Query the migration start block and end block for both assethub and relay chain
-				// Also query the eras for the given start blocks.
-				// Then set `migrationBoundaries`
+				const rcApi = ApiPromiseRegistry.getApiByType('relay')[0].api;
+
+				// Get start and end blocks
+				const [ahStart, ahEnd, rcStart, rcEnd] = await Promise.all([
+					this.api.query.ahMigrator?.migrationStartBlock<Option<u32>>(),
+					this.api.query.ahMigrator?.migrationEndBlock<Option<u32>>(),
+					rcApi.query.rcMigrator?.migrationStartBlock<Option<u32>>(),
+					rcApi.query.rcMigrator?.migrationEndBlock<Option<u32>>(),
+				]);
+
+				if (ahStart.isNone || ahEnd.isNone || rcStart.isNone || rcEnd.isNone) {
+					return this.fetchAccountStakingPayout(hash, address, depth, era, unclaimedOnly, currentEra, historicApi);
+				}
+
+				const [ahEndBlockHash, rcStartBlockHash] = await Promise.all([
+					this.api.rpc.chain.getBlockHash(ahEnd.unwrap()),
+					rcApi.rpc.chain.getBlockHash(rcStart.unwrap()),
+				]);
+
+				const [ahApiAt, rcApiAt] = await Promise.all([this.api.at(ahEndBlockHash), rcApi.at(rcStartBlockHash)]);
+
+				const [ahCurrentEra, rcCurrentEra] = await Promise.all([
+					ahApiAt.query.staking.currentEra(),
+					rcApiAt.query.staking.currentEra(),
+				]);
+
+				if (ahCurrentEra.isNone || rcCurrentEra.isNone) {
+					throw new Error('No era found');
+				}
+
+				migrationBoundaries = {
+					relayChainLastEra: rcCurrentEra.unwrap().toNumber(),
+					assetHubFirstEra: ahCurrentEra.unwrap().toNumber(),
+					assetHubMigrationStartedAt: ahStart.unwrap().toNumber(),
+					assetHubMigrationEndedAt: ahEnd.unwrap().toNumber(),
+					relayMigrationStartedAt: rcStart.unwrap().toNumber(),
+					relayMigrationEndedAt: rcEnd.unwrap().toNumber(),
+				};
 			} else {
 				// Fallback to regular method if no migration boundaries defined
 				return this.fetchAccountStakingPayout(hash, address, depth, era, unclaimedOnly, currentEra, historicApi);


### PR DESCRIPTION
## Summary

This ensures that staking payouts is dynamic for dealing with post migration querying with eras. Since we require the start and end block of both the relay chain and asset hub when query a depth of 84 from a certain block on assetHub it's required we need this information in storage, before we can get it hardcoded in the codebase.

We also added `asset-hub-paseo` to the config.

### Affected Endpoint

`/accounts/{accountId}/staking-payouts`

