### PR TITLE
fix: bump grep from 20 to 50 in benchmarks

### DIFF
--- a/scripts/ci/benchmarks/generate_benchmark_result.sh
+++ b/scripts/ci/benchmarks/generate_benchmark_result.sh
@@ -20,7 +20,7 @@ do
     COUNTER=$((COUNTER+1))
     # "/accounts/{accountId}/balance-info:" -> "accounts-{accountId}-balance-info"
     benchmark_name=$(echo ${benchmark} | cut -d ":" -f1 | sed 's/\///' | sed 's/\//-/g' )
-    result=$(cat ${RESULT_FILE} | grep -A 20 ${benchmark} | grep "Avg RequestTime(Latency)" | awk '{print $3}')
+    result=$(cat ${RESULT_FILE} | grep -A 50 ${benchmark} | grep "Avg RequestTime(Latency)" | awk '{print $3}')
     unit=${result: -2}
     result_value=${result::-2}
     echo "  {"


### PR DESCRIPTION
### Description
Bump `grep -A 20` to `grep -A 50` in `scripts/ci/benchmarks/generate_benchmark_result.sh`

### Reason
The first benchmark when running `yarn bench` prints `util.print_endpoints()` output (approximately 20 lines of endpoint list) before wrk's output. With `-A 20`, the script can't reach the `Avg RequestTime(Latency)` line for that entry, emits invalid JSON (`"value": ,`), and the publish job fails parsing.
After the benchmark migration, all 30 endpoints produce valid wrk output. Only the first one trips this script-side limit because `print_endpoints` uses a lockfile to print only once per run. `-A 50` covers the worst current case (17-endpoint prelude + wrk + report = ~39 lines to the latency line) with margin.