### PR TITLE
fix: add validatorSet when forceNone for /staking/progress if it exists

### DIFF
--- a/src/services/pallets/PalletsStakingProgressService.ts
+++ b/src/services/pallets/PalletsStakingProgressService.ts
@@ -121,6 +121,7 @@ export class PalletsStakingProgressService extends AbstractService {
 			unappliedSlashes: unappliedSlashesAtActiveEra.toString()
 				? unappliedSlashesAtActiveEra[0][1].map((slash) => slash.toJSON())
 				: ([] as AnyJson[]),
+			validatorSet: validators && validators.length ? validators.map((accountId) => accountId.toString()) : [],
 		};
 
 		if (forceEra.isForceNone) {


### PR DESCRIPTION
This ensures that if there is a validator set available during a ForceNone era, we display it in the base response.