### PR TITLE
docs: Update doc references to docsv2 changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ NOTE: Node LTS (`long term support`) versions start with an even number, and odd
 - [Source code installation and usage](#source-code-installation-and-usage)
 - [Configuration](#configuration)
 - [Debugging fee and staking payout calculations](#debugging-staking-payout-calculations)
-- [Available endpoints](https://paritytech.github.io/substrate-api-sidecar/dist/)
+- [Available endpoints](https://paritytech.github.io/substrate-api-sidecar/docsv2/)
 - [Chain integration guide](./guides/CHAIN_INTEGRATION.md)
 - [Docker](#docker)
 - [Notes for maintainers](#notes-for-maintainers)
@@ -112,7 +112,7 @@ node_modules/.bin/substrate-api-sidecar
 
 [Jump to the configuration section](#configuration) for more details on connecting to a node.
 
-[Click here for full endpoint docs.](https://paritytech.github.io/substrate-api-sidecar/dist/)
+[Click here for full endpoint docs.](https://paritytech.github.io/substrate-api-sidecar/docsv2/)
 
 In the full endpoints doc, you will also find the following `trace` related endpoints :
 - `/experimental/blocks/{blockId}/traces/operations?actions=false`
@@ -318,7 +318,7 @@ CALC_DEBUG=1 sh calc/build.sh
 
 ## Available endpoints
 
-[Click here for full endpoint docs.](https://paritytech.github.io/substrate-api-sidecar/dist/)
+[Click here for full endpoint docs.](https://paritytech.github.io/substrate-api-sidecar/docsv2/)
 
 ## Chain integration guide
 

--- a/guides/STAKING_IMPLEMENTATION_DETAILS.md
+++ b/guides/STAKING_IMPLEMENTATION_DETAILS.md
@@ -4,7 +4,7 @@ This document outlines the implementation details for the `claimed` field return
 Before proceeding, please check out the introductory helper guide in this [HackMd](https://hackmd.io/@LwMsxe3-SFmNXxugAXOKgg/ryPwFoezyl).
 
 ## Description
-In Sidecar, the `/accounts/{accountId}/staking-info` endpoint ([docs](https://paritytech.github.io/substrate-api-sidecar/dist/)) takes two parameters: 
+In Sidecar, the `/accounts/{accountId}/staking-info` endpoint ([docs](https://paritytech.github.io/substrate-api-sidecar/docsv2/)) takes two parameters: 
 - a stash account (required field): this can be a validator's account or a nominator's account. 
 - a block height (optional - default latest block): based on the height, the corresponding eras are returned.
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -102,7 +102,7 @@ export default class App {
 		// Set up a root route
 		this.app.get('/', (_req: Request, res: Response) => {
 			res.send({
-				docs: 'https://paritytech.github.io/substrate-api-sidecar/dist',
+				docs: 'https://paritytech.github.io/substrate-api-sidecar/docsv2',
 				github: 'https://github.com/paritytech/substrate-api-sidecar',
 				version: packageJson.version,
 				listen: `${this.host}:${this.port}`,


### PR DESCRIPTION
Original PR was [here](https://github.com/paritytech/substrate-api-sidecar/pull/1742)

We might as well link to version 2 of the docs so more people use it and it is easier to find.