### PR TITLE
fix: use all params for cache key

### DIFF
--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -234,15 +234,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 				};
 
 				// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
-				const cacheKey =
-					ahHash.toString() +
-					Number(options.eventDocs) +
-					Number(options.extrinsicDocs) +
-					Number(options.checkFinalized) +
-					Number(options.noFees) +
-					Number(options.checkDecodedXcm) +
-					Number(options.paraId) +
-					Number(options.useEvmAddressFormat);
+				const cacheKey = ahHash.toString() + Object.values(options).join();
 
 				const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -318,15 +310,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 			useEvmAddressFormat: useEvmFormat === 'true',
 		};
 		// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
-		const cacheKey =
-			hash.toString() +
-			Number(options.eventDocs) +
-			Number(options.extrinsicDocs) +
-			Number(options.checkFinalized) +
-			Number(options.noFees) +
-			Number(options.checkDecodedXcm) +
-			Number(options.paraId) +
-			Number(options.useEvmAddressFormat);
+		const cacheKey = hash.toString() + Object.values(options).join();
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -409,15 +393,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 				};
 
 				// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
-				const cacheKey =
-					ahHash.toString() +
-					Number(options.eventDocs) +
-					Number(options.extrinsicDocs) +
-					Number(options.checkFinalized) +
-					Number(options.noFees) +
-					Number(options.checkDecodedXcm) +
-					Number(options.paraId) +
-					Number(options.useEvmAddressFormat);
+				const cacheKey = ahHash.toString() + Object.values(options).join();
 
 				const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -490,15 +466,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		};
 
 		// Create a key for the cache that is a concatenation of the block hash and all the query params included in the request
-		const cacheKey =
-			hash.toString() +
-			Number(options.eventDocs) +
-			Number(options.extrinsicDocs) +
-			Number(options.checkFinalized) +
-			Number(options.noFees) +
-			Number(options.checkDecodedXcm) +
-			Number(options.paraId) +
-			Number(options.useEvmAddressFormat);
+		const cacheKey = hash.toString() + Object.values(options).join();
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 

--- a/src/controllers/blocks/BlocksExtrinsicsController.ts
+++ b/src/controllers/blocks/BlocksExtrinsicsController.ts
@@ -83,14 +83,7 @@ export default class BlocksExtrinsicsController extends AbstractController<Block
 					useEvmAddressFormat: useEvmFormat === 'true',
 				};
 
-				const cacheKey =
-					ahHash.toString() +
-					Number(options.eventDocs) +
-					Number(options.extrinsicDocs) +
-					Number(options.checkFinalized) +
-					Number(options.noFees) +
-					Number(options.checkDecodedXcm) +
-					Number(options.useEvmAddressFormat);
+				const cacheKey = ahHash.toString() + Object.values(options).join();
 
 				const isBlockCached = this.blockStore.get(cacheKey);
 				const historicApi = await this.api.at(ahHash);
@@ -145,14 +138,7 @@ export default class BlocksExtrinsicsController extends AbstractController<Block
 				useEvmAddressFormat: useEvmFormat === 'true',
 			};
 
-			const cacheKey =
-				hash.toString() +
-				Number(options.eventDocs) +
-				Number(options.extrinsicDocs) +
-				Number(options.checkFinalized) +
-				Number(options.noFees) +
-				Number(options.checkDecodedXcm) +
-				Number(options.useEvmAddressFormat);
+			const cacheKey = hash.toString() + Object.values(options).join();
 
 			const isBlockCached = this.blockStore.get(cacheKey);
 			const historicApi = await this.api.at(hash);

--- a/src/controllers/rc/blocks/RcBlocksController.ts
+++ b/src/controllers/rc/blocks/RcBlocksController.ts
@@ -144,14 +144,7 @@ export default class RcBlocksController extends AbstractController<BlocksService
 			paraId: paraIdArg,
 		};
 
-		const cacheKey =
-			hash.toString() +
-			Number(options.eventDocs) +
-			Number(options.extrinsicDocs) +
-			Number(options.checkFinalized) +
-			Number(options.noFees) +
-			Number(options.checkDecodedXcm) +
-			Number(options.paraId);
+		const cacheKey = hash.toString() + Object.values(options).join();
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 
@@ -219,14 +212,7 @@ export default class RcBlocksController extends AbstractController<BlocksService
 			paraId: paraIdArg,
 		};
 
-		const cacheKey =
-			hash.toString() +
-			Number(options.eventDocs) +
-			Number(options.extrinsicDocs) +
-			Number(options.checkFinalized) +
-			Number(options.noFees) +
-			Number(options.checkDecodedXcm) +
-			Number(options.paraId);
+		const cacheKey = hash.toString() + Object.values(options).join();
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 

--- a/src/controllers/rc/blocks/RcBlocksExtrinsicsController.ts
+++ b/src/controllers/rc/blocks/RcBlocksExtrinsicsController.ts
@@ -74,13 +74,7 @@ export default class RcBlocksExtrinsicsController extends AbstractController<Blo
 			paraId: undefined,
 		};
 
-		const cacheKey =
-			hash.toString() +
-			Number(options.eventDocs) +
-			Number(options.extrinsicDocs) +
-			Number(options.checkFinalized) +
-			Number(options.noFees) +
-			Number(options.checkDecodedXcm);
+		const cacheKey = hash.toString() + Object.values(options).join();
 
 		const isBlockCached = this.blockStore.get(cacheKey);
 		const historicApi = await rcApi.at(hash);


### PR DESCRIPTION
Requesting head block with `finalized=true` sometimes returns block with `finalized=false` property.
Adding all params to cache key should prevent this.

Maybe you can consider increasing LRU cache a bit, default is only storing 2 items.

Test script which seems to be working fine when including fix from this PR
```
SAS_SUBSTRATE_URL=wss://rpc-shadow.crust.network/
SAS_EXPRESS_PORT=8070
```

```
#!/usr/bin/env bash

set -euo pipefail

while true; do
    nonfinalized=$(curl -s "http://localhost:8070/blocks/head?finalized=false" | jq -r .finalized)
    echo "Finalized block: $nonfinalized"
    finalized=$(curl -s "http://localhost:8070/blocks/head?finalized=true" | jq -r .finalized)

    if [[ "$finalized" == "false" ]]; then
        echo "❌ Error: Block is not finalized!"
        exit 1
    elif [[ "$finalized" == "true" ]]; then
        echo "✅ Block is finalized."
    else
        echo "⚠️ Unexpected response: $finalized"
    fi

    sleep 5s
done
```