### PR TITLE
fix: enforce correct config CACHE_CAPACITY type

### DIFF
--- a/src/Specs.ts
+++ b/src/Specs.ts
@@ -189,7 +189,7 @@ export class Specs {
 			this._specs.getSpec(CONFIG.CACHE_CAPACITY, 'max cache size for @polkadot/api caching system, 0 bypasses cache', {
 				default: 0,
 				mandatory: false,
-				type: 'number'
+				type: 'number',
 			}),
 		);
 


### PR DESCRIPTION
closes: https://github.com/paritytech/substrate-api-sidecar/issues/1780

## To Reproduce

```bash
export SAS_SUBSTRATE_CACHE_CAPACITY=1000
export SAS_SUBSTRATE_URL=wss://rpc.polkadot.io
yarn test:test-release
```

## The Fix

Ensures that the `CACHE_CAPACITY` config is validated as a `number` as the config level.
