### PR TITLE
feat: Add `/rc/accounts/*` Endpoints for Relay Chain Queries with Multi Chain AH setup

### DIFF
--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -933,6 +933,59 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /rc/accounts/{address}/staking-info:
+    get:
+      tags:
+      - rc
+      summary: Get staking information for a _Stash_ account on the relay chain.
+      description: Returns information about a _Stash_ account's staking activity on the relay chain. This endpoint is specifically for Asset Hub and queries the relay chain (Polkadot/Kusama) for staking information. The _Stash_ account can be either a validator or nominator account.
+      operationId: getRcAccountStakingInfo
+      parameters:
+      - name: address
+        in: path
+        description: SS58 address of the account. Must be a _Stash_ account.
+        required: true
+        schema:
+          type: string
+          format: SS58
+      - name: at
+        in: query
+        description: Block at which to query the staking info for the
+          specified account.
+        required: false
+        schema:
+          type: string
+          description: Block height (as a non-negative integer) or hash
+            (as a hex string).
+          format: unsignedInteger or $hex
+      - name: includeClaimedRewards
+        in: query
+        description: When set to `false`, the `claimedRewards` field is not included
+          in the response.
+        required: false
+        schema:
+          type: string
+          format: boolean
+          default: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountStakingInfo'
+        "400":
+          description: Invalid Address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "404":
+          description: account not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /rc/node/network:
     get:
       tags:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -889,6 +889,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /rc/accounts/{address}/vesting-info:
+    get:
+      tags:
+      - rc
+      summary: Get vesting information for an account on the relay chain.
+      description: Returns the vesting schedule for an account on the relay chain. This endpoint is specifically for Asset Hub and queries the relay chain (Polkadot/Kusama) for vesting information.
+      operationId: getRcAccountVestingInfo
+      parameters:
+      - name: address
+        in: path
+        description: SS58 address of the account.
+        required: true
+        schema:
+          type: string
+          format: SS58
+      - name: at
+        in: query
+        description: Block at which to query the vesting info for the
+          specified account.
+        required: false
+        schema:
+          type: string
+          description: Block height (as a non-negative integer) or hash
+            (as a hex string).
+          format: unsignedInteger or $hex
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVestingInfo'
+        "400":
+          description: Invalid Address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "404":
+          description: account not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /rc/node/network:
     get:
       tags:

--- a/docs/src/openapi-v1.yaml
+++ b/docs/src/openapi-v1.yaml
@@ -986,6 +986,75 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /rc/accounts/{address}/staking-payouts:
+    get:
+      tags:
+      - rc
+      summary: Get payout information for a _Stash_ account on the relay chain.
+      description: Returns payout information for the last specified eras on the relay chain. This endpoint is specifically for Asset Hub and queries the relay chain (Polkadot/Kusama) for staking payout information. If specifying both the depth and era query params, this endpoint will return information for (era - depth) through era. (i.e. if depth=5 and era=20 information will be returned for eras 16 through 20). The _Stash_ account can be either a validator or nominator account.
+      operationId: getRcAccountStakingPayouts
+      parameters:
+      - name: address
+        in: path
+        description: SS58 address of the account. Must be a _Stash_ account.
+        required: true
+        schema:
+          type: string
+          format: SS58
+      - name: at
+        in: query
+        description: Block at which to query staking payouts.
+        required: false
+        schema:
+          type: string
+          description: Block height (as a non-negative integer) or hash
+            (as a hex string).
+          format: unsignedInteger or $hex
+      - name: depth
+        in: query
+        description: The number of eras to query for payouts of. Must be less
+          than or equal to `HISTORY_DEPTH`. In cases where `era - (depth -1)` is
+          less than 0, the first era queried will be 0.
+        required: false
+        schema:
+          type: string
+          format: unsignedInteger
+          default: 1
+      - name: era
+        in: query
+        description: The era to query at. Max era payout info is available for
+          is the latest finished era (active_era - 1).
+        required: false
+        schema:
+          type: string
+          format: unsignedInteger
+      - name: unclaimedOnly
+        in: query
+        description: Only return unclaimed rewards.
+        required: false
+        schema:
+          type: string
+          format: boolean
+          default: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountStakingPayouts'
+        "400":
+          description: Invalid Address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "404":
+          description: account not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /rc/node/network:
     get:
       tags:

--- a/src/chains-config/assetHubKusamaControllers.ts
+++ b/src/chains-config/assetHubKusamaControllers.ts
@@ -41,6 +41,7 @@ export const assetHubKusamaControllers: ControllerConfig = {
 		'PalletsForeignAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',
 		'RcBlocksRawExtrinsics',

--- a/src/chains-config/assetHubKusamaControllers.ts
+++ b/src/chains-config/assetHubKusamaControllers.ts
@@ -41,6 +41,7 @@ export const assetHubKusamaControllers: ControllerConfig = {
 		'PalletsForeignAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsStakingInfo',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubKusamaControllers.ts
+++ b/src/chains-config/assetHubKusamaControllers.ts
@@ -42,6 +42,7 @@ export const assetHubKusamaControllers: ControllerConfig = {
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
 		'RcAccountsStakingInfo',
+		'RcAccountsStakingPayouts',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubNextWestendControllers.ts
+++ b/src/chains-config/assetHubNextWestendControllers.ts
@@ -53,6 +53,7 @@ export const assetHubNextWestendControllers: ControllerConfig = {
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
 		'RcAccountsStakingInfo',
+		'RcAccountsStakingPayouts',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubNextWestendControllers.ts
+++ b/src/chains-config/assetHubNextWestendControllers.ts
@@ -52,6 +52,7 @@ export const assetHubNextWestendControllers: ControllerConfig = {
 		'PalletsPoolAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsStakingInfo',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubNextWestendControllers.ts
+++ b/src/chains-config/assetHubNextWestendControllers.ts
@@ -52,6 +52,7 @@ export const assetHubNextWestendControllers: ControllerConfig = {
 		'PalletsPoolAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',
 		'RcBlocksRawExtrinsics',

--- a/src/chains-config/assetHubPolkadotControllers.ts
+++ b/src/chains-config/assetHubPolkadotControllers.ts
@@ -43,6 +43,7 @@ export const assetHubPolkadotControllers: ControllerConfig = {
 		'PalletsForeignAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',
 		'RcBlocksRawExtrinsics',

--- a/src/chains-config/assetHubPolkadotControllers.ts
+++ b/src/chains-config/assetHubPolkadotControllers.ts
@@ -44,6 +44,7 @@ export const assetHubPolkadotControllers: ControllerConfig = {
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
 		'RcAccountsStakingInfo',
+		'RcAccountsStakingPayouts',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubPolkadotControllers.ts
+++ b/src/chains-config/assetHubPolkadotControllers.ts
@@ -43,6 +43,7 @@ export const assetHubPolkadotControllers: ControllerConfig = {
 		'PalletsForeignAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsStakingInfo',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubWestendControllers.ts
+++ b/src/chains-config/assetHubWestendControllers.ts
@@ -52,6 +52,7 @@ export const assetHubWestendControllers: ControllerConfig = {
 		'PalletsPoolAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsStakingInfo',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/chains-config/assetHubWestendControllers.ts
+++ b/src/chains-config/assetHubWestendControllers.ts
@@ -52,6 +52,7 @@ export const assetHubWestendControllers: ControllerConfig = {
 		'PalletsPoolAssets',
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
+		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',
 		'RcBlocksRawExtrinsics',

--- a/src/chains-config/assetHubWestendControllers.ts
+++ b/src/chains-config/assetHubWestendControllers.ts
@@ -53,6 +53,7 @@ export const assetHubWestendControllers: ControllerConfig = {
 		'RcAccountsBalanceInfo',
 		'RcAccountsProxyInfo',
 		'RcAccountsStakingInfo',
+		'RcAccountsStakingPayouts',
 		'RcAccountsVestingInfo',
 		'RcBlocks',
 		'RcBlocksExtrinsics',

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -47,7 +47,7 @@ import {
 	PalletsStorage,
 } from './pallets';
 import { Paras } from './paras';
-import { RcAccountsBalanceInfo, RcAccountsProxyInfo } from './rc/accounts';
+import { RcAccountsBalanceInfo, RcAccountsProxyInfo, RcAccountsVestingInfo } from './rc/accounts';
 import { RcBlocks, RcBlocksExtrinsics, RcBlocksRawExtrinsics, RcBlocksTrace } from './rc/blocks';
 import { RcNodeNetwork, RcNodeTransactionPool, RcNodeVersion } from './rc/node';
 import {
@@ -101,6 +101,7 @@ export const controllers = {
 	NodeVersion,
 	RcAccountsBalanceInfo,
 	RcAccountsProxyInfo,
+	RcAccountsVestingInfo,
 	RcBlocks,
 	RcBlocksExtrinsics,
 	RcBlocksRawExtrinsics,

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -47,7 +47,12 @@ import {
 	PalletsStorage,
 } from './pallets';
 import { Paras } from './paras';
-import { RcAccountsBalanceInfo, RcAccountsProxyInfo, RcAccountsVestingInfo } from './rc/accounts';
+import {
+	RcAccountsBalanceInfo,
+	RcAccountsProxyInfo,
+	RcAccountsStakingInfo,
+	RcAccountsVestingInfo,
+} from './rc/accounts';
 import { RcBlocks, RcBlocksExtrinsics, RcBlocksRawExtrinsics, RcBlocksTrace } from './rc/blocks';
 import { RcNodeNetwork, RcNodeTransactionPool, RcNodeVersion } from './rc/node';
 import {
@@ -101,6 +106,7 @@ export const controllers = {
 	NodeVersion,
 	RcAccountsBalanceInfo,
 	RcAccountsProxyInfo,
+	RcAccountsStakingInfo,
 	RcAccountsVestingInfo,
 	RcBlocks,
 	RcBlocksExtrinsics,

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -51,6 +51,7 @@ import {
 	RcAccountsBalanceInfo,
 	RcAccountsProxyInfo,
 	RcAccountsStakingInfo,
+	RcAccountsStakingPayouts,
 	RcAccountsVestingInfo,
 } from './rc/accounts';
 import { RcBlocks, RcBlocksExtrinsics, RcBlocksRawExtrinsics, RcBlocksTrace } from './rc/blocks';
@@ -107,6 +108,7 @@ export const controllers = {
 	RcAccountsBalanceInfo,
 	RcAccountsProxyInfo,
 	RcAccountsStakingInfo,
+	RcAccountsStakingPayouts,
 	RcAccountsVestingInfo,
 	RcBlocks,
 	RcBlocksExtrinsics,

--- a/src/controllers/rc/accounts/RcAccountsStakingInfoController.ts
+++ b/src/controllers/rc/accounts/RcAccountsStakingInfoController.ts
@@ -1,0 +1,120 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { RequestHandler } from 'express';
+import { IAddressParam } from 'src/types/requests';
+
+import { ApiPromiseRegistry } from '../../../apiRegistry';
+import { validateAddress, validateBoolean } from '../../../middleware';
+import { AccountsStakingInfoService } from '../../../services';
+import AbstractController from '../../AbstractController';
+
+/**
+ * GET staking information for an address on the relay chain.
+ *
+ * Paths:
+ * - `address`: The _Stash_ address for staking.
+ *
+ * Query:
+ * - (Optional)`at`: Block at which to retrieve staking information at. Block
+ * 		identifier, as the block height or block hash. Defaults to most recent block.
+ * - (Optional) `includeClaimedRewards`: Controls whether or not the `claimedRewards`
+ * 		field is included in the response. Defaults to `true`.
+ * 		If set to `false`:
+ * 		- the field `claimedRewards` will be omitted from the response and
+ * 		- all internal calculations for claimed rewards in `AccountsStakingInfoService`
+ * 		  will be skipped, potentially speeding up the response time.
+ *
+ * Returns:
+ * - `at`: Block number and hash at which the call was made.
+ * - `rewardDestination`: The account to which rewards will be paid. Can be 'Staked' (Stash
+ *   account, adding to the amount at stake), 'Stash' (Stash address, not adding to the amount at
+ *   stake), 'Controller' (Controller address), or 'Account(AccountId)' (address identified by AccountId).
+ * - `controller`: Controller address for the given Stash.
+ * - `numSlashingSpans`: Number of slashing spans on Stash account; `null` if provided address is
+ *    not a Controller.
+ * - `staking`: The staking ledger. Empty object if provided address is not a Controller.
+ *   - `stash`: The stash account whose balance is actually locked and at stake.
+ *   - `total`: The total amount of the stash's balance that we are currently accounting for.
+ *     Simply `active + unlocking`.
+ *   - `active`: The total amount of the stash's balance that will be at stake in any forthcoming
+ *     eras.
+ *   - `unlocking`: Any balance that is becoming free, which may eventually be transferred out of
+ *     the stash (assuming it doesn't get slashed first). Represented as an array of objects, each
+ *     with an `era` at which `value` will be unlocked.
+ *   - `claimedRewards`: Array of eras for which the stakers behind a validator have claimed
+ *     rewards. Only updated for _validators._
+ *
+ * Note: Runtime versions of Kusama less than 1062 will either have `lastReward` in place of
+ * `claimedRewards`, or no field at all. This is related to changes in reward distribution. See:
+ * - Lazy Payouts: https://github.com/paritytech/substrate/pull/4474
+ * - Simple Payouts: https://github.com/paritytech/substrate/pull/5406
+ *
+ * Substrate Reference:
+ * - Staking Pallet: https://crates.parity.io/pallet_staking/index.html
+ * - `RewardDestination`: https://crates.parity.io/pallet_staking/enum.RewardDestination.html
+ * - `Bonded`: https://crates.parity.io/pallet_staking/struct.Bonded.html
+ * - `StakingLedger`: https://crates.parity.io/pallet_staking/struct.StakingLedger.html
+ */
+export default class RcAccountsStakingInfoController extends AbstractController<AccountsStakingInfoService> {
+	static controllerName = 'RcAccountsStakingInfo';
+	static requiredPallets = [
+		['Staking', 'System'],
+		['ParachainStaking', 'ParachainSystem'],
+		['ParachainStaking', 'System'],
+		['Staking', 'ParachainSystem'],
+	];
+
+	constructor(_api: string) {
+		const rcApiSpecName = ApiPromiseRegistry.getSpecNameByType('relay')?.values();
+		const rcSpecName = rcApiSpecName ? Array.from(rcApiSpecName)[0] : undefined;
+		if (!rcSpecName) {
+			throw new Error('Relay chain API spec name is not defined.');
+		}
+		super(rcSpecName, '/rc/accounts/:address/staking-info', new AccountsStakingInfoService(rcSpecName));
+		this.initRoutes();
+	}
+
+	protected initRoutes(): void {
+		this.router.use(this.path, validateAddress, validateBoolean(['includeClaimedRewards']));
+
+		this.safeMountAsyncGetHandlers([['', this.getAccountStakingInfo]]);
+	}
+
+	/**
+	 * Get the latest account staking summary of `address` on the relay chain.
+	 *
+	 * @param req Express Request
+	 * @param res Express Response
+	 */
+	private getAccountStakingInfo: RequestHandler<IAddressParam> = async (
+		{ params: { address }, query: { at, includeClaimedRewards } },
+		res,
+	): Promise<void> => {
+		const rcApi = ApiPromiseRegistry.getApiByType('relay')[0]?.api;
+
+		if (!rcApi) {
+			throw new Error('Relay chain API not found, please use SAS_SUBSTRATE_MULTI_CHAIN_URL env variable');
+		}
+
+		const includeClaimedRewardsArg = includeClaimedRewards !== 'false';
+
+		const hash = await this.getHashFromAt(at, { api: rcApi });
+		const result = await this.service.fetchAccountStakingInfo(hash, includeClaimedRewardsArg, address);
+
+		RcAccountsStakingInfoController.sanitizedSend(res, result);
+	};
+}

--- a/src/controllers/rc/accounts/RcAccountsStakingPayoutsController.ts
+++ b/src/controllers/rc/accounts/RcAccountsStakingPayoutsController.ts
@@ -1,0 +1,236 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import type { ApiDecoration } from '@polkadot/api/types';
+import { Option, u32 } from '@polkadot/types';
+import BN from 'bn.js';
+import { RequestHandler } from 'express';
+import { BadRequest, InternalServerError } from 'http-errors';
+
+import { ApiPromiseRegistry } from '../../../apiRegistry';
+import { validateAddress, validateBoolean } from '../../../middleware';
+import { AccountsStakingPayoutsService } from '../../../services';
+import { IEarlyErasBlockInfo } from '../../../services/accounts/AccountsStakingPayoutsService';
+import kusamaEarlyErasBlockInfo from '../../../services/accounts/kusamaEarlyErasBlockInfo.json';
+import { IAddressParam } from '../../../types/requests';
+import AbstractController from '../../AbstractController';
+
+/**
+ * GET payout information for a stash account on the relay chain.
+ *
+ * Path params:
+ * - `address`: SS58 address of the account. Must be a _Stash_ account.
+ *
+ * Query params:
+ * - (Optional) `depth`: The number of eras to query for payouts of. Must be less
+ * 	than `HISTORY_DEPTH`. In cases where `era - (depth -1)` is less
+ *	than 0, the first era queried will be 0. Defaults to 1.
+ * - (Optional) `era`: The era to query at. Max era payout info is available for
+ * 	 is the latest finished era: `active_era - 1`. Defaults to `active_era - 1`.
+ * - (Optional) `unclaimedOnly`: Only return unclaimed rewards. Defaults to true.
+ *
+ * Returns:
+ * - `at`:
+ * 	- `hash`: The block's hash.
+ * 	- `height`: The block's height.
+ * - `eraPayouts`: array of
+ * 	- `era`: Era this information is associated with.
+ * 	- `totalEraRewardPoints`: Total reward points for the era.
+ * 	- `totalEraPayout`: Total payout for the era. Validators split the payout
+ * 			based on the portion of `totalEraRewardPoints` they have.
+ * 	- `payouts`: array of
+ * 		- `validatorId`: AccountId of the validator the payout is coming from.
+ * 		- `nominatorStakingPayout`: Payout for the reward destination associated with the
+ * 			accountId the query was made for.
+ * 		- `claimed`: Whether or not the reward has been claimed.
+ * 		- `totalValidatorRewardPoints`: Number of reward points earned by the validator.
+ * 		- `validatorCommission`: The percentage of the total payout that the validator
+ * 				takes as commission, expressed as a Perbill.
+ * 		- `totalValidatorExposure`: The sum of the validator's and its nominators' stake.
+ * 		- `nominatorExposure`: The amount of stake the nominator has behind the validator.
+ *
+ * Description:
+ * Returns payout information for the last specified eras on the relay chain. If specifying both
+ * the depth and era query params, this endpoint will return information for
+ * (era - depth) through era. (i.e. if depth=5 and era=20 information will be
+ * returned for eras 16 through 20). N.B. You cannot query eras less then
+ * `current_era - HISTORY_DEPTH`.
+ *
+ * N.B. The `nominator*` fields correspond to the address being queried, even if it
+ * is a validator's _stash_ address. This is because a validator is technically
+ * nominating itself.
+ *
+ * `payouts` Is an array of payouts for a nominating stash address and information
+ * about the validator they were nominating. `eraPayouts` contains an array of
+ * objects that has staking reward metadata for each era, and an array of the
+ * aformentioned payouts.
+ */
+export default class RcAccountsStakingPayoutsController extends AbstractController<AccountsStakingPayoutsService> {
+	static controllerName = 'RcAccountsStakingPayouts';
+	static requiredPallets = [
+		['Staking', 'System'],
+		['ParachainStaking', 'ParachainSystem'],
+		['ParachainStaking', 'System'],
+		['Staking', 'ParachainSystem'],
+	];
+
+	constructor(_api: string) {
+		const rcApiSpecName = ApiPromiseRegistry.getSpecNameByType('relay')?.values();
+		const rcSpecName = rcApiSpecName ? Array.from(rcApiSpecName)[0] : undefined;
+		if (!rcSpecName) {
+			throw new Error('Relay chain API spec name is not defined.');
+		}
+		super(rcSpecName, '/rc/accounts/:address/staking-payouts', new AccountsStakingPayoutsService(rcSpecName));
+		this.initRoutes();
+	}
+
+	protected initRoutes(): void {
+		this.router.use(this.path, validateAddress, validateBoolean(['unclaimedOnly']));
+
+		this.safeMountAsyncGetHandlers([['', this.getStakingPayoutsByAccountId]]);
+	}
+
+	/**
+	 * Get the payouts of `address` for `depth` starting from the `era` on the relay chain.
+	 *
+	 * @param req Express Request
+	 * @param res Express Response
+	 */
+	private getStakingPayoutsByAccountId: RequestHandler<IAddressParam> = async (
+		{ params: { address }, query: { depth, era, unclaimedOnly, at } },
+		res,
+	): Promise<void> => {
+		const rcApi = ApiPromiseRegistry.getApiByType('relay')[0]?.api;
+
+		if (!rcApi) {
+			throw new Error('Relay chain API not found, please use SAS_SUBSTRATE_MULTI_CHAIN_URL env variable');
+		}
+
+		const { specName } = this;
+		const isKusama = specName.toString().toLowerCase() === 'kusama';
+
+		let hash = await this.getHashFromAt(at, { api: rcApi });
+		let apiAt = await rcApi.at(hash);
+
+		const { eraArg, currentEra } = await this.getEraAndHash(apiAt, this.verifyAndCastOr('era', era, undefined));
+
+		const sanitizedDepth = this.sanitizeDepth({
+			isKusama,
+			depth: depth?.toString(),
+			era: era?.toString(),
+			currentEra,
+		});
+
+		if (isKusama && currentEra < 518) {
+			const earlyErasBlockInfo: IEarlyErasBlockInfo = kusamaEarlyErasBlockInfo;
+			const block = earlyErasBlockInfo[currentEra].start;
+			hash = await this.getHashFromAt(block.toString(), { api: rcApi });
+			apiAt = await rcApi.at(hash);
+		}
+
+		if (!apiAt.query.staking) {
+			throw new BadRequest('Staking pallet not found for queried runtime');
+		}
+
+		// For RC endpoints, we always use the regular fetchAccountStakingPayout method
+		// since we're querying the relay chain directly
+		const result = await this.service.fetchAccountStakingPayout(
+			hash,
+			address,
+			this.verifyAndCastOr('depth', sanitizedDepth, 1) as number,
+			eraArg,
+			unclaimedOnly === 'false' ? false : true,
+			currentEra,
+			apiAt,
+		);
+
+		RcAccountsStakingPayoutsController.sanitizedSend(res, result);
+	};
+
+	private sanitizeDepth({
+		isKusama,
+		depth,
+		era,
+		currentEra,
+	}: {
+		isKusama: boolean;
+		depth?: string;
+		era?: string;
+		currentEra: number;
+	}): string | undefined {
+		if (!isKusama) return depth;
+
+		if (currentEra <= 519) {
+			if (depth !== undefined)
+				throw new InternalServerError('The `depth` query parameter is disabled for eras less than 518.');
+			if (era !== undefined)
+				throw new InternalServerError('The `era` query parameter is disabled for eras less than 518.');
+			return undefined;
+		}
+
+		if (depth) {
+			return Math.min(Number(depth), currentEra - 518).toString();
+		}
+
+		return undefined;
+	}
+
+	private async getEraAndHash(apiAt: ApiDecoration<'promise'>, era?: number) {
+		const currentEra = await this.getCurrentEra(apiAt);
+		const activeEra = await this.getActiveEra(apiAt, currentEra);
+		if (era !== undefined && era > activeEra - 1) {
+			throw new BadRequest(
+				`The specified era (${era}) is too large. Largest era payout info is available for is ${activeEra - 1}`,
+			);
+		}
+
+		return {
+			eraArg: era ?? activeEra - 1,
+			currentEra,
+		};
+	}
+
+	private async getCurrentEra(apiAt: ApiDecoration<'promise'>): Promise<number> {
+		const currentEraMaybe = (await apiAt.query.staking.currentEra()) as u32 & Option<u32>;
+
+		if (currentEraMaybe instanceof Option) {
+			if (currentEraMaybe.isNone) throw new InternalServerError('CurrentEra is None when Some was expected');
+			return currentEraMaybe.unwrap().toNumber();
+		}
+
+		if ((currentEraMaybe as unknown) instanceof BN) {
+			return (currentEraMaybe as BN).toNumber();
+		}
+
+		throw new InternalServerError('Query for current_era returned a non-processable result.');
+	}
+
+	private async getActiveEra(apiAt: ApiDecoration<'promise'>, currentEra: number): Promise<number> {
+		if (!apiAt.query.staking.activeEra) {
+			const sessionIndex = (await apiAt.query.session.currentIndex()).toNumber();
+			return currentEra < 518 || sessionIndex % 6 > 0 ? currentEra : currentEra - 1;
+		}
+
+		const activeEraOption = await apiAt.query.staking.activeEra();
+		if (activeEraOption.isNone) {
+			const historicActiveEra = await apiAt.query.staking.currentEra();
+			if (historicActiveEra.isNone) throw new InternalServerError('ActiveEra is None when Some was expected');
+			return historicActiveEra.unwrap().toNumber();
+		}
+
+		return activeEraOption.unwrap().index.toNumber();
+	}
+}

--- a/src/controllers/rc/accounts/RcAccountsVestingInfoController.ts
+++ b/src/controllers/rc/accounts/RcAccountsVestingInfoController.ts
@@ -1,0 +1,87 @@
+// Copyright 2017-2025 Parity Technologies (UK) Ltd.
+// This file is part of Substrate API Sidecar.
+//
+// Substrate API Sidecar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { RequestHandler } from 'express';
+import { IAddressParam } from 'src/types/requests';
+
+import { ApiPromiseRegistry } from '../../../apiRegistry';
+import { validateAddress } from '../../../middleware';
+import { AccountsVestingInfoService } from '../../../services';
+import AbstractController from '../../AbstractController';
+
+/**
+ * GET vesting information for an address on the relay chain.
+ *
+ * Paths:
+ * - `address`: Address to query.
+ *
+ * Query params:
+ * - (Optional)`at`: Block at which to retrieve vesting information at. Block
+ * 		identifier, as the block height or block hash. Defaults to most recent block.
+ *
+ * Returns:
+ * - `at`: Block number and hash at which the call was made.
+ * - `vesting`: Vesting schedule for an account.
+ *   - `locked`: Number of tokens locked at start.
+ *   - `perBlock`: Number of tokens that gets unlocked every block after `startingBlock`.
+ *   - `startingBlock`: Starting block for unlocking(vesting).
+ *
+ * Substrate Reference:
+ * - Vesting Pallet: https://crates.parity.io/pallet_vesting/index.html
+ * - `VestingInfo`: https://crates.parity.io/pallet_vesting/struct.VestingInfo.html
+ */
+export default class RcAccountsVestingInfoController extends AbstractController<AccountsVestingInfoService> {
+	static controllerName = 'RcAccountsVestingInfo';
+	static requiredPallets = [['Vesting'], ['CalamariVesting']];
+
+	constructor(_api: string) {
+		const rcApiSpecName = ApiPromiseRegistry.getSpecNameByType('relay')?.values();
+		const rcSpecName = rcApiSpecName ? Array.from(rcApiSpecName)[0] : undefined;
+		if (!rcSpecName) {
+			throw new Error('Relay chain API spec name is not defined.');
+		}
+		super(rcSpecName, '/rc/accounts/:address/vesting-info', new AccountsVestingInfoService(rcSpecName));
+		this.initRoutes();
+	}
+
+	protected initRoutes(): void {
+		this.router.use(this.path, validateAddress);
+
+		this.safeMountAsyncGetHandlers([['', this.getAccountVestingInfo]]);
+	}
+
+	/**
+	 * Get vesting information for an account on the relay chain.
+	 *
+	 * @param req Express Request
+	 * @param res Express Response
+	 */
+	private getAccountVestingInfo: RequestHandler<IAddressParam> = async (
+		{ params: { address }, query: { at } },
+		res,
+	): Promise<void> => {
+		const rcApi = ApiPromiseRegistry.getApiByType('relay')[0]?.api;
+
+		if (!rcApi) {
+			throw new Error('Relay chain API not found, please use SAS_SUBSTRATE_MULTI_CHAIN_URL env variable');
+		}
+
+		const hash = await this.getHashFromAt(at, { api: rcApi });
+		const result = await this.service.fetchAccountVestingInfo(hash, address);
+
+		RcAccountsVestingInfoController.sanitizedSend(res, result);
+	};
+}

--- a/src/controllers/rc/accounts/index.ts
+++ b/src/controllers/rc/accounts/index.ts
@@ -16,3 +16,4 @@
 
 export { default as RcAccountsBalanceInfo } from './RcAccountsBalanceInfoController';
 export { default as RcAccountsProxyInfo } from './RcAccountsProxyInfoController';
+export { default as RcAccountsVestingInfo } from './RcAccountsVestingInfoController';

--- a/src/controllers/rc/accounts/index.ts
+++ b/src/controllers/rc/accounts/index.ts
@@ -17,4 +17,5 @@
 export { default as RcAccountsBalanceInfo } from './RcAccountsBalanceInfoController';
 export { default as RcAccountsProxyInfo } from './RcAccountsProxyInfoController';
 export { default as RcAccountsStakingInfo } from './RcAccountsStakingInfoController';
+export { default as RcAccountsStakingPayouts } from './RcAccountsStakingPayoutsController';
 export { default as RcAccountsVestingInfo } from './RcAccountsVestingInfoController';

--- a/src/controllers/rc/accounts/index.ts
+++ b/src/controllers/rc/accounts/index.ts
@@ -16,4 +16,5 @@
 
 export { default as RcAccountsBalanceInfo } from './RcAccountsBalanceInfoController';
 export { default as RcAccountsProxyInfo } from './RcAccountsProxyInfoController';
+export { default as RcAccountsStakingInfo } from './RcAccountsStakingInfoController';
 export { default as RcAccountsVestingInfo } from './RcAccountsVestingInfoController';


### PR DESCRIPTION
  ## Summary
  Added three new `/rc/accounts/{accountId}/*` endpoints to enable Asset Hub instances to query relay chain account data directly.

  ## New Endpoints
  - `/rc/accounts/{accountId}/vesting-info` - Get vesting schedules from relay chain
  - `/rc/accounts/{accountId}/staking-info` - Get staking information from relay chain
  - `/rc/accounts/{accountId}/staking-payouts` - Get staking payout history from relay chain