### PR TITLE
fix: ensure no error for event mapping for specVersion 1020000 or above

### DIFF
--- a/src/services/blocks/BlocksService.ts
+++ b/src/services/blocks/BlocksService.ts
@@ -170,7 +170,7 @@ export class BlocksService extends AbstractService {
 			nonSanitizedExtrinsics,
 			hash,
 			eventDocs,
-			specVersion
+			specVersion,
 		);
 
 		let finalized = undefined;


### PR DESCRIPTION
This PR ensures there is no error on event mapping for specVersion 1020000.

closes: https://github.com/paritytech/substrate-api-sidecar/issues/1767