### PR TITLE
fix: remove redundant isApiAssetHub specName check

### DIFF
--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -34,9 +34,7 @@ export class PalletsStakingProgressService extends AbstractService {
 	 * @param hash `BlockHash` to make call at
 	 */
 	async derivePalletStakingProgress(hash: BlockHash): Promise<IPalletStakingProgress> {
-		const { api, specName } = this;
-		const apiType = ApiPromiseRegistry.getTypeBySpecName(specName);
-		const isApiAssetHub = apiType === 'assethub';
+		const { api } = this;
 		const RCApiPromise = this.assetHubInfo.isAssetHub ? ApiPromiseRegistry.getApiByType('relay') : null;
 
 		if (this.assetHubInfo.isAssetHub && !RCApiPromise?.length) {
@@ -49,7 +47,7 @@ export class PalletsStakingProgressService extends AbstractService {
 			throw new Error('Staking pallet not found for queried runtime');
 		}
 		const sessionValidators =
-			this.assetHubInfo.isAssetHub && isApiAssetHub
+			this.assetHubInfo.isAssetHub
 				? RCApiPromise![0].api.query.session.validators
 				: historicApi.query.session.validators;
 
@@ -75,7 +73,7 @@ export class PalletsStakingProgressService extends AbstractService {
 		}
 
 		let deriveSessionAndEra;
-		if (this.assetHubInfo.isAssetHub && this.assetHubInfo.isAssetHubMigrated && isApiAssetHub) {
+		if (this.assetHubInfo.isAssetHub && this.assetHubInfo.isAssetHubMigrated) {
 			deriveSessionAndEra = this.deriveSessionAndEraProgressAssetHub(historicApi, RCApiPromise?.[0].api);
 		} else {
 			deriveSessionAndEra = this.deriveSessionAndEraProgress(historicApi);

--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -46,10 +46,9 @@ export class PalletsStakingProgressService extends AbstractService {
 		if (historicApi.query.staking === undefined) {
 			throw new Error('Staking pallet not found for queried runtime');
 		}
-		const sessionValidators =
-			this.assetHubInfo.isAssetHub
-				? RCApiPromise![0].api.query.session.validators
-				: historicApi.query.session.validators;
+		const sessionValidators = this.assetHubInfo.isAssetHub
+			? RCApiPromise![0].api.query.session.validators
+			: historicApi.query.session.validators;
 
 		if (!sessionValidators) {
 			throw new Error('Session pallet not found for queried runtime');


### PR DESCRIPTION
`isApiAssetHub` may be undefined when the multi chain input doesn't set assethubs specName. It is not required to have the specName as part of the multi chain input, but also the logic was redundant internally, and can be removed.